### PR TITLE
Add fallback loading for scene XML

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -6,6 +6,7 @@
 #include "SceneLoader.h"
 #include <cstdio>
 #include <simd/simd.h>
+#include <filesystem>
 
 using namespace MetalCppPathTracer;
 
@@ -122,7 +123,13 @@ void Renderer::buildShaders() {
 }
 
 void Renderer::updateVisibleScene() {
-  SceneLoader::LoadSceneFromXML("scene.xml", _pScene);
+  // Attempt to load scene from working directory. If it fails, try a path
+  // relative to the source file location.
+  if (!SceneLoader::LoadSceneFromXML("scene.xml", _pScene)) {
+    std::filesystem::path alt =
+        std::filesystem::path(__FILE__).parent_path() / "../scene.xml";
+    SceneLoader::LoadSceneFromXML(alt.string(), _pScene);
+  }
 
   Camera::screenSize = _pScene->screenSize;
 

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -72,11 +72,11 @@ static void LoadOBJ(const std::string& path, std::vector<simd::float3>& verts, s
     printf("Loaded OBJ: %zu vertices, %zu triangles\n", verts.size(), tris.size());
 }
 
-void SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
+bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
     XMLDocument doc;
     if (doc.LoadFile(path.c_str()) != XML_SUCCESS) {
         printf("Failed to load scene XML: %s\n", path.c_str());
-        return;
+        return false;
     }
 
     scene->clear();
@@ -84,7 +84,7 @@ void SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
     auto* root = doc.FirstChildElement("Scene");
     if (!root) {
         printf("No <Scene> root.\n");
-        return;
+        return false;
     }
 
     scene->screenSize.x = root->FloatAttribute("width", scene->screenSize.x);
@@ -148,6 +148,8 @@ void SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             }
         }
     }
+
+    return true;
 }
 
 }

--- a/MetalCpp Path Tracer/Scene/SceneLoader.h
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.h
@@ -8,7 +8,8 @@ namespace MetalCppPathTracer {
 
 class SceneLoader {
 public:
-    static void LoadSceneFromXML(const std::string& path, Scene* scene);
+    // Returns true on success, false if the XML could not be loaded or parsed
+    static bool LoadSceneFromXML(const std::string& path, Scene* scene);
 };
 
 }

--- a/MetalCpp Path Tracer/Window/ApplicationDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ApplicationDelegate.cpp
@@ -28,11 +28,14 @@ void ApplicationDelegate::applicationDidFinishLaunching(
   _initialized = true;
 
   Scene tmpScene;
-  SceneLoader::LoadSceneFromXML(
+  bool loaded = SceneLoader::LoadSceneFromXML(
       "/Users/apollo/Downloads/"
       "MetalPathtracing-05e922c76da6c603e7840e71f7b563ad9b7eb4ea/MetalCpp Path "
       "Tracer/scene.xml",
       &tmpScene);
+  if (!loaded) {
+    SceneLoader::LoadSceneFromXML("scene.xml", &tmpScene);
+  }
 
   CGRect frame = {{100.0, 100.0}, {tmpScene.screenSize.x, tmpScene.screenSize.y}};
 


### PR DESCRIPTION
## Summary
- enhance SceneLoader to return success status
- try alternate scene.xml locations when initial load fails

## Testing
- `clang++ -std=c++17 -I. -c Scene/SceneLoader.cpp` (fails: command not found)
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` (fails: repository not signed)


------
https://chatgpt.com/codex/tasks/task_e_6895f2bd22c8832d82c91a1f57e896bc