### PR TITLE
Add dielectric material and update bunny scene with mirror

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -264,9 +264,10 @@ inline float4 rayColor(
             light += absorption * float4(emissionColor, 1.0) * emissionPower;
         }
 
-        float3 target = bestHit.normal + randomUnitVector(seed);
-        r.origin = bestHit.point + 0.0001 * bestHit.normal;
-        r.direction = normalize(target);
+        float3 offsetNormal = bestHit.frontFace ? bestHit.normal : -bestHit.normal;
+        r.origin = bestHit.point + 0.0001 * offsetNormal;
+        scatter(r, bestHit, materialType, seed);
+        seed = random(seed);
         absorption *= float4(albedo, 1.0);
 
         // Russian roulette termination to avoid tracing very long ray paths

--- a/MetalCpp Path Tracer/scene.xml
+++ b/MetalCpp Path Tracer/scene.xml
@@ -7,11 +7,14 @@
 
     <!-- Small sphere that emits light -->
     <Sphere position="0,20,-100" radius="10" albedo="0.0,0.0,0.0" emission="1.0,0.9,0.7" materialType="0" emissionPower="5" />
+    
+    <!-- Mirror beside the bunny -->
+    <Sphere position="25,10,-100" radius="10" albedo="1.0,1.0,1.0" emission="0,0,0" materialType="-1" emissionPower="0" />
 
-    <!-- Bunny Mesh beside the light sphere -->
+    <!-- Bunny Mesh beside the mirror -->
     <Mesh
-        file="/Users/apollo/Downloads/MetalPathtracing-05e922c76da6c603e7840e71f7b563ad9b7eb4ea/MetalCpp Path Tracer/assets/bunny.obj"
-        position="-25,0,-100"
+        file="assets/bunny.obj"
+        position="15,0,-100"
         scale="10.0"
         albedo="0.9,0.5,0.3"
         emission="0,0,0"


### PR DESCRIPTION
## Summary
- Integrate scatter-based material handling to support dielectric refraction and reflection
- Add reflective mirror sphere and position bunny beside it with relative mesh path

## Testing
- `g++ -std=c++17 'MetalCpp Path Tracer/main.cpp' -o /tmp/testbuild 2>&1` *(fails: Metal/Metal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895ef11fea0832dafcd84f36ee70fbe