### PR TITLE
Fix BVH traversal by encoding right child index

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -95,13 +95,14 @@ inline intersection firstHitBVH(
         float3 bmin = bvhNodes[2 * nodeIdx + 0].xyz;
         float3 bmax = bvhNodes[2 * nodeIdx + 1].xyz;
         int leftFirst = as_type<int>(bvhNodes[2 * nodeIdx + 0].w);
-        int count = as_type<int>(bvhNodes[2 * nodeIdx + 1].w);
+        int second = as_type<int>(bvhNodes[2 * nodeIdx + 1].w);
 
         if (!intersectAABB(r, bmin, bmax, 0.0001, in.t))
             continue;
 
-        if (count > 0)
+        if (second > 0)
         {
+            int count = second;
             for (int i = 0; i < count; ++i)
             {
                 int primIdx = primitiveIndices[leftFirst + i];
@@ -186,8 +187,9 @@ inline intersection firstHitBVH(
         }
         else
         {
+            int rightChild = -second;
             stack[stackPtr++] = leftFirst;
-            stack[stackPtr++] = leftFirst + 1;
+            stack[stackPtr++] = rightChild;
         }
     }
 

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -26,7 +26,7 @@ struct BVHNode {
     simd::float3 boundsMin;
     simd::float3 boundsMax;
     int leftFirst;
-    int count;
+    int count; // >0: number of primitives (leaf). <=0: -right child index (internal)
 };
 
 class Scene {
@@ -310,8 +310,13 @@ private:
         int leftChild = buildBVHRecursive(start, bestSplit);
         int rightChild = buildBVHRecursive(bestSplit, end);
 
+        // For internal nodes, store both child indices.
+        // leftFirst keeps the left child's node index and
+        // count stores the negated right child's index.
+        // Leaf nodes maintain a positive count to denote
+        // the number of primitives they contain.
         bvhNodes[nodeIndex].leftFirst = leftChild;
-        bvhNodes[nodeIndex].count = 0;
+        bvhNodes[nodeIndex].count = -rightChild;
 
         return nodeIndex;
     }


### PR DESCRIPTION
## Summary
- Encode BVH internal nodes with negative right child indices
- Update Metal path tracing shader to traverse BVH using stored child indices

## Testing
- `g++ -std=c++17 -fsyntax-only 'MetalCpp Path Tracer/Scene/Scene.h'` *(fails: simd/simd.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893420fdac4832d99b8dacff5791c24