### PR TITLE
Add rectangle primitive and fix bunny loading

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -122,18 +122,15 @@ void Renderer::buildShaders() {
 }
 
 void Renderer::updateVisibleScene() {
-  SceneLoader::LoadSceneFromXML(
-      "/Users/apollo/Downloads/"
-      "MetalPathtracing-05e922c76da6c603e7840e71f7b563ad9b7eb4ea/MetalCpp Path "
-      "Tracer/scene.xml",
-      _pScene);
+  SceneLoader::LoadSceneFromXML("scene.xml", _pScene);
 
   Camera::screenSize = _pScene->screenSize;
 
-  printf("Scene loaded: %zu total primitives (%zu spheres, %zu triangles)\n",
+  printf("Scene loaded: %zu total primitives (%zu spheres, %zu triangles, %zu rectangles)\n",
          _pScene->getPrimitiveCount(),
-         _pScene->getPrimitiveCount() - _pScene->getTriangleCount(),
-         _pScene->getTriangleCount());
+         _pScene->getSphereCount(),
+         _pScene->getTriangleCount(),
+         _pScene->getRectangleCount());
 
   _pScene->buildBVH();
 

--- a/MetalCpp Path Tracer/Renderer/Shaders/Intersect.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Intersect.h
@@ -82,6 +82,35 @@ inline bool triangleIntersection(
     return true;
 }
 
+// Rectangle intersection
+inline bool rectangleIntersection(
+    thread const ray &ray,
+    float3 center,
+    float3 e1,
+    float3 e2,
+    thread float &tHit,
+    thread float3 &normal)
+{
+    normal = normalize(cross(e1, e2));
+    float denom = dot(normal, ray.direction);
+    if (fabs(denom) < 1e-6)
+        return false;
+
+    float t = dot(center - ray.origin, normal) / denom;
+    if (t < ray.min_distance || t > ray.max_distance)
+        return false;
+
+    float3 pHit = ray.origin + t * ray.direction;
+    float3 rel = pHit - center;
+    float u = dot(rel, e1) / dot(e1, e1);
+    float v = dot(rel, e2) / dot(e2, e2);
+    if (fabs(u) > 1.0 || fabs(v) > 1.0)
+        return false;
+
+    tHit = t;
+    return true;
+}
+
 #endif
 
 

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -175,6 +175,32 @@ inline intersection firstHitBVH(
                         }
                     }
                 }
+                else if (primitiveType == 2)
+                {
+                    float3 center = p0.xyz;
+                    float3 e1 = p1.xyz;
+                    float3 e2 = p2.xyz;
+                    float3 normal = normalize(cross(e1, e2));
+                    float denom = dot(normal, r.direction);
+                    if (fabs(denom) > 1e-5)
+                    {
+                        float tt = dot(center - r.origin, normal) / denom;
+                        if (tt > 0.0001 && tt < in.t)
+                        {
+                            float3 hitPoint = r.origin + tt * r.direction;
+                            float3 rel = hitPoint - center;
+                            float u = dot(rel, e1) / dot(e1, e1);
+                            float v = dot(rel, e2) / dot(e2, e2);
+                            if (fabs(u) <= 1.0 && fabs(v) <= 1.0)
+                            {
+                                tHit = tt;
+                                hit = hitPoint;
+                                n = normal;
+                                hitThis = true;
+                            }
+                        }
+                    }
+                }
                 
                 if (hitThis && tHit < in.t)
                 {

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -108,6 +108,20 @@ void SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
 
             scene->addPrimitive(p);
         }
+        else if (tag == "Rectangle") {
+            Primitive p;
+            p.type = PrimitiveType::Rectangle;
+            p.data0 = parseVec3(e->Attribute("position"));
+            p.data1 = parseVec3(e->Attribute("u"));
+            p.data2 = parseVec3(e->Attribute("v"));
+
+            p.material.albedo = parseVec3(e->Attribute("albedo"));
+            p.material.emissionColor = parseVec3(e->Attribute("emission"));
+            p.material.materialType = e->FloatAttribute("materialType", 0);
+            p.material.emissionPower = e->FloatAttribute("emissionPower", 0);
+
+            scene->addPrimitive(p);
+        }
         else if (tag == "Mesh") {
             std::vector<simd::float3> verts;
             std::vector<simd::uint3> tris;

--- a/MetalCpp Path Tracer/scene.xml
+++ b/MetalCpp Path Tracer/scene.xml
@@ -9,7 +9,7 @@
     <Sphere position="0,20,-100" radius="10" albedo="0.0,0.0,0.0" emission="1.0,0.9,0.7" materialType="0" emissionPower="5" />
     
     <!-- Mirror beside the bunny -->
-    <Sphere position="25,10,-100" radius="10" albedo="1.0,1.0,1.0" emission="0,0,0" materialType="-1" emissionPower="0" />
+    <Rectangle position="25,10,-100" u="0,10,0" v="0,0,10" albedo="1.0,1.0,1.0" emission="0,0,0" materialType="-1" emissionPower="0" />
 
     <!-- Bunny Mesh beside the mirror -->
     <Mesh


### PR DESCRIPTION
## Summary
- support rectangle primitives and compute their bounds for BVH
- load rectangle objects from scene XML and use one for mirror
- fix scene loading path so bunny mesh renders correctly

## Testing
- `g++ -std=c++17 -fsyntax-only 'MetalCpp Path Tracer/main.cpp' -I'MetalCpp Path Tracer'` *(fails: Metal/Metal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895f0abcbc4832d9748a1f29a25c884