### PR TITLE
Move scene objects out of view and add runs directory

### DIFF
--- a/MetalCpp Path Tracer/runs/.gitkeep
+++ b/MetalCpp Path Tracer/runs/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder file to ensure the runs directory is tracked by Git.

--- a/MetalCpp Path Tracer/scene.xml
+++ b/MetalCpp Path Tracer/scene.xml
@@ -3,15 +3,18 @@
     <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
 
     <!-- Large floating sphere -->
-    <Sphere position="0,100,-100" radius="40" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
+    <!-- Positioned ahead of the camera initially and behind it after the camera moves forward -->
+    <Sphere position="0,100,0" radius="40" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
 
     <!-- Small sphere that emits light -->
-    <Sphere position="0,20,-100" radius="10" albedo="0.0,0.0,0.0" emission="1.0,0.9,0.7" materialType="0" emissionPower="5" />
+    <!-- Starts in view and ends up behind the camera at the end of the movement -->
+    <Sphere position="0,20,0" radius="10" albedo="0.0,0.0,0.0" emission="1.0,0.9,0.7" materialType="0" emissionPower="5" />
 
     <!-- Bunny Mesh beside the light sphere -->
+    <!-- Its position ensures it is visible only at the beginning of the camera path -->
     <Mesh
         file="/Users/apollo/Downloads/MetalPathtracing-05e922c76da6c603e7840e71f7b563ad9b7eb4ea/MetalCpp Path Tracer/assets/bunny.obj"
-        position="-25,0,-100"
+        position="-25,0,0"
         scale="10.0"
         albedo="0.9,0.5,0.3"
         emission="0,0,0"


### PR DESCRIPTION
## Summary
- reposition scene geometry so objects start in front of the camera but end up behind it after camera movement
- add `runs` directory for storing BLAS/TLAS objects

## Testing
- `g++ -fsyntax-only 'MetalCpp Path Tracer/main.cpp'` *(fails: Metal/Metal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68961aa0db68832db5b5f5e1a5672226