### PR TITLE
Allow configuring screen size and ray depth via scene XML

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -25,6 +25,8 @@ struct UniformsData {
   uint64_t frameCount = 0;
   uint64_t totalPrimitiveCount;
   uint64_t tlasNodeCount;
+  uint32_t maxRayDepth;
+  uint32_t _pad;
 };
 
 inline uint32_t bitm_random() {
@@ -43,7 +45,6 @@ Renderer::Renderer(MTL::Device *pDevice)
   _pCommandQueue = _pDevice->newCommandQueue();
 
   Camera::reset();
-  Camera::screenSize = {1280, 720};
 
   updateVisibleScene();
   buildShaders();
@@ -126,6 +127,8 @@ void Renderer::updateVisibleScene() {
       "MetalPathtracing-05e922c76da6c603e7840e71f7b563ad9b7eb4ea/MetalCpp Path "
       "Tracer/scene.xml",
       _pScene);
+
+  Camera::screenSize = _pScene->screenSize;
 
   printf("Scene loaded: %zu total primitives (%zu spheres, %zu triangles)\n",
          _pScene->getPrimitiveCount(),
@@ -303,6 +306,7 @@ void Renderer::updateUniforms() {
   u.primitiveCount = _pScene->getPrimitiveCount();
   u.triangleCount = _pScene->getTriangleCount();
   u.tlasNodeCount = _tlasNodeCount;
+  u.maxRayDepth = _pScene->maxRayDepth;
 
   _pUniformsBuffer->didModifyRange(NS::Range::Make(0, sizeof(UniformsData)));
 }

--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -57,7 +57,8 @@ float4 fragment fragmentMain(
         materials,
         u.primitiveCount,
         primitiveIndices,
-        seed
+        seed,
+        u.maxRayDepth
     );
 
 

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -214,14 +214,13 @@ inline float4 rayColor(
     device const float4* materials,
     uint primitiveCount,
     device const int* primitiveIndices,
-    thread uint32_t& seed)
+    thread uint32_t& seed,
+    uint maxRayDepth)
 {
-    constexpr size_t maxRayDepth = 32;
-
     float4 absorption = float4(1.0);
     float4 light = float4(0.0);
 
-    for (size_t depth = 0; depth < maxRayDepth; ++depth)
+    for (uint depth = 0; depth < maxRayDepth; ++depth)
     {
         intersection bestHit;
         bestHit.t = INFINITY;

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -37,8 +37,8 @@ struct UniformsData
     uint64_t frameCount = 0;
     uint64_t totalPrimitiveCount;
     uint64_t tlasNodeCount;
-
-
+    uint maxRayDepth;
+    uint _pad;
 };
 
 

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -6,6 +6,7 @@
 #include <limits>
 #include <algorithm>
 #include <simd/simd.h>
+#include <cstdint>
 
 namespace MetalCppPathTracer {
 
@@ -31,12 +32,16 @@ struct BVHNode {
 
 class Scene {
 public:
-    Scene() = default;
+    Scene() {
+        clear();
+    }
 
     void clear() {
         primitives.clear();
         bvhNodes.clear();
         primitiveIndices.clear();
+        screenSize = {1280.f, 720.f};
+        maxRayDepth = 32;
     }
 
     size_t addPrimitive(const Primitive& p) {
@@ -67,6 +72,9 @@ public:
     const std::vector<size_t>& getPrimitiveIndices() const {
         return primitiveIndices;
     }
+
+    simd::float2 screenSize;
+    uint32_t maxRayDepth;
 
     void buildBVH() {
         std::stable_sort(primitives.begin(), primitives.end(),

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -87,6 +87,10 @@ void SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         return;
     }
 
+    scene->screenSize.x = root->FloatAttribute("width", scene->screenSize.x);
+    scene->screenSize.y = root->FloatAttribute("height", scene->screenSize.y);
+    scene->maxRayDepth = root->UnsignedAttribute("maxRayDepth", scene->maxRayDepth);
+
     for (auto* e = root->FirstChildElement(); e; e = e->NextSiblingElement()) {
         std::string tag = e->Name();
         if (tag == "Sphere") {

--- a/MetalCpp Path Tracer/Window/ApplicationDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ApplicationDelegate.cpp
@@ -1,4 +1,5 @@
 #include "ApplicationDelegate.h"
+#include "SceneLoader.h"
 
 using namespace MetalCppPathTracer;
 
@@ -25,7 +26,15 @@ void ApplicationDelegate::applicationDidFinishLaunching(
   if (_initialized)
     return;
   _initialized = true;
-  CGRect frame = {{100.0, 100.0}, {1280.0, 720.0}};
+
+  Scene tmpScene;
+  SceneLoader::LoadSceneFromXML(
+      "/Users/apollo/Downloads/"
+      "MetalPathtracing-05e922c76da6c603e7840e71f7b563ad9b7eb4ea/MetalCpp Path "
+      "Tracer/scene.xml",
+      &tmpScene);
+
+  CGRect frame = {{100.0, 100.0}, {tmpScene.screenSize.x, tmpScene.screenSize.y}};
 
   _pWindow = NS::Window::alloc()->init(frame,
                                        NS::WindowStyleMaskClosable |

--- a/MetalCpp Path Tracer/scene.xml
+++ b/MetalCpp Path Tracer/scene.xml
@@ -1,4 +1,4 @@
-<Scene>
+<Scene width="1280" height="720" maxRayDepth="32">
     <!-- Ground -->
     <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
 


### PR DESCRIPTION
## Summary
- Load screen resolution and max ray depth values from scene.xml and expose them in Scene
- Pass max ray depth through uniforms to the shader and use it during ray traversal
- Size the application window and camera to the scene's requested resolution

## Testing
- `g++ -std=c++17 -fsyntax-only 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` *(fails: Metal/Metal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895eb6f576c832d860e567e07356fe8