### PR TITLE
Fix mesh loader path resolution for scene assets

### DIFF
--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include <fstream>
 #include <sstream>
+#include <filesystem>
 #include "tiny_obj_loader.h"
 
 using namespace tinyxml2;
@@ -87,6 +88,9 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         return false;
     }
 
+    // Resolve relative paths against the directory containing the scene file
+    std::filesystem::path baseDir = std::filesystem::path(path).parent_path();
+
     scene->screenSize.x = root->FloatAttribute("width", scene->screenSize.x);
     scene->screenSize.y = root->FloatAttribute("height", scene->screenSize.y);
     scene->maxRayDepth = root->UnsignedAttribute("maxRayDepth", scene->maxRayDepth);
@@ -126,7 +130,10 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             std::vector<simd::float3> verts;
             std::vector<simd::uint3> tris;
 
-            LoadOBJ(e->Attribute("file"), verts, tris);
+            // Build full path to mesh file relative to the scene's directory
+            const char* fileAttr = e->Attribute("file");
+            std::filesystem::path meshPath = baseDir / (fileAttr ? fileAttr : "");
+            LoadOBJ(meshPath.string(), verts, tris);
 
             simd::float3 pos = parseVec3(e->Attribute("position"));
             float scale = e->FloatAttribute("scale", 1.0f);


### PR DESCRIPTION
## Summary
- resolve mesh file paths relative to the scene XML
- include `<filesystem>` to support path manipulation

## Testing
- `g++ -std=c++17 -c 'MetalCpp Path Tracer/Scene/SceneLoader.cpp'` *(fails: simd/simd.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895f460f878832da6708f41c5358ef8