### PR TITLE
Fix culling for large primitives and rebuild buffers on camera update

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -297,9 +297,11 @@ bool Renderer::updateCamera() {
 }
 
 void Renderer::updateUniforms() {
+  bool cameraChanged = updateCamera();
+
   UniformsData &u = *((UniformsData *)_pUniformsBuffer->contents());
 
-  if (updateCamera()) {
+  if (cameraChanged) {
     u.frameCount = 0;
     u.randomSeed = {randomFloat(), randomFloat(), randomFloat()};
   } else {
@@ -418,4 +420,7 @@ void Renderer::rebuildAccelerationStructures() {
   _pPrimitiveIndexBuffer->didModifyRange(
       NS::Range::Make(0, sizeof(int) * _pScene->getPrimitiveCount()));
   delete[] rawIndices;
+
+  // Rebuild primitive buffers so restored primitives become visible
+  buildBuffers();
 }


### PR DESCRIPTION
## Summary
- Improve primitive visibility test to consider bounding radius so large objects aren't culled
- Rebuild primitive buffers when acceleration structures are updated
- Update uniform handling to account for buffer rebuilds

## Testing
- `g++ -std=c++17 -I'./MetalCpp Path Tracer' 'MetalCpp Path Tracer/main.cpp' -c` *(fails: Metal/Metal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895d9274a04832dbc82c0779316a8bf