### PR TITLE
Bind TLAS buffer and integrate top-level BVH culling

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -50,7 +50,9 @@ private:
     MTL::Buffer* _pTriangleIndexBuffer = nullptr;
     MTL::Buffer* _pUniformsBuffer = nullptr;
     MTL::Buffer* _pBVHBuffer = nullptr;
-    MTL::Buffer* _pPrimitiveIndexBuffer = nullptr;  
+    MTL::Buffer* _pPrimitiveIndexBuffer = nullptr;
+    MTL::Buffer* _pTLASBuffer = nullptr;
+    size_t _tlasNodeCount = 0;
     // Accumulation framebuffers
     MTL::Texture* _accumulationTargets[2] = {nullptr, nullptr};
 };

--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -14,6 +14,7 @@ float4 fragment fragmentMain(
     device const float3* vertexBuffer [[buffer(4)]],
     device const uint3* indexBuffer [[buffer(5)]],
     device const int* primitiveIndices [[buffer(6)]],
+    device const float4* tlasNodes [[buffer(7)]],
     texture2d<float, access::read_write> lastFrame [[texture(0)]],
     texture2d<float, access::read_write> currentFrame [[texture(1)]])
 
@@ -49,6 +50,8 @@ float4 fragment fragmentMain(
 
     float4 color = rayColor(
         r,
+        tlasNodes,
+        u.tlasNodeCount,
         bvhNodes,
         primitives,       // <- Each primitive is 3 float4s
         materials,

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -36,6 +36,7 @@ struct UniformsData
     uint64_t triangleCount;
     uint64_t frameCount = 0;
     uint64_t totalPrimitiveCount;
+    uint64_t tlasNodeCount;
 
 
 };

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -158,6 +158,41 @@ public:
         return buffer;
     }
 
+    // Build a simple TLAS from the root's children. Returns number of TLAS nodes via outCount
+    simd::float4* createTLASBuffer(size_t& outCount) {
+        outCount = 0;
+        if (bvhNodes.empty()) {
+            return nullptr;
+        }
+
+        const BVHNode& root = bvhNodes[0];
+        if (root.count > 0) {
+            // Degenerate case: only a single leaf BVH, treat as one TLAS node
+            outCount = 1;
+            simd::float4* buffer = new simd::float4[2];
+            int rootIndex = 0;
+            buffer[0] = simd::make_float4(root.boundsMin, *(float*)&rootIndex);
+            buffer[1] = simd::make_float4(root.boundsMax, 0.0f);
+            return buffer;
+        }
+
+        int leftChild = root.leftFirst;
+        int rightChild = -root.count;
+
+        outCount = 2;
+        simd::float4* buffer = new simd::float4[outCount * 2];
+
+        const BVHNode& left = bvhNodes[leftChild];
+        buffer[0] = simd::make_float4(left.boundsMin, *(float*)&leftChild);
+        buffer[1] = simd::make_float4(left.boundsMax, 0.0f);
+
+        const BVHNode& right = bvhNodes[rightChild];
+        buffer[2] = simd::make_float4(right.boundsMin, *(float*)&rightChild);
+        buffer[3] = simd::make_float4(right.boundsMax, 0.0f);
+
+        return buffer;
+    }
+
     int* createPrimitiveIndexBuffer() {
         int* buffer = new int[primitiveIndices.size()];
         for (size_t i = 0; i < primitiveIndices.size(); ++i) {


### PR DESCRIPTION
## Summary
- build TLAS nodes from top-level BVH children and upload buffer
- pass TLAS node count in uniforms and bind buffer for shaders
- traverse TLAS in path tracer before descending into BLAS nodes

## Testing
- `clang++ -std=c++17 -I'MetalCpp Path Tracer' -I'MetalCpp Path Tracer/MetalCpp/metal-cpp' -c 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` (fails: command not found)
- `apt-get update` (fails: repository not signed)


------
https://chatgpt.com/codex/tasks/task_e_689520072560832d89f0f623ad4545ab