### PR TITLE
Preserve camera path and export acceleration structures

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -61,7 +61,14 @@ bool Renderer::isInView(const BoundingSphere &b) {
 }
 
 void Renderer::syncSceneWithActivePrimitives() {
+  // Preserve camera path and settings while refreshing primitive list
+  auto cameraPath = _pScene->cameraPath;
+  auto size = _pScene->screenSize;
+  auto depth = _pScene->maxRayDepth;
   _pScene->clear();
+  _pScene->cameraPath = cameraPath;
+  _pScene->screenSize = size;
+  _pScene->maxRayDepth = depth;
   _activeToGlobalIndex.clear();
   for (size_t i = 0; i < _allPrimitives.size(); ++i) {
     if (_activePrimitive[i]) {
@@ -508,4 +515,8 @@ void Renderer::rebuildAccelerationStructures() {
   _pPrimitiveIndexBuffer->didModifyRange(
       NS::Range::Make(0, sizeof(int) * _pScene->getPrimitiveCount()));
   delete[] rawIndices;
+
+  // Export acceleration structures for visualization
+  _pScene->exportBVHAsOBJ("blas.obj");
+  _pScene->exportTLASAsOBJ("tlas.obj");
 }

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <simd/simd.h>
 #include <cstdint>
+#include <string>
 
 namespace MetalCppPathTracer {
 
@@ -45,6 +46,9 @@ public:
     int *createPrimitiveIndexBuffer();
     void createTriangleBuffers(std::vector<simd::float3> &outVertices,
                                std::vector<simd::uint3> &outIndices);
+
+    void exportBVHAsOBJ(const std::string &path);
+    void exportTLASAsOBJ(const std::string &path);
 
     std::vector<CameraKeyframe> cameraPath;
 


### PR DESCRIPTION
## Summary
- Preserve camera path, screen size, and ray depth when updating active primitives to keep camera animation working
- Export BLAS and TLAS nodes to `blas.obj` and `tlas.obj` for visualization

## Testing
- `g++ -std=c++17 -c 'MetalCpp Path Tracer/Scene/Scene.cpp' -o /tmp/scene.o` *(fails: simd/simd.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68960b7a5458832db538b485e52f3e7c