### PR TITLE
Refactor shapes into separate files

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -186,16 +186,16 @@ void Renderer::updateVisibleScene() {
   for (size_t i = 0; i < primCount; ++i) {
     const Primitive &p = _allPrimitives[i];
     if (p.type == PrimitiveType::Sphere) {
-      _primitiveBounds[i] = {p.data0, p.data1.x};
+      _primitiveBounds[i] = {p.sphere.center, p.sphere.radius};
     } else if (p.type == PrimitiveType::Triangle) {
-      simd::float3 c = (p.data0 + p.data1 + p.data2) / 3.0f;
-      float r = simd::length(p.data0 - c);
-      r = std::max(r, (float)simd::length(p.data1 - c));
-      r = std::max(r, (float)simd::length(p.data2 - c));
+      simd::float3 c = (p.triangle.v0 + p.triangle.v1 + p.triangle.v2) / 3.0f;
+      float r = simd::length(p.triangle.v0 - c);
+      r = std::max(r, (float)simd::length(p.triangle.v1 - c));
+      r = std::max(r, (float)simd::length(p.triangle.v2 - c));
       _primitiveBounds[i] = {c, r};
     } else {
-      float r = simd::length(p.data1) + simd::length(p.data2);
-      _primitiveBounds[i] = {p.data0, r};
+      float r = simd::length(p.rectangle.u) + simd::length(p.rectangle.v);
+      _primitiveBounds[i] = {p.rectangle.center, r};
     }
   }
 

--- a/MetalCpp Path Tracer/Scene/Rectangle.h
+++ b/MetalCpp Path Tracer/Scene/Rectangle.h
@@ -1,0 +1,16 @@
+#ifndef RECTANGLE_H
+#define RECTANGLE_H
+
+#include <simd/simd.h>
+
+namespace MetalCppPathTracer {
+
+struct Rectangle {
+    simd::float3 center;
+    simd::float3 u;
+    simd::float3 v;
+};
+
+}
+
+#endif

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -98,12 +98,10 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
     for (auto* e = root->FirstChildElement(); e; e = e->NextSiblingElement()) {
         std::string tag = e->Name();
         if (tag == "Sphere") {
-            Primitive p;
+            Primitive p{};
             p.type = PrimitiveType::Sphere;
-            p.data0 = parseVec3(e->Attribute("position"));
-            float r = e->FloatAttribute("radius", 1.0f);
-            p.data1 = simd::make_float3(r,0,0);
-            p.data2 = simd::float3(0); // unused for spheres
+            p.sphere.center = parseVec3(e->Attribute("position"));
+            p.sphere.radius = e->FloatAttribute("radius", 1.0f);
 
             p.material.albedo = parseVec3(e->Attribute("albedo"));
             p.material.emissionColor = parseVec3(e->Attribute("emission"));
@@ -113,11 +111,11 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             scene->addPrimitive(p);
         }
         else if (tag == "Rectangle") {
-            Primitive p;
+            Primitive p{};
             p.type = PrimitiveType::Rectangle;
-            p.data0 = parseVec3(e->Attribute("position"));
-            p.data1 = parseVec3(e->Attribute("u"));
-            p.data2 = parseVec3(e->Attribute("v"));
+            p.rectangle.center = parseVec3(e->Attribute("position"));
+            p.rectangle.u = parseVec3(e->Attribute("u"));
+            p.rectangle.v = parseVec3(e->Attribute("v"));
 
             p.material.albedo = parseVec3(e->Attribute("albedo"));
             p.material.emissionColor = parseVec3(e->Attribute("emission"));
@@ -145,11 +143,11 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             m.emissionPower = e->FloatAttribute("emissionPower", 0);
 
             for (const auto& tri : tris) {
-                Primitive p;
+                Primitive p{};
                 p.type = PrimitiveType::Triangle;
-                p.data0 = pos + scale * verts[tri.x];
-                p.data1 = pos + scale * verts[tri.y];
-                p.data2 = pos + scale * verts[tri.z];
+                p.triangle.v0 = pos + scale * verts[tri.x];
+                p.triangle.v1 = pos + scale * verts[tri.y];
+                p.triangle.v2 = pos + scale * verts[tri.z];
                 p.material = m;
                 scene->addPrimitive(p);
             }

--- a/MetalCpp Path Tracer/Scene/Sphere.h
+++ b/MetalCpp Path Tracer/Scene/Sphere.h
@@ -1,0 +1,15 @@
+#ifndef SPHERE_H
+#define SPHERE_H
+
+#include <simd/simd.h>
+
+namespace MetalCppPathTracer {
+
+struct Sphere {
+    simd::float3 center;
+    float radius;
+};
+
+}
+
+#endif

--- a/MetalCpp Path Tracer/Scene/Triangle.h
+++ b/MetalCpp Path Tracer/Scene/Triangle.h
@@ -1,0 +1,16 @@
+#ifndef TRIANGLE_H
+#define TRIANGLE_H
+
+#include <simd/simd.h>
+
+namespace MetalCppPathTracer {
+
+struct Triangle {
+    simd::float3 v0;
+    simd::float3 v1;
+    simd::float3 v2;
+};
+
+}
+
+#endif


### PR DESCRIPTION
## Summary
- Introduce dedicated headers for Sphere, Rectangle, and Triangle shapes
- Update scene and renderer to use explicit shape structs
- Adjust scene loading and buffers for new shape definitions

## Testing
- `g++ -std=c++17 -I'MetalCpp Path Tracer' -fsyntax-only 'MetalCpp Path Tracer/Scene/SceneLoader.cpp'` *(fails: simd/simd.h: No such file or directory)*
- `g++ -std=c++17 -I'MetalCpp Path Tracer' -fsyntax-only 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` *(fails: Metal/Metal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895fe60ed48832da1a1f6311e486d17