### PR TITLE
Fix camera path frame advance

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -347,6 +347,8 @@ bool Renderer::updateCamera() {
     recalculateViewport();
     rebuildAccelerationStructures();
   }
+  // Advance animation frame after processing camera path
+  _animationFrame++;
   return changed;
 }
 
@@ -446,7 +448,6 @@ void Renderer::draw(MTK::View *pView) {
   }
 
   pPool->release();
-  _animationFrame++;
 }
 
 void Renderer::drawableSizeWillChange(MTK::View *pView, CGSize size) {


### PR DESCRIPTION
## Summary
- Advance animation frame inside camera update so dynamic camera paths progress every frame
- Remove obsolete frame increment from draw loop

## Testing
- `clang++ -fsyntax-only Renderer/Renderer.cpp` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6896093a63b4832d9d2499c2606b176b