### PR TITLE
Print updated BLAS/TLAS node counts on rebuild

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -51,6 +51,7 @@ private:
   MTL::Buffer *_pBVHBuffer = nullptr;
   MTL::Buffer *_pPrimitiveIndexBuffer = nullptr;
   MTL::Buffer *_pTLASBuffer = nullptr;
+  size_t _blasNodeCount = 0;
   size_t _tlasNodeCount = 0;
   // Accumulation framebuffers
   MTL::Texture *_accumulationTargets[2] = {nullptr, nullptr};


### PR DESCRIPTION
## Summary
- Track BLAS and TLAS node counts inside the renderer
- Log BLAS/TLAS node counts whenever acceleration structures rebuild

## Testing
- `g++ -std=c++17 -fsyntax-only 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` (fails: Metal/Metal.hpp: No such file or directory)

------
https://chatgpt.com/codex/tasks/task_e_6895cc5c090c832db660a2e6d91766f3