### PR TITLE
Add acceleration structure debug visualization and reposition mirror

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -26,8 +26,9 @@ struct UniformsData {
   uint64_t frameCount = 0;
   uint64_t totalPrimitiveCount;
   uint64_t tlasNodeCount;
+  uint64_t blasNodeCount;
   uint32_t maxRayDepth;
-  uint32_t _pad;
+  uint32_t debugAS;
 };
 
 inline uint32_t bitm_random() {
@@ -310,7 +311,9 @@ void Renderer::updateUniforms() {
   u.primitiveCount = _pScene->getPrimitiveCount();
   u.triangleCount = _pScene->getTriangleCount();
   u.tlasNodeCount = _tlasNodeCount;
+  u.blasNodeCount = _blasNodeCount;
   u.maxRayDepth = _pScene->maxRayDepth;
+  u.debugAS = InputSystem::debugAS;
 
   _pUniformsBuffer->didModifyRange(NS::Range::Make(0, sizeof(UniformsData)));
 }

--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -58,7 +58,9 @@ float4 fragment fragmentMain(
         u.primitiveCount,
         primitiveIndices,
         seed,
-        u.maxRayDepth
+        u.maxRayDepth,
+        u.debugAS,
+        u.blasNodeCount
     );
 
 

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -17,6 +17,7 @@ struct intersection
     bool frontFace;
     int primitiveId = -1;
     int isTriangle = 0;
+    int nodeIndex = -1; // BLAS leaf node index
 };
 
 
@@ -37,8 +38,9 @@ struct UniformsData
     uint64_t frameCount = 0;
     uint64_t totalPrimitiveCount;
     uint64_t tlasNodeCount;
+    uint64_t blasNodeCount;
     uint maxRayDepth;
-    uint _pad;
+    uint debugAS;
 };
 
 

--- a/MetalCpp Path Tracer/Window/ControllerView.mm
+++ b/MetalCpp Path Tracer/Window/ControllerView.mm
@@ -46,14 +46,21 @@ MTK::View *MetalCppPathTracer::ControllerView::get(CGRect frame) {
 - (void)keyDown:(NSEvent *)event {
     if(event.keyCode == 2) MetalCppPathTracer::InputSystem::movementInput.x = 1; // right - d
     else if(event.keyCode == 0) MetalCppPathTracer::InputSystem::movementInput.x = -1; // left - a
-    
+
     if(event.keyCode == 49) MetalCppPathTracer::InputSystem::movementInput.y = 1; // up - space
     else if(event.keyCode == 8) MetalCppPathTracer::InputSystem::movementInput.y = -1; // down - c
-    
+
     if(event.keyCode == 13) MetalCppPathTracer::InputSystem::movementInput.z = 1; // forward - w
     else if(event.keyCode == 1) MetalCppPathTracer::InputSystem::movementInput.z = -1; // backward - s
-    
+
     if(event.keyCode == 15) MetalCppPathTracer::InputSystem::resetInput = 1;
+
+    if(event.keyCode == 17) { // t - toggle TLAS debug
+        MetalCppPathTracer::InputSystem::debugAS = (MetalCppPathTracer::InputSystem::debugAS == 1) ? 0 : 1;
+    }
+    if(event.keyCode == 11) { // b - toggle BLAS debug
+        MetalCppPathTracer::InputSystem::debugAS = (MetalCppPathTracer::InputSystem::debugAS == 2) ? 0 : 2;
+    }
 }
 
 - (void)keyUp:(NSEvent *)event {

--- a/MetalCpp Path Tracer/Window/InputSystem.h
+++ b/MetalCpp Path Tracer/Window/InputSystem.h
@@ -12,6 +12,7 @@ inline simd::float3 movementInput {0};
 inline simd::float2 rotationInput {0};
 inline float zoomInput = 0;
 inline bool resetInput = 0;
+inline int debugAS = 0; // 0:none, 1:TLAS, 2:BLAS
 
 inline void clearInputs()
 {

--- a/MetalCpp Path Tracer/scene.xml
+++ b/MetalCpp Path Tracer/scene.xml
@@ -8,8 +8,8 @@
     <!-- Small sphere that emits light -->
     <Sphere position="0,20,-100" radius="10" albedo="0.0,0.0,0.0" emission="1.0,0.9,0.7" materialType="0" emissionPower="5" />
     
-    <!-- Mirror beside the bunny -->
-    <Rectangle position="25,10,-100" u="0,10,0" v="0,0,10" albedo="1.0,1.0,1.0" emission="0,0,0" materialType="-1" emissionPower="0" />
+    <!-- Mirror behind the bunny, facing the camera -->
+    <Rectangle position="15,10,-120" u="10,0,0" v="0,10,0" albedo="1.0,1.0,1.0" emission="0,0,0" materialType="-1" emissionPower="0" />
 
     <!-- Bunny Mesh beside the mirror -->
     <Mesh


### PR DESCRIPTION
## Summary
- Reposition the rectangular mirror behind the bunny so it's visible from the camera
- Add TLAS/BLAS visualization toggled by 't' and 'b' keys
- Track BLAS leaf node indices and expose debug options through uniforms and shaders

## Testing
- `clang++ -std=c++17 main.cpp -c` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y clang` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6895f7eed6c4832da2cec5bdbe37acd7