### PR TITLE
Add frustum culling and export of acceleration structures

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -22,9 +22,11 @@ public:
   void recalculateViewport();
   bool updateCamera();
 
-  void updateUniforms();
-  void draw(MTK::View *pView);
-  void drawableSizeWillChange(MTK::View *pView, CGSize size);
+    void updateUniforms();
+    void draw(MTK::View *pView);
+    void drawableSizeWillChange(MTK::View *pView, CGSize size);
+    void exportAccelerationStructures(const char *blasPath,
+                                      const char *tlasPath);
 
   std::vector<std::pair<simd::float3, float>> _allSpheres;
 
@@ -39,8 +41,9 @@ private:
   MTL::CommandQueue *_pCommandQueue = nullptr;
   MTL::RenderPipelineState *_pPSO = nullptr;
 
-  // Core scene and geometry data
-  Scene *_pScene = nullptr;
+    // Core scene and geometry data
+    Scene *_fullScene = nullptr;   // persistent scene storage
+    Scene *_pScene = nullptr;      // currently visible subset
 
   // Buffers
   MTL::Buffer *_pSphereBuffer = nullptr;

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -68,6 +68,9 @@ public:
         return primitiveIndices;
     }
 
+    // Expose raw primitives for higher-level systems (e.g., view frustum culling)
+    const std::vector<Primitive>& getPrimitives() const { return primitives; }
+
     void buildBVH() {
         std::stable_sort(primitives.begin(), primitives.end(),
                          [](const Primitive& a, const Primitive& b) {


### PR DESCRIPTION
## Summary
- maintain both full and visible scenes and rebuild BLAS/TLAS after frustum culling
- add function to dump BLAS and TLAS bounding boxes to OBJ files for debugging
- expose raw primitives from Scene for culling

## Testing
- `g++ -std=c++17 -c 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` *(fails: Metal/Metal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895d1e44674832d964cbfd3fbd2ec78