### PR TITLE
Cull offscreen primitives and dump acceleration data

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -132,6 +132,10 @@ void Renderer::updateVisibleScene() {
          _pScene->getPrimitiveCount() - _pScene->getTriangleCount(),
          _pScene->getTriangleCount());
 
+  _pScene->restoreVisiblePrimitives(Camera::position, Camera::forward,
+                                   Camera::verticalFov);
+  _pScene->cullOffscreenPrimitives(Camera::position, Camera::forward,
+                                   Camera::verticalFov);
   _pScene->buildBVH();
 
   // Report separate BLAS and TLAS node counts
@@ -147,6 +151,7 @@ void Renderer::updateVisibleScene() {
       bvhData, sizeof(simd::float4) * _pScene->getBVHNodeCount() * 2,
       MTL::ResourceStorageModeManaged);
   _pBVHBuffer->didModifyRange(NS::Range::Make(0, _pBVHBuffer->length()));
+  _pScene->dumpBVH("bvh_dump.txt");
   delete[] bvhData; // optional if `createBVHBuffer` allocates on heap
 
   // Build TLAS buffer from root children
@@ -164,6 +169,7 @@ void Renderer::updateVisibleScene() {
   } else {
     _pTLASBuffer = _pDevice->newBuffer(1, MTL::ResourceStorageModeManaged);
   }
+  Scene::dumpTLAS(tlasData, tlasCount, "tlas_dump.txt");
   delete[] tlasData;
 
   // 🆕 Primitive index buffer (for BVH leaf traversal)
@@ -360,6 +366,10 @@ void Renderer::drawableSizeWillChange(MTK::View *pView, CGSize size) {
 }
 
 void Renderer::rebuildAccelerationStructures() {
+  _pScene->restoreVisiblePrimitives(Camera::position, Camera::forward,
+                                   Camera::verticalFov);
+  _pScene->cullOffscreenPrimitives(Camera::position, Camera::forward,
+                                   Camera::verticalFov);
   _pScene->buildBVH();
 
   size_t newBlasCount = _pScene->getBVHNodeCount();
@@ -376,6 +386,7 @@ void Renderer::rebuildAccelerationStructures() {
       bvhData, sizeof(simd::float4) * newBlasCount * 2,
       MTL::ResourceStorageModeManaged);
   _pBVHBuffer->didModifyRange(NS::Range::Make(0, _pBVHBuffer->length()));
+  _pScene->dumpBVH("bvh_dump.txt");
   delete[] bvhData;
 
   size_t tlasCount = 0;
@@ -395,6 +406,7 @@ void Renderer::rebuildAccelerationStructures() {
   } else {
     _pTLASBuffer = _pDevice->newBuffer(1, MTL::ResourceStorageModeManaged);
   }
+  Scene::dumpTLAS(tlasData, tlasCount, "tlas_dump.txt");
   delete[] tlasData;
 
   int *rawIndices = _pScene->createPrimitiveIndexBuffer();

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -6,6 +6,8 @@
 #include <limits>
 #include <algorithm>
 #include <simd/simd.h>
+#include <cmath>
+#include <fstream>
 
 namespace MetalCppPathTracer {
 
@@ -66,6 +68,36 @@ public:
 
     const std::vector<size_t>& getPrimitiveIndices() const {
         return primitiveIndices;
+    }
+
+    void restoreVisiblePrimitives(const simd::float3& camPos,
+                                  const simd::float3& camForward,
+                                  float fovDegrees) {
+        float cosFov = cosf(fovDegrees * 0.5f * (M_PI / 180.0f));
+        auto it = hiddenPrimitives.begin();
+        while (it != hiddenPrimitives.end()) {
+            if (isPrimitiveVisible(*it, camPos, camForward, cosFov)) {
+                primitives.push_back(*it);
+                it = hiddenPrimitives.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    void cullOffscreenPrimitives(const simd::float3& camPos,
+                                 const simd::float3& camForward,
+                                 float fovDegrees) {
+        float cosFov = cosf(fovDegrees * 0.5f * (M_PI / 180.0f));
+        auto it = primitives.begin();
+        while (it != primitives.end()) {
+            if (!isPrimitiveVisible(*it, camPos, camForward, cosFov)) {
+                hiddenPrimitives.push_back(*it);
+                it = primitives.erase(it);
+            } else {
+                ++it;
+            }
+        }
     }
 
     void buildBVH() {
@@ -201,6 +233,27 @@ public:
         return buffer;
     }
 
+    void dumpBVH(const char* path) const {
+        std::ofstream out(path);
+        for (size_t i = 0; i < bvhNodes.size(); ++i) {
+            const auto& n = bvhNodes[i];
+            out << i << " "
+                << n.boundsMin.x << " " << n.boundsMin.y << " " << n.boundsMin.z << " "
+                << n.boundsMax.x << " " << n.boundsMax.y << " " << n.boundsMax.z << "\n";
+        }
+    }
+
+    static void dumpTLAS(const simd::float4* data, size_t count, const char* path) {
+        std::ofstream out(path);
+        for (size_t i = 0; i < count; ++i) {
+            const simd::float4& mn = data[2 * i + 0];
+            const simd::float4& mx = data[2 * i + 1];
+            out << i << " "
+                << mn.x << " " << mn.y << " " << mn.z << " "
+                << mx.x << " " << mx.y << " " << mx.z << "\n";
+        }
+    }
+
     void createTriangleBuffers(
         std::vector<simd::float3>& outVertices,
         std::vector<simd::uint3>& outIndices)
@@ -224,8 +277,21 @@ public:
 
 private:
     std::vector<Primitive> primitives;
+    std::vector<Primitive> hiddenPrimitives;
     std::vector<size_t> primitiveIndices;
     std::vector<BVHNode> bvhNodes;
+
+    bool isPrimitiveVisible(const Primitive& p,
+                            const simd::float3& camPos,
+                            const simd::float3& camForward,
+                            float cosFov) const {
+        simd::float3 center = p.data0;
+        if (p.type == PrimitiveType::Triangle) {
+            center = (p.data0 + p.data1 + p.data2) / 3.0f;
+        }
+        simd::float3 dir = simd::normalize(center - camPos);
+        return simd::dot(dir, camForward) > cosFov;
+    }
 
     int buildBVHRecursive(size_t start, size_t end) {
         BVHNode node;


### PR DESCRIPTION
## Summary
- Cull primitives that fall outside the camera frustum to offload their BLAS data
- Rebuild TLAS/BLAS only for visible primitives and log node counts
- Dump BVH and TLAS bounds to text files for simple visualization

## Testing
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6895d72c2c08832dad451655f5fa8dc2