### PR TITLE
Add Russian roulette termination to path tracer

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -268,6 +268,17 @@ inline float4 rayColor(
         r.origin = bestHit.point + 0.0001 * bestHit.normal;
         r.direction = normalize(target);
         absorption *= float4(albedo, 1.0);
+
+        // Russian roulette termination to avoid tracing very long ray paths
+        if (depth >= 5)
+        {
+            float p = max(absorption.x, max(absorption.y, absorption.z));
+            float randVal = randomFloat(seed);
+            seed = random(seed);
+            if (randVal >= p)
+                break;
+            absorption /= p;
+        }
     }
 
     return clamp(light, 0.0, 1.0);


### PR DESCRIPTION
## Summary
- add Russian roulette ray termination in `rayColor` to probabilistically stop long paths and scale throughput

## Testing
- `clang++ 'MetalCpp Path Tracer/main.cpp' -o app` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895edcb3928832da91c0945d12736ec