### PR TITLE
Use BVH traversal in rayColor

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -50,12 +50,10 @@ float4 fragment fragmentMain(
     float4 color = rayColor(
         r,
         bvhNodes,
-        primitives,       // <- Each primitive is 3 float4s
+        primitives,
         materials,
         u.primitiveCount,
-        nullptr,
-        nullptr,
-        0,
+        primitiveIndices,
         seed
     );
 

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -73,23 +73,20 @@ inline bool intersectAABB(
 
 // BVH traversal version of firstHit
 inline intersection firstHitBVH(
-    thread const ray& ray,
+    thread const ray& r,
     device const float4* bvhNodes,
-    device const float4* spheres,
-    uint32_t sphereCount,
-    device const float3* vertices,
-    device const uint3* indices,
-    uint32_t triangleCount)
+    device const float4* primitives,
+    device const int* primitiveIndices)
 {
     intersection in;
     in.t = INFINITY;
-    in.sphereId = -1;
-    in.triangleId = -1;
+    in.primitiveId = -1;
+    in.isTriangle = 0;
 
     constexpr int stackSize = 64;
     int stack[stackSize];
     int stackPtr = 0;
-    stack[stackPtr++] = 0; // Root node index = 0
+    stack[stackPtr++] = 0; // root
 
     while (stackPtr > 0)
     {
@@ -100,48 +97,90 @@ inline intersection firstHitBVH(
         int leftFirst = as_type<int>(bvhNodes[2 * nodeIdx + 0].w);
         int count = as_type<int>(bvhNodes[2 * nodeIdx + 1].w);
 
-        if (!intersectAABB(ray, bmin, bmax, 0.0001, in.t))
+        if (!intersectAABB(r, bmin, bmax, 0.0001, in.t))
             continue;
 
         if (count > 0)
         {
             for (int i = 0; i < count; ++i)
             {
-                int primIdx = leftFirst + i;
+                int primIdx = primitiveIndices[leftFirst + i];
+                int base = primIdx * 3;
+                float4 p0 = primitives[base + 0];
+                float4 p1 = primitives[base + 1];
+                float4 p2 = primitives[base + 2];
 
-                if (primIdx < sphereCount)
+                int primitiveType = int(p0.w);
+                float tHit = INFINITY;
+                float3 n = float3(0);
+                float3 hit = float3(0);
+                bool hitThis = false;
+
+                if (primitiveType == 0)
                 {
-                    float root = sphereIntersection(ray, spheres[primIdx]);
-                    if (root < in.t && root != INFINITY)
-                    {
-                        in.t = root;
-                        in.sphereId = primIdx;
-                        in.triangleId = -1;
-                    }
-                }
-                else if (primIdx < sphereCount + triangleCount)
-                {
-                    int triIdx = primIdx - sphereCount;
-                    if (triIdx < 0 || triIdx >= triangleCount)
-                        continue;
+                    float3 center = p0.xyz;
+                    float radius = p1.x;
+                    float3 oc = r.origin - center;
+                    float a = dot(r.direction, r.direction);
+                    float b = dot(oc, r.direction);
+                    float c = dot(oc, oc) - radius * radius;
+                    float discriminant = b * b - a * c;
 
-                    float tTri;
-                    float3 bary;
-                    uint3 idx = indices[triIdx];
-                    float3 v0 = vertices[idx.x];
-                    float3 v1 = vertices[idx.y];
-                    float3 v2 = vertices[idx.z];
-
-                    if (triangleIntersection(ray, v0, v1, v2, tTri, bary))
+                    if (discriminant > 0.0)
                     {
-                        if (tTri < in.t)
+                        float sqrtD = sqrt(discriminant);
+                        float temp = (-b - sqrtD) / a;
+                        if (temp < in.t && temp > 0.0001)
                         {
-                            in.t = tTri;
-                            in.sphereId = -1;
-                            in.triangleId = triIdx;
-                            in.normal = normalize(cross(v1 - v0, v2 - v0));
+                            tHit = temp;
+                            hit = r.origin + tHit * r.direction;
+                            n = normalize(hit - center);
+                            hitThis = true;
                         }
                     }
+                }
+                else if (primitiveType == 1)
+                {
+                    float3 v0 = p0.xyz;
+                    float3 v1 = p1.xyz;
+                    float3 v2 = p2.xyz;
+
+                    float3 edge1 = v1 - v0;
+                    float3 edge2 = v2 - v0;
+                    float3 h = cross(r.direction, edge2);
+                    float a = dot(edge1, h);
+                    if (abs(a) > 1e-5)
+                    {
+                        float f = 1.0 / a;
+                        float3 s = r.origin - v0;
+                        float u = f * dot(s, h);
+                        if (u >= 0.0 && u <= 1.0)
+                        {
+                            float3 q = cross(s, edge1);
+                            float v = f * dot(r.direction, q);
+                            if (v >= 0.0 && u + v <= 1.0)
+                            {
+                                float tt = f * dot(edge2, q);
+                                if (tt > 0.0001 && tt < in.t)
+                                {
+                                    tHit = tt;
+                                    hit = r.origin + tHit * r.direction;
+                                    n = normalize(cross(edge1, edge2));
+                                    hitThis = true;
+                                    in.isTriangle = 1;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (hitThis && tHit < in.t)
+                {
+                    in.t = tHit;
+                    in.primitiveId = primIdx;
+                    in.normal = n;
+                    in.point = hit;
+                    in.isTriangle = primitiveType;
                 }
             }
         }
@@ -152,31 +191,24 @@ inline intersection firstHitBVH(
         }
     }
 
-    if (in.t == INFINITY)
-        return in;
-
-    in.point = ray.origin + (in.t * ray.direction);
-
-    if (in.sphereId >= 0)
-        in.normal = normalize(in.point - spheres[in.sphereId].xyz);
-
-    in.frontFace = dot(in.normal, ray.direction) < 0.0;
-    if (!in.frontFace)
-        in.normal = -in.normal;
+    if (in.primitiveId != -1)
+    {
+        in.frontFace = dot(in.normal, r.direction) < 0.0;
+        if (!in.frontFace)
+            in.normal = -in.normal;
+    }
 
     return in;
 }
 
 
 inline float4 rayColor(
-    ray ray,
+    ray r,
     device const float4* bvhNodes,
     device const float4* primitives,
     device const float4* materials,
     uint primitiveCount,
-    device const float3* vertexBuffer,
-    device const uint3* indexBuffer,
-    uint triangleCount,
+    device const int* primitiveIndices,
     thread uint32_t& seed)
 {
     constexpr size_t maxRayDepth = 32;
@@ -186,100 +218,20 @@ inline float4 rayColor(
 
     for (size_t depth = 0; depth < maxRayDepth; ++depth)
     {
-        float tMin = 1e-3;
-        float tClosest = 1e9;
-        int hitIndex = -1;
-        float3 hitNormal = float3(0);
-        float3 hitPosition = float3(0);
-        bool isTriangle = false;
+        intersection hit = firstHitBVH(r, bvhNodes, primitives, primitiveIndices);
 
-        for (uint i = 0; i < primitiveCount; ++i)
+        if (hit.primitiveId == -1)
         {
-            int base = int(i) * 3;
-            float4 p0 = primitives[base + 0];
-            float4 p1 = primitives[base + 1];
-            float4 p2 = primitives[base + 2];
-
-            int primitiveType = int(p0.w);
-            float t = 1e9;
-            float3 n = float3(0);
-            float3 hit = float3(0);
-            bool hitThis = false;
-
-            if (primitiveType == 0) // Sphere
-            {
-                float3 center = p0.xyz;
-                float radius = p1.x;
-                float3 oc = ray.origin - center;
-                float a = dot(ray.direction, ray.direction);
-                float b = dot(oc, ray.direction);
-                float c = dot(oc, oc) - radius * radius;
-                float discriminant = b * b - a * c;
-
-                if (discriminant > 0.0)
-                {
-                    float sqrtD = sqrt(discriminant);
-                    float temp = (-b - sqrtD) / a;
-                    if (temp < tClosest && temp > tMin)
-                    {
-                        t = temp;
-                        hit = ray.origin + t * ray.direction;
-                        n = normalize(hit - center);
-                        hitThis = true;
-                    }
-                }
-            }
-            else if (primitiveType == 1) // Triangle
-            {
-                float3 v0 = p0.xyz;
-                float3 v1 = p1.xyz;
-                float3 v2 = p2.xyz;
-
-                float3 edge1 = v1 - v0;
-                float3 edge2 = v2 - v0;
-                float3 h = cross(ray.direction, edge2);
-                float a = dot(edge1, h);
-                if (abs(a) < 1e-5) continue;
-
-                float f = 1.0 / a;
-                float3 s = ray.origin - v0;
-                float u = f * dot(s, h);
-                if (u < 0.0 || u > 1.0) continue;
-
-                float3 q = cross(s, edge1);
-                float v = f * dot(ray.direction, q);
-                if (v < 0.0 || u + v > 1.0) continue;
-
-                float tt = f * dot(edge2, q);
-                if (tt > tMin && tt < tClosest)
-                {
-                    t = tt;
-                    hit = ray.origin + t * ray.direction;
-                    n = normalize(cross(edge1, edge2));
-                    hitThis = true;
-                    isTriangle = true;
-                }
-            }
-
-            if (hitThis && t < tClosest)
-            {
-                tClosest = t;
-                hitIndex = int(i);
-                hitNormal = n;
-                hitPosition = hit;
-            }
-        }
-
-        if (hitIndex == -1)
-        {
-            float3 unitDir = normalize(ray.direction);
+            float3 unitDir = normalize(r.direction);
             float t = 0.5 * (unitDir.y + 1.0);
             float3 skyColor = mix(float3(1.0), float3(0.6, 0.7, 1.0), t);
             light += absorption * float4(skyColor, 1.0);
             break;
         }
 
-        int matIndex = hitIndex * 2;
+        int matIndex = hit.primitiveId * 2;
+        if (matIndex + 1 >= int(primitiveCount) * 2)
+            break;
         float4 m0 = materials[matIndex + 0];
         float4 m1 = materials[matIndex + 1];
 
@@ -291,13 +243,11 @@ inline float4 rayColor(
         if (emissionPower > 0.0 || materialType == 2)
         {
             light += absorption * float4(emissionColor, 1.0) * emissionPower;
-            // Let it continue bouncing if you want indirect light to propagate
         }
 
-        // Lambertian scatter
-        float3 target = hitNormal + randomUnitVector(seed);
-        ray.origin = hitPosition + 0.0001 * hitNormal;
-        ray.direction = normalize(target);
+        float3 target = hit.normal + randomUnitVector(seed);
+        r.origin = hit.point + 0.0001 * hit.normal;
+        r.direction = normalize(target);
         absorption *= float4(albedo, 1.0);
     }
 

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -15,8 +15,8 @@ struct intersection
     float3 point;
     float3 normal;
     bool frontFace;
-    int sphereId = -1;
-    int triangleId = -1;
+    int primitiveId = -1;
+    int isTriangle = 0;
 };
 
 


### PR DESCRIPTION
## Summary
- unify intersection info with primitive id and type
- traverse BVH with primitive index buffer and use it in rayColor
- pass primitive indices to rayColor from fragment shader

## Testing
- `apt-get update` *(fails: repository not signed)*
- `cc -fsyntax-only -x c++ MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal` *(fails: metal_stdlib missing)*

------
https://chatgpt.com/codex/tasks/task_e_6893384a38d8832da1b8d09dbb5cbc04