### PR TITLE
Use custom view and rebuild acceleration structures on camera moves

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1,346 +1,397 @@
 #include "Renderer.h"
 
-#include <simd/simd.h>
-#include "Scene.h"
-#include "InputSystem.h"
 #include "Camera.h"
-#include <cstdio>
+#include "InputSystem.h"
+#include "Scene.h"
 #include "SceneLoader.h"
+#include <cstdio>
+#include <simd/simd.h>
 
 using namespace MetalCppPathTracer;
 
-struct UniformsData
-{
-    int primitiveIndex;
-    simd::float3 cameraPosition;
-    simd::float2 screenSize;
+struct UniformsData {
+  int primitiveIndex;
+  simd::float3 cameraPosition;
+  simd::float2 screenSize;
 
-    simd::float3 viewportU;
-    simd::float3 viewportV;
-    simd::float3 firstPixelPosition;
+  simd::float3 viewportU;
+  simd::float3 viewportV;
+  simd::float3 firstPixelPosition;
 
-    simd::float3 randomSeed;
+  simd::float3 randomSeed;
 
-    uint64_t primitiveCount;
-    uint64_t triangleCount;
-    uint64_t frameCount = 0;
-    uint64_t totalPrimitiveCount;
-    uint64_t tlasNodeCount;
+  uint64_t primitiveCount;
+  uint64_t triangleCount;
+  uint64_t frameCount = 0;
+  uint64_t totalPrimitiveCount;
+  uint64_t tlasNodeCount;
 };
 
-inline uint32_t bitm_random()
-{
-    static uint32_t current_seed = 92407235;
-    const uint32_t state = current_seed * 747796405u + 2891336453u;
-    const uint32_t word = ((state >> ((state >> 28u) + 4u)) ^ state);
-    return (current_seed = (word >> 22u) ^ word);
+inline uint32_t bitm_random() {
+  static uint32_t current_seed = 92407235;
+  const uint32_t state = current_seed * 747796405u + 2891336453u;
+  const uint32_t word = ((state >> ((state >> 28u) + 4u)) ^ state);
+  return (current_seed = (word >> 22u) ^ word);
 }
 
-inline float randomFloat()
-{
-    return (float)bitm_random() / (float)std::numeric_limits<uint32_t>::max();
+inline float randomFloat() {
+  return (float)bitm_random() / (float)std::numeric_limits<uint32_t>::max();
 }
 
-Renderer::Renderer(MTL::Device* pDevice)
-: _pDevice(pDevice->retain()), _pScene(new Scene())
-{
-    _pCommandQueue = _pDevice->newCommandQueue();
+Renderer::Renderer(MTL::Device *pDevice)
+    : _pDevice(pDevice->retain()), _pScene(new Scene()) {
+  _pCommandQueue = _pDevice->newCommandQueue();
 
-    Camera::reset();
-    Camera::screenSize = {1280, 720};
+  Camera::reset();
+  Camera::screenSize = {1280, 720};
 
-    updateVisibleScene();
-    buildShaders();
-    buildBuffers();
-    buildTextures();
+  updateVisibleScene();
+  buildShaders();
+  buildBuffers();
+  buildTextures();
 
+  recalculateViewport();
+}
+
+Renderer::~Renderer() {
+  if (_pSphereBuffer)
+    _pSphereBuffer->release();
+  if (_pSphereMaterialBuffer)
+    _pSphereMaterialBuffer->release();
+  if (_pTriangleVertexBuffer)
+    _pTriangleVertexBuffer->release();
+  if (_pTriangleIndexBuffer)
+    _pTriangleIndexBuffer->release();
+  if (_pUniformsBuffer)
+    _pUniformsBuffer->release();
+  if (_pBVHBuffer)
+    _pBVHBuffer->release();
+  if (_pPrimitiveIndexBuffer)
+    _pPrimitiveIndexBuffer->release();
+  if (_pTLASBuffer)
+    _pTLASBuffer->release();
+
+  for (int i = 0; i < 2; i++)
+    if (_accumulationTargets[i])
+      _accumulationTargets[i]->release();
+
+  if (_pPSO)
+    _pPSO->release();
+  if (_pCommandQueue)
+    _pCommandQueue->release();
+  if (_pDevice)
+    _pDevice->release();
+
+  delete _pScene;
+}
+
+void Renderer::buildShaders() {
+  using NS::StringEncoding::UTF8StringEncoding;
+
+  NS::Error *pError = nullptr;
+  MTL::Library *pLibrary = _pDevice->newDefaultLibrary();
+
+  if (!pLibrary) {
+    __builtin_printf("Failed to load Metal library\n");
+    assert(false);
+  }
+
+  MTL::Function *pVertexFn = pLibrary->newFunction(
+      NS::String::string("vertexMain", UTF8StringEncoding));
+  MTL::Function *pFragFn = pLibrary->newFunction(
+      NS::String::string("fragmentMain", UTF8StringEncoding));
+
+  MTL::RenderPipelineDescriptor *pDesc =
+      MTL::RenderPipelineDescriptor::alloc()->init();
+  pDesc->setVertexFunction(pVertexFn);
+  pDesc->setFragmentFunction(pFragFn);
+  pDesc->colorAttachments()->object(0)->setPixelFormat(
+      MTL::PixelFormat::PixelFormatRGBA16Float);
+
+  _pPSO = _pDevice->newRenderPipelineState(pDesc, &pError);
+  if (!_pPSO) {
+    __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
+    assert(false);
+  }
+
+  pVertexFn->release();
+  pFragFn->release();
+  pDesc->release();
+  pLibrary->release();
+}
+
+void Renderer::updateVisibleScene() {
+  SceneLoader::LoadSceneFromXML(
+      "/Users/apollo/Downloads/"
+      "MetalPathtracing-05e922c76da6c603e7840e71f7b563ad9b7eb4ea/MetalCpp Path "
+      "Tracer/scene.xml",
+      _pScene);
+
+  printf("Scene loaded: %zu total primitives (%zu spheres, %zu triangles)\n",
+         _pScene->getPrimitiveCount(),
+         _pScene->getPrimitiveCount() - _pScene->getTriangleCount(),
+         _pScene->getTriangleCount());
+
+  _pScene->buildBVH();
+
+  // Report separate BLAS and TLAS node counts
+  size_t blasNodeCount = _pScene->getBVHNodeCount();
+  printf("BLAS node count: %zu\n", blasNodeCount);
+
+  // BVH node buffer
+  simd::float4 *bvhData = _pScene->createBVHBuffer();
+  if (_pBVHBuffer)
+    _pBVHBuffer->release();
+  _pBVHBuffer = _pDevice->newBuffer(
+      bvhData, sizeof(simd::float4) * _pScene->getBVHNodeCount() * 2,
+      MTL::ResourceStorageModeManaged);
+  _pBVHBuffer->didModifyRange(NS::Range::Make(0, _pBVHBuffer->length()));
+  delete[] bvhData; // optional if `createBVHBuffer` allocates on heap
+
+  // Build TLAS buffer from root children
+  size_t tlasCount = 0;
+  simd::float4 *tlasData = _pScene->createTLASBuffer(tlasCount);
+  printf("TLAS node count: %zu\n", tlasCount);
+  if (_pTLASBuffer)
+    _pTLASBuffer->release();
+  if (tlasData && tlasCount > 0) {
+    _pTLASBuffer =
+        _pDevice->newBuffer(tlasData, sizeof(simd::float4) * tlasCount * 2,
+                            MTL::ResourceStorageModeManaged);
+    _pTLASBuffer->didModifyRange(NS::Range::Make(0, _pTLASBuffer->length()));
+  } else {
+    _pTLASBuffer = _pDevice->newBuffer(1, MTL::ResourceStorageModeManaged);
+  }
+  delete[] tlasData;
+  _tlasNodeCount = tlasCount;
+
+  // 🆕 Primitive index buffer (for BVH leaf traversal)
+  int *rawIndices = _pScene->createPrimitiveIndexBuffer();
+  if (_pPrimitiveIndexBuffer)
+    _pPrimitiveIndexBuffer->release();
+  _pPrimitiveIndexBuffer = _pDevice->newBuffer(
+      rawIndices, sizeof(int) * _pScene->getPrimitiveCount(),
+      MTL::ResourceStorageModeManaged);
+  _pPrimitiveIndexBuffer->didModifyRange(
+      NS::Range::Make(0, sizeof(int) * _pScene->getPrimitiveCount()));
+  delete[] rawIndices;
+
+  buildBuffers();
+}
+
+void Renderer::recalculateViewport() {
+  float aspectRatio = Camera::screenSize.x / Camera::screenSize.y;
+  float fovRad = Camera::verticalFov * (M_PI / 180.0f);
+  float halfHeight = tanf(fovRad * 0.5f);
+  float halfWidth = aspectRatio * halfHeight;
+
+  simd::float3 w = simd::normalize(-Camera::forward);
+  simd::float3 u = simd::normalize(simd::cross(Camera::up, w));
+  simd::float3 v = simd::cross(w, u);
+
+  simd::float3 viewportU = u * (2.0f * halfWidth);
+  simd::float3 viewportV = -v * (2.0f * halfHeight);
+
+  simd::float3 firstPixelPosition =
+      Camera::position - w - (viewportU * 0.5f) - (viewportV * 0.5f);
+
+  UniformsData *uData = (UniformsData *)_pUniformsBuffer->contents();
+  uData->cameraPosition = Camera::position;
+  uData->viewportU = viewportU;
+  uData->viewportV = viewportV;
+  uData->firstPixelPosition = firstPixelPosition;
+  uData->screenSize = Camera::screenSize;
+
+  _pUniformsBuffer->didModifyRange(NS::Range::Make(0, sizeof(UniformsData)));
+
+  printf("viewportU: (%f, %f, %f)\n", viewportU.x, viewportU.y, viewportU.z);
+  printf("viewportV: (%f, %f, %f)\n", viewportV.x, viewportV.y, viewportV.z);
+  printf("firstPixel: (%f, %f, %f)\n", firstPixelPosition.x,
+         firstPixelPosition.y, firstPixelPosition.z);
+}
+
+void Renderer::buildBuffers() {
+  const size_t primitiveCount = _pScene->getPrimitiveCount();
+  const size_t uniformsDataSize = sizeof(UniformsData);
+
+  // Uniforms
+  if (_pUniformsBuffer)
+    _pUniformsBuffer->release();
+  _pUniformsBuffer =
+      _pDevice->newBuffer(uniformsDataSize, MTL::ResourceStorageModeManaged);
+  _pUniformsBuffer->didModifyRange(NS::Range::Make(0, uniformsDataSize));
+
+  // Destroy previous
+  if (_pSphereBuffer) {
+    _pSphereBuffer->release();
+    _pSphereBuffer = nullptr;
+  }
+  if (_pSphereMaterialBuffer) {
+    _pSphereMaterialBuffer->release();
+    _pSphereMaterialBuffer = nullptr;
+  }
+
+  // ✅ Unified buffer
+  simd::float4 *primitiveBuffer =
+      _pScene->createTransformsBuffer(); // 3 float4s per primitive
+  simd::float4 *materialBuffer =
+      _pScene->createMaterialsBuffer(); // 2 float4s per primitive
+
+  const size_t primitiveSize = primitiveCount * 3 * sizeof(simd::float4);
+  const size_t materialSize = primitiveCount * 2 * sizeof(simd::float4);
+
+  _pSphereBuffer =
+      _pDevice->newBuffer(primitiveSize, MTL::ResourceStorageModeManaged);
+  _pSphereMaterialBuffer =
+      _pDevice->newBuffer(materialSize, MTL::ResourceStorageModeManaged);
+
+  memcpy(_pSphereBuffer->contents(), primitiveBuffer, primitiveSize);
+  memcpy(_pSphereMaterialBuffer->contents(), materialBuffer, materialSize);
+
+  _pSphereBuffer->didModifyRange(NS::Range::Make(0, primitiveSize));
+  _pSphereMaterialBuffer->didModifyRange(NS::Range::Make(0, materialSize));
+
+  delete[] primitiveBuffer;
+  delete[] materialBuffer;
+
+  // Dummy triangle buffer bindings
+  simd::float3 dummyVertex = {0, 0, 0};
+  simd::uint3 dummyIndex = {0, 0, 0};
+
+  _pTriangleVertexBuffer = _pDevice->newBuffer(
+      &dummyVertex, sizeof(simd::float3), MTL::ResourceStorageModeManaged);
+  _pTriangleIndexBuffer = _pDevice->newBuffer(&dummyIndex, sizeof(simd::uint3),
+                                              MTL::ResourceStorageModeManaged);
+}
+
+void Renderer::buildTextures() {
+  MTL::TextureDescriptor *textureDescriptor =
+      MTL::TextureDescriptor::alloc()->init();
+
+  textureDescriptor->setPixelFormat(MTL::PixelFormat::PixelFormatRGBA32Float);
+  textureDescriptor->setTextureType(MTL::TextureType::TextureType2D);
+  textureDescriptor->setWidth(Camera::screenSize.x);
+  textureDescriptor->setHeight(Camera::screenSize.y);
+  textureDescriptor->setStorageMode(MTL::StorageMode::StorageModePrivate);
+  textureDescriptor->setUsage(MTL::TextureUsageShaderRead |
+                              MTL::TextureUsageShaderWrite);
+
+  for (uint i = 0; i < 2; i++)
+    _accumulationTargets[i] = _pDevice->newTexture(textureDescriptor);
+}
+
+bool Renderer::updateCamera() {
+  bool changed = Camera::transformWithInputs();
+  if (changed) {
     recalculateViewport();
+    rebuildAccelerationStructures();
+  }
+  return changed;
 }
 
-Renderer::~Renderer()
-{
-    if (_pSphereBuffer) _pSphereBuffer->release();
-    if (_pSphereMaterialBuffer) _pSphereMaterialBuffer->release();
-    if (_pTriangleVertexBuffer) _pTriangleVertexBuffer->release();
-    if (_pTriangleIndexBuffer) _pTriangleIndexBuffer->release();
-    if (_pUniformsBuffer) _pUniformsBuffer->release();
-    if (_pBVHBuffer) _pBVHBuffer->release();
-    if (_pPrimitiveIndexBuffer) _pPrimitiveIndexBuffer->release();
-    if (_pTLASBuffer) _pTLASBuffer->release();
+void Renderer::updateUniforms() {
+  UniformsData &u = *((UniformsData *)_pUniformsBuffer->contents());
 
+  if (updateCamera()) {
+    u.frameCount = 0;
+    u.randomSeed = {randomFloat(), randomFloat(), randomFloat()};
+  } else {
+    u.frameCount++;
+  }
 
-    for (int i = 0; i < 2; i++)
-        if (_accumulationTargets[i]) _accumulationTargets[i]->release();
+  u.primitiveCount = _pScene->getPrimitiveCount();
+  u.triangleCount = _pScene->getTriangleCount();
+  u.tlasNodeCount = _tlasNodeCount;
 
-    if (_pPSO) _pPSO->release();
-    if (_pCommandQueue) _pCommandQueue->release();
-    if (_pDevice) _pDevice->release();
-
-    delete _pScene;
+  _pUniformsBuffer->didModifyRange(NS::Range::Make(0, sizeof(UniformsData)));
 }
 
-void Renderer::buildShaders()
-{
-    using NS::StringEncoding::UTF8StringEncoding;
+void Renderer::draw(MTK::View *pView) {
+  static int frameCounter = 0;
+  frameCounter++;
 
-    NS::Error* pError = nullptr;
-    MTL::Library* pLibrary = _pDevice->newDefaultLibrary();
+  // if (frameCounter % 30 == 0)
+  //     updateVisibleScene();
 
-    if (!pLibrary)
-    {
-        __builtin_printf("Failed to load Metal library\n");
-        assert(false);
-    }
+  updateUniforms();
+  std::swap(_accumulationTargets[0], _accumulationTargets[1]);
 
-    MTL::Function* pVertexFn = pLibrary->newFunction(NS::String::string("vertexMain", UTF8StringEncoding));
-    MTL::Function* pFragFn = pLibrary->newFunction(NS::String::string("fragmentMain", UTF8StringEncoding));
+  NS::AutoreleasePool *pPool = NS::AutoreleasePool::alloc()->init();
 
-    MTL::RenderPipelineDescriptor* pDesc = MTL::RenderPipelineDescriptor::alloc()->init();
-    pDesc->setVertexFunction(pVertexFn);
-    pDesc->setFragmentFunction(pFragFn);
-    pDesc->colorAttachments()->object(0)->setPixelFormat(MTL::PixelFormat::PixelFormatRGBA16Float);
+  MTL::CommandBuffer *pCmd = _pCommandQueue->commandBuffer();
+  MTL::RenderPassDescriptor *pRpd = pView->currentRenderPassDescriptor();
+  MTL::RenderCommandEncoder *pEnc = pCmd->renderCommandEncoder(pRpd);
 
-    _pPSO = _pDevice->newRenderPipelineState(pDesc, &pError);
-    if (!_pPSO)
-    {
-        __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
-        assert(false);
-    }
+  pEnc->setRenderPipelineState(_pPSO);
 
-    pVertexFn->release();
-    pFragFn->release();
-    pDesc->release();
-    pLibrary->release();
+  // Always bind something for each slot
+  pEnc->setFragmentBuffer(_pBVHBuffer, 0, 0); // New!
+  pEnc->setFragmentBuffer(_pSphereBuffer, 0, 1);
+  pEnc->setFragmentBuffer(_pSphereMaterialBuffer, 0, 2);
+  pEnc->setFragmentBuffer(_pUniformsBuffer, 0, 3);
+  pEnc->setFragmentBuffer(_pTriangleVertexBuffer, 0, 4);
+  pEnc->setFragmentBuffer(_pTriangleIndexBuffer, 0, 5);
+  pEnc->setFragmentBuffer(_pPrimitiveIndexBuffer, 0, 6);
+  pEnc->setFragmentBuffer(_pTLASBuffer, 0, 7);
+
+  pEnc->setFragmentTexture(_accumulationTargets[0], 0);
+  pEnc->setFragmentTexture(_accumulationTargets[1], 1);
+
+  pEnc->drawPrimitives(MTL::PrimitiveType::PrimitiveTypeTriangle,
+                       NS::UInteger(0), NS::UInteger(6));
+
+  pEnc->endEncoding();
+  pCmd->presentDrawable(pView->currentDrawable());
+  pCmd->commit();
+
+  pPool->release();
 }
 
-void Renderer::updateVisibleScene()
-{
-    SceneLoader::LoadSceneFromXML("/Users/apollo/Downloads/MetalPathtracing-05e922c76da6c603e7840e71f7b563ad9b7eb4ea/MetalCpp Path Tracer/scene.xml", _pScene);
+void Renderer::drawableSizeWillChange(MTK::View *pView, CGSize size) {
+  for (uint i = 0; i < 2; i++)
+    if (_accumulationTargets[i])
+      _accumulationTargets[i]->release();
 
-    printf("Scene loaded: %zu total primitives (%zu spheres, %zu triangles)\n",
-           _pScene->getPrimitiveCount(),
-           _pScene->getPrimitiveCount() - _pScene->getTriangleCount(),
-           _pScene->getTriangleCount());
+  Camera::screenSize = {(float)size.width, (float)size.height};
 
-    _pScene->buildBVH();
-
-    // Report separate BLAS and TLAS node counts
-    size_t blasNodeCount = _pScene->getBVHNodeCount();
-    printf("BLAS node count: %zu\n", blasNodeCount);
-
-    // BVH node buffer
-    simd::float4* bvhData = _pScene->createBVHBuffer();
-    if (_pBVHBuffer) _pBVHBuffer->release();
-    _pBVHBuffer = _pDevice->newBuffer(
-        bvhData,
-        sizeof(simd::float4) * _pScene->getBVHNodeCount() * 2,
-        MTL::ResourceStorageModeManaged
-    );
-    _pBVHBuffer->didModifyRange(NS::Range::Make(0, _pBVHBuffer->length()));
-    delete[] bvhData; // optional if `createBVHBuffer` allocates on heap
-
-    // Build TLAS buffer from root children
-    size_t tlasCount = 0;
-    simd::float4* tlasData = _pScene->createTLASBuffer(tlasCount);
-    printf("TLAS node count: %zu\n", tlasCount);
-    if (_pTLASBuffer) _pTLASBuffer->release();
-    if (tlasData && tlasCount > 0) {
-        _pTLASBuffer = _pDevice->newBuffer(
-            tlasData,
-            sizeof(simd::float4) * tlasCount * 2,
-            MTL::ResourceStorageModeManaged
-        );
-        _pTLASBuffer->didModifyRange(NS::Range::Make(0, _pTLASBuffer->length()));
-    } else {
-        _pTLASBuffer = _pDevice->newBuffer(1, MTL::ResourceStorageModeManaged);
-    }
-    delete[] tlasData;
-    _tlasNodeCount = tlasCount;
-
-    // 🆕 Primitive index buffer (for BVH leaf traversal)
-    int* rawIndices = _pScene->createPrimitiveIndexBuffer();
-    if (_pPrimitiveIndexBuffer) _pPrimitiveIndexBuffer->release();
-    _pPrimitiveIndexBuffer = _pDevice->newBuffer(
-        rawIndices,
-        sizeof(int) * _pScene->getPrimitiveCount(),
-        MTL::ResourceStorageModeManaged
-    );
-    _pPrimitiveIndexBuffer->didModifyRange(NS::Range::Make(0, sizeof(int) * _pScene->getPrimitiveCount()));
-    delete[] rawIndices;
-
-    buildBuffers();
+  buildTextures();
+  recalculateViewport();
 }
 
+void Renderer::rebuildAccelerationStructures() {
+  _pScene->buildBVH();
 
+  simd::float4 *bvhData = _pScene->createBVHBuffer();
+  if (_pBVHBuffer)
+    _pBVHBuffer->release();
+  _pBVHBuffer = _pDevice->newBuffer(
+      bvhData, sizeof(simd::float4) * _pScene->getBVHNodeCount() * 2,
+      MTL::ResourceStorageModeManaged);
+  _pBVHBuffer->didModifyRange(NS::Range::Make(0, _pBVHBuffer->length()));
+  delete[] bvhData;
 
-void Renderer::recalculateViewport()
-{
-    float aspectRatio = Camera::screenSize.x / Camera::screenSize.y;
-    float fovRad = Camera::verticalFov * (M_PI / 180.0f);
-    float halfHeight = tanf(fovRad * 0.5f);
-    float halfWidth = aspectRatio * halfHeight;
+  size_t tlasCount = 0;
+  simd::float4 *tlasData = _pScene->createTLASBuffer(tlasCount);
+  if (_pTLASBuffer)
+    _pTLASBuffer->release();
+  if (tlasData && tlasCount > 0) {
+    _pTLASBuffer =
+        _pDevice->newBuffer(tlasData, sizeof(simd::float4) * tlasCount * 2,
+                            MTL::ResourceStorageModeManaged);
+    _pTLASBuffer->didModifyRange(NS::Range::Make(0, _pTLASBuffer->length()));
+  } else {
+    _pTLASBuffer = _pDevice->newBuffer(1, MTL::ResourceStorageModeManaged);
+  }
+  delete[] tlasData;
+  _tlasNodeCount = tlasCount;
 
-    simd::float3 w = simd::normalize(-Camera::forward);
-    simd::float3 u = simd::normalize(simd::cross(Camera::up, w));
-    simd::float3 v = simd::cross(w, u);
-
-    simd::float3 viewportU = u * (2.0f * halfWidth);
-    simd::float3 viewportV = -v * (2.0f * halfHeight);
-
-    simd::float3 firstPixelPosition = Camera::position - w - (viewportU * 0.5f) - (viewportV * 0.5f);
-
-    UniformsData* uData = (UniformsData*)_pUniformsBuffer->contents();
-    uData->cameraPosition = Camera::position;
-    uData->viewportU = viewportU;
-    uData->viewportV = viewportV;
-    uData->firstPixelPosition = firstPixelPosition;
-    uData->screenSize = Camera::screenSize;
-
-    _pUniformsBuffer->didModifyRange(NS::Range::Make(0, sizeof(UniformsData)));
-    
-    printf("viewportU: (%f, %f, %f)\n", viewportU.x, viewportU.y, viewportU.z);
-    printf("viewportV: (%f, %f, %f)\n", viewportV.x, viewportV.y, viewportV.z);
-    printf("firstPixel: (%f, %f, %f)\n", firstPixelPosition.x, firstPixelPosition.y, firstPixelPosition.z);
-
-}
-
-void Renderer::buildBuffers()
-{
-    const size_t primitiveCount = _pScene->getPrimitiveCount();
-    const size_t uniformsDataSize = sizeof(UniformsData);
-
-    // Uniforms
-    if (_pUniformsBuffer) _pUniformsBuffer->release();
-    _pUniformsBuffer = _pDevice->newBuffer(uniformsDataSize, MTL::ResourceStorageModeManaged);
-    _pUniformsBuffer->didModifyRange(NS::Range::Make(0, uniformsDataSize));
-
-    // Destroy previous
-    if (_pSphereBuffer) { _pSphereBuffer->release(); _pSphereBuffer = nullptr; }
-    if (_pSphereMaterialBuffer) { _pSphereMaterialBuffer->release(); _pSphereMaterialBuffer = nullptr; }
-
-    // ✅ Unified buffer
-    simd::float4* primitiveBuffer = _pScene->createTransformsBuffer();    // 3 float4s per primitive
-    simd::float4* materialBuffer = _pScene->createMaterialsBuffer();      // 2 float4s per primitive
-
-    const size_t primitiveSize = primitiveCount * 3 * sizeof(simd::float4);
-    const size_t materialSize = primitiveCount * 2 * sizeof(simd::float4);
-
-    _pSphereBuffer = _pDevice->newBuffer(primitiveSize, MTL::ResourceStorageModeManaged);
-    _pSphereMaterialBuffer = _pDevice->newBuffer(materialSize, MTL::ResourceStorageModeManaged);
-
-    memcpy(_pSphereBuffer->contents(), primitiveBuffer, primitiveSize);
-    memcpy(_pSphereMaterialBuffer->contents(), materialBuffer, materialSize);
-
-    _pSphereBuffer->didModifyRange(NS::Range::Make(0, primitiveSize));
-    _pSphereMaterialBuffer->didModifyRange(NS::Range::Make(0, materialSize));
-
-    delete[] primitiveBuffer;
-    delete[] materialBuffer;
-
-    // Dummy triangle buffer bindings
-    simd::float3 dummyVertex = {0, 0, 0};
-    simd::uint3 dummyIndex = {0, 0, 0};
-
-    _pTriangleVertexBuffer = _pDevice->newBuffer(&dummyVertex, sizeof(simd::float3), MTL::ResourceStorageModeManaged);
-    _pTriangleIndexBuffer = _pDevice->newBuffer(&dummyIndex, sizeof(simd::uint3), MTL::ResourceStorageModeManaged);
-}
-
-
-
-
-void Renderer::buildTextures()
-{
-    MTL::TextureDescriptor* textureDescriptor = MTL::TextureDescriptor::alloc()->init();
-
-    textureDescriptor->setPixelFormat(MTL::PixelFormat::PixelFormatRGBA32Float);
-    textureDescriptor->setTextureType(MTL::TextureType::TextureType2D);
-    textureDescriptor->setWidth(Camera::screenSize.x);
-    textureDescriptor->setHeight(Camera::screenSize.y);
-    textureDescriptor->setStorageMode(MTL::StorageMode::StorageModePrivate);
-    textureDescriptor->setUsage(MTL::TextureUsageShaderRead | MTL::TextureUsageShaderWrite);
-
-    for (uint i = 0; i < 2; i++)
-        _accumulationTargets[i] = _pDevice->newTexture(textureDescriptor);
-}
-
-bool Renderer::updateCamera()
-{
-    bool changed = Camera::transformWithInputs();
-    if (changed)
-        recalculateViewport();
-    return changed;
-}
-
-void Renderer::updateUniforms()
-{
-    UniformsData& u = *((UniformsData*)_pUniformsBuffer->contents());
-
-    if (updateCamera()) {
-        u.frameCount = 0;
-        u.randomSeed = {randomFloat(), randomFloat(), randomFloat()};
-    } else {
-        u.frameCount++;
-    }
-
-    u.primitiveCount = _pScene->getPrimitiveCount();
-    u.triangleCount = _pScene->getTriangleCount();
-    u.tlasNodeCount = _tlasNodeCount;
-
-
-    _pUniformsBuffer->didModifyRange(NS::Range::Make(0, sizeof(UniformsData)));
-}
-
-void Renderer::draw(MTK::View* pView)
-{
-    static int frameCounter = 0;
-    frameCounter++;
-
-    //if (frameCounter % 30 == 0)
-    //    updateVisibleScene();
-
-    updateUniforms();
-    std::swap(_accumulationTargets[0], _accumulationTargets[1]);
-
-    NS::AutoreleasePool* pPool = NS::AutoreleasePool::alloc()->init();
-
-    MTL::CommandBuffer* pCmd = _pCommandQueue->commandBuffer();
-    MTL::RenderPassDescriptor* pRpd = pView->currentRenderPassDescriptor();
-    MTL::RenderCommandEncoder* pEnc = pCmd->renderCommandEncoder(pRpd);
-
-    pEnc->setRenderPipelineState(_pPSO);
-
-    // Always bind something for each slot
-    pEnc->setFragmentBuffer(_pBVHBuffer, 0, 0);               // New!
-    pEnc->setFragmentBuffer(_pSphereBuffer, 0, 1);
-    pEnc->setFragmentBuffer(_pSphereMaterialBuffer, 0, 2);
-    pEnc->setFragmentBuffer(_pUniformsBuffer, 0, 3);
-    pEnc->setFragmentBuffer(_pTriangleVertexBuffer, 0, 4);
-    pEnc->setFragmentBuffer(_pTriangleIndexBuffer, 0, 5);
-    pEnc->setFragmentBuffer(_pPrimitiveIndexBuffer, 0, 6);
-    pEnc->setFragmentBuffer(_pTLASBuffer, 0, 7);
-
-
-
-
-    pEnc->setFragmentTexture(_accumulationTargets[0], 0);
-    pEnc->setFragmentTexture(_accumulationTargets[1], 1);
-
-    pEnc->drawPrimitives(MTL::PrimitiveType::PrimitiveTypeTriangle, NS::UInteger(0), NS::UInteger(6));
-
-    pEnc->endEncoding();
-    pCmd->presentDrawable(pView->currentDrawable());
-    pCmd->commit();
-
-    pPool->release();
-}
-
-void Renderer::drawableSizeWillChange(MTK::View* pView, CGSize size)
-{
-    for (uint i = 0; i < 2; i++)
-        if (_accumulationTargets[i]) _accumulationTargets[i]->release();
-
-    Camera::screenSize = {(float)size.width, (float)size.height};
-
-    buildTextures();
-    recalculateViewport();
+  int *rawIndices = _pScene->createPrimitiveIndexBuffer();
+  if (_pPrimitiveIndexBuffer)
+    _pPrimitiveIndexBuffer->release();
+  _pPrimitiveIndexBuffer = _pDevice->newBuffer(
+      rawIndices, sizeof(int) * _pScene->getPrimitiveCount(),
+      MTL::ResourceStorageModeManaged);
+  _pPrimitiveIndexBuffer->didModifyRange(
+      NS::Range::Make(0, sizeof(int) * _pScene->getPrimitiveCount()));
+  delete[] rawIndices;
 }

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -7,54 +7,55 @@
 
 #include "Scene.h"
 
-namespace MetalCppPathTracer
-{
+namespace MetalCppPathTracer {
 
-class Renderer
-{
+class Renderer {
 public:
-    Renderer(MTL::Device* pDevice);
-    ~Renderer();
+  Renderer(MTL::Device *pDevice);
+  ~Renderer();
 
-    void updateVisibleScene();
-    void buildShaders();
-    void buildBuffers();
-    void buildTextures();
+  void updateVisibleScene();
+  void buildShaders();
+  void buildBuffers();
+  void buildTextures();
 
-    void recalculateViewport();
-    bool updateCamera();
+  void recalculateViewport();
+  bool updateCamera();
 
-    void updateUniforms();
-    void draw(MTK::View* pView);
-    void drawableSizeWillChange(MTK::View* pView, CGSize size);
+  void updateUniforms();
+  void draw(MTK::View *pView);
+  void drawableSizeWillChange(MTK::View *pView, CGSize size);
 
-    std::vector<std::pair<simd::float3, float>> _allSpheres;
+  std::vector<std::pair<simd::float3, float>> _allSpheres;
 
-    struct Chunk {
-        std::vector<std::pair<simd::float4, simd::float4>> spheres; // (transform, material)
-        simd::int3 chunkCoords;
-    };
+  struct Chunk {
+    std::vector<std::pair<simd::float4, simd::float4>>
+        spheres; // (transform, material)
+    simd::int3 chunkCoords;
+  };
 
 private:
-    MTL::Device* _pDevice = nullptr;
-    MTL::CommandQueue* _pCommandQueue = nullptr;
-    MTL::RenderPipelineState* _pPSO = nullptr;
+  MTL::Device *_pDevice = nullptr;
+  MTL::CommandQueue *_pCommandQueue = nullptr;
+  MTL::RenderPipelineState *_pPSO = nullptr;
 
-    // Core scene and geometry data
-    Scene* _pScene = nullptr;
+  // Core scene and geometry data
+  Scene *_pScene = nullptr;
 
-    // Buffers
-    MTL::Buffer* _pSphereBuffer = nullptr;
-    MTL::Buffer* _pSphereMaterialBuffer = nullptr;
-    MTL::Buffer* _pTriangleVertexBuffer = nullptr;
-    MTL::Buffer* _pTriangleIndexBuffer = nullptr;
-    MTL::Buffer* _pUniformsBuffer = nullptr;
-    MTL::Buffer* _pBVHBuffer = nullptr;
-    MTL::Buffer* _pPrimitiveIndexBuffer = nullptr;
-    MTL::Buffer* _pTLASBuffer = nullptr;
-    size_t _tlasNodeCount = 0;
-    // Accumulation framebuffers
-    MTL::Texture* _accumulationTargets[2] = {nullptr, nullptr};
+  // Buffers
+  MTL::Buffer *_pSphereBuffer = nullptr;
+  MTL::Buffer *_pSphereMaterialBuffer = nullptr;
+  MTL::Buffer *_pTriangleVertexBuffer = nullptr;
+  MTL::Buffer *_pTriangleIndexBuffer = nullptr;
+  MTL::Buffer *_pUniformsBuffer = nullptr;
+  MTL::Buffer *_pBVHBuffer = nullptr;
+  MTL::Buffer *_pPrimitiveIndexBuffer = nullptr;
+  MTL::Buffer *_pTLASBuffer = nullptr;
+  size_t _tlasNodeCount = 0;
+  // Accumulation framebuffers
+  MTL::Texture *_accumulationTargets[2] = {nullptr, nullptr};
+
+  void rebuildAccelerationStructures();
 };
 
 } // namespace MetalCppPathTracer

--- a/MetalCpp Path Tracer/Window/ApplicationDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ApplicationDelegate.cpp
@@ -2,59 +2,63 @@
 
 using namespace MetalCppPathTracer;
 
-ApplicationDelegate::~ApplicationDelegate()
-{
-    if (_pMtkView) _pMtkView->release();
-    if (_pWindow) _pWindow->release();
-    if (_pDevice) _pDevice->release();
-    if (_pViewDelegate) delete _pViewDelegate;
+ApplicationDelegate::~ApplicationDelegate() {
+  if (_pMtkView)
+    _pMtkView->release();
+  if (_pWindow)
+    _pWindow->release();
+  if (_pDevice)
+    _pDevice->release();
+  if (_pViewDelegate)
+    delete _pViewDelegate;
 }
 
-void ApplicationDelegate::applicationWillFinishLaunching(NS::Notification* pNotification)
-{
-    NS::Application* pApp = reinterpret_cast<NS::Application*>(pNotification->object());
-    pApp->setActivationPolicy(NS::ActivationPolicy::ActivationPolicyRegular);
+void ApplicationDelegate::applicationWillFinishLaunching(
+    NS::Notification *pNotification) {
+  NS::Application *pApp =
+      reinterpret_cast<NS::Application *>(pNotification->object());
+  pApp->setActivationPolicy(NS::ActivationPolicy::ActivationPolicyRegular);
 }
 
-void ApplicationDelegate::applicationDidFinishLaunching(NS::Notification* pNotification)
-{
-    if(_initialized)
-        return;
-    _initialized = true;
-    CGRect frame = {{100.0, 100.0}, {1280.0, 720.0}};
+void ApplicationDelegate::applicationDidFinishLaunching(
+    NS::Notification *pNotification) {
+  if (_initialized)
+    return;
+  _initialized = true;
+  CGRect frame = {{100.0, 100.0}, {1280.0, 720.0}};
 
-    _pWindow = NS::Window::alloc()->init(
-        frame,
-        NS::WindowStyleMaskClosable | NS::WindowStyleMaskTitled | NS::WindowStyleMaskResizable,
-        NS::BackingStoreBuffered,
-        false
-    );
+  _pWindow = NS::Window::alloc()->init(frame,
+                                       NS::WindowStyleMaskClosable |
+                                           NS::WindowStyleMaskTitled |
+                                           NS::WindowStyleMaskResizable,
+                                       NS::BackingStoreBuffered, false);
 
-    _pDevice = MTL::CreateSystemDefaultDevice();
+  _pDevice = MTL::CreateSystemDefaultDevice();
 
-    _pMtkView = MTK::View::alloc()->init(frame, _pDevice);
-    _pMtkView->setDevice(_pDevice);
-    _pMtkView->setColorPixelFormat(MTL::PixelFormat::PixelFormatRGBA16Float);
-    _pMtkView->setClearColor(MTL::ClearColor::Make(0.0, 0.0, 0.0, 1.0));
-    _pMtkView->setPreferredFramesPerSecond(60);
-    _pMtkView->setEnableSetNeedsDisplay(false);
-    _pMtkView->setPaused(false);
+  _pMtkView = _controllerView.get(frame);
+  _pMtkView->setDevice(_pDevice);
+  _pMtkView->setColorPixelFormat(MTL::PixelFormat::PixelFormatRGBA16Float);
+  _pMtkView->setClearColor(MTL::ClearColor::Make(0.0, 0.0, 0.0, 1.0));
+  _pMtkView->setPreferredFramesPerSecond(60);
+  _pMtkView->setEnableSetNeedsDisplay(false);
+  _pMtkView->setPaused(false);
 
-    _pViewDelegate = new ViewDelegate(_pDevice);
-    _pMtkView->setDelegate(_pViewDelegate);
+  _pViewDelegate = new ViewDelegate(_pDevice);
+  _pMtkView->setDelegate(_pViewDelegate);
 
-    _pWindow->setContentView(_pMtkView);
-    _pWindow->setTitle(NS::String::string("MetalCpp Path Tracer", NS::StringEncoding::UTF8StringEncoding));
-    _pWindow->makeKeyAndOrderFront(nullptr);
+  _pWindow->setContentView(_pMtkView);
+  _pWindow->setTitle(NS::String::string(
+      "MetalCpp Path Tracer", NS::StringEncoding::UTF8StringEncoding));
+  _pWindow->makeKeyAndOrderFront(nullptr);
 
-    NS::Application* pApp = reinterpret_cast<NS::Application*>(pNotification->object());
-    pApp->activateIgnoringOtherApps(true);
+  NS::Application *pApp =
+      reinterpret_cast<NS::Application *>(pNotification->object());
+  pApp->activateIgnoringOtherApps(true);
 }
 
-bool ApplicationDelegate::applicationShouldTerminateAfterLastWindowClosed(NS::Application* /*pSender*/)
-{
-    return true;
+bool ApplicationDelegate::applicationShouldTerminateAfterLastWindowClosed(
+    NS::Application * /*pSender*/) {
+  return true;
 }
 
-
-//hehehehe
+// hehehehe

--- a/MetalCpp Path Tracer/Window/ApplicationDelegate.h
+++ b/MetalCpp Path Tracer/Window/ApplicationDelegate.h
@@ -1,34 +1,37 @@
 #ifndef APPLICATION_DELEGATE_H
 #define APPLICATION_DELEGATE_H
 
-#include <Metal/Metal.hpp>
-#include <MetalKit/MetalKit.hpp>
 #include <AppKit/AppKit.hpp>
 #include <Foundation/Foundation.hpp>
+#include <Metal/Metal.hpp>
+#include <MetalKit/MetalKit.hpp>
 
+#include "ControllerView.hpp"
 #include "ViewDelegate.h"
 
-namespace MetalCppPathTracer
-{
+namespace MetalCppPathTracer {
 
-class ApplicationDelegate : public NS::ApplicationDelegate
-{
-    public:
-        ~ApplicationDelegate();
-    
-        ApplicationDelegate() = default;
-        virtual void applicationWillFinishLaunching( NS::Notification* pNotification ) override;
-        virtual void applicationDidFinishLaunching( NS::Notification* pNotification ) override;
-        virtual bool applicationShouldTerminateAfterLastWindowClosed( NS::Application* pSender ) override;
+class ApplicationDelegate : public NS::ApplicationDelegate {
+public:
+  ~ApplicationDelegate();
 
-    private:
-        NS::Window* _pWindow;
-        MTK::View* _pMtkView;
-        MTL::Device* _pDevice;
-        ViewDelegate* _pViewDelegate = nullptr;
-        bool _initialized = false;
+  ApplicationDelegate() = default;
+  virtual void
+  applicationWillFinishLaunching(NS::Notification *pNotification) override;
+  virtual void
+  applicationDidFinishLaunching(NS::Notification *pNotification) override;
+  virtual bool applicationShouldTerminateAfterLastWindowClosed(
+      NS::Application *pSender) override;
+
+private:
+  NS::Window *_pWindow;
+  MTK::View *_pMtkView;
+  MTL::Device *_pDevice;
+  ViewDelegate *_pViewDelegate = nullptr;
+  ControllerView _controllerView;
+  bool _initialized = false;
 };
 
-};
+}; // namespace MetalCppPathTracer
 
-#endif  //  APPLICATION_DELEGATE_H
+#endif //  APPLICATION_DELEGATE_H


### PR DESCRIPTION
## Summary
- Instantiate MTKView through `ControllerView` so input events drive the camera and to avoid spawning additional windows.
- Rebuild BLAS/TLAS whenever the camera transforms to keep acceleration structures in sync.

## Testing
- `xcodebuild -project 'MetalCpp Path Tracer.xcodeproj' -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895c988f77c832dbdb63f0f81b4a6bb