### PR TITLE
Expand camera path and export BLAS/TLAS OBJ files

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -123,6 +123,9 @@ void Renderer::updateVisibleScene()
     _pScene->buildBVH();
     printf("BVH node count: %zu\n", _pScene->getBVHNodeCount());
 
+    _pScene->saveTLASObj("runs/tlas.obj");
+    _pScene->saveBLASObj("runs/blas.obj");
+
     // BVH node buffer
     simd::float4* bvhData = _pScene->createBVHBuffer();
     if (_pBVHBuffer) _pBVHBuffer->release();

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -6,6 +6,8 @@
 #include <limits>
 #include <algorithm>
 #include <simd/simd.h>
+#include <fstream>
+#include <string>
 
 namespace MetalCppPathTracer {
 
@@ -184,6 +186,77 @@ public:
 
             outIndices.push_back(simd::make_uint3(baseVertex, baseVertex + 1, baseVertex + 2));
             baseVertex += 3;
+        }
+    }
+
+    void saveTLASObj(const std::string& path) const {
+        std::ofstream out(path);
+        if (!out) {
+            printf("Failed to open %s for writing\n", path.c_str());
+            return;
+        }
+        size_t baseIndex = 1;
+        for (const auto& node : bvhNodes) {
+            simd::float3 mn = node.boundsMin;
+            simd::float3 mx = node.boundsMax;
+            simd::float3 v[8] = {
+                {mn.x, mn.y, mn.z},
+                {mx.x, mn.y, mn.z},
+                {mx.x, mx.y, mn.z},
+                {mn.x, mx.y, mn.z},
+                {mn.x, mn.y, mx.z},
+                {mx.x, mn.y, mx.z},
+                {mx.x, mx.y, mx.z},
+                {mn.x, mx.y, mx.z}
+            };
+            for (int i = 0; i < 8; ++i)
+                out << "v " << v[i].x << " " << v[i].y << " " << v[i].z << "\n";
+            out << "f " << baseIndex << " " << baseIndex + 1 << " " << baseIndex + 2 << " " << baseIndex + 3 << "\n";
+            out << "f " << baseIndex + 4 << " " << baseIndex + 5 << " " << baseIndex + 6 << " " << baseIndex + 7 << "\n";
+            out << "f " << baseIndex << " " << baseIndex + 1 << " " << baseIndex + 5 << " " << baseIndex + 4 << "\n";
+            out << "f " << baseIndex + 1 << " " << baseIndex + 2 << " " << baseIndex + 6 << " " << baseIndex + 5 << "\n";
+            out << "f " << baseIndex + 2 << " " << baseIndex + 3 << " " << baseIndex + 7 << " " << baseIndex + 6 << "\n";
+            out << "f " << baseIndex + 3 << " " << baseIndex << " " << baseIndex + 4 << " " << baseIndex + 7 << "\n";
+            baseIndex += 8;
+        }
+    }
+
+    void saveBLASObj(const std::string& path) const {
+        std::ofstream out(path);
+        if (!out) {
+            printf("Failed to open %s for writing\n", path.c_str());
+            return;
+        }
+        size_t baseIndex = 1;
+        for (const auto& p : primitives) {
+            simd::float3 mn, mx;
+            if (p.type == PrimitiveType::Sphere) {
+                float r = p.data1.x;
+                mn = p.data0 - r;
+                mx = p.data0 + r;
+            } else {
+                mn = simd::min(p.data0, simd::min(p.data1, p.data2));
+                mx = simd::max(p.data0, simd::max(p.data1, p.data2));
+            }
+            simd::float3 v[8] = {
+                {mn.x, mn.y, mn.z},
+                {mx.x, mn.y, mn.z},
+                {mx.x, mx.y, mn.z},
+                {mn.x, mx.y, mn.z},
+                {mn.x, mn.y, mx.z},
+                {mx.x, mn.y, mx.z},
+                {mx.x, mx.y, mx.z},
+                {mn.x, mx.y, mx.z}
+            };
+            for (int i = 0; i < 8; ++i)
+                out << "v " << v[i].x << " " << v[i].y << " " << v[i].z << "\n";
+            out << "f " << baseIndex << " " << baseIndex + 1 << " " << baseIndex + 2 << " " << baseIndex + 3 << "\n";
+            out << "f " << baseIndex + 4 << " " << baseIndex + 5 << " " << baseIndex + 6 << " " << baseIndex + 7 << "\n";
+            out << "f " << baseIndex << " " << baseIndex + 1 << " " << baseIndex + 5 << " " << baseIndex + 4 << "\n";
+            out << "f " << baseIndex + 1 << " " << baseIndex + 2 << " " << baseIndex + 6 << " " << baseIndex + 5 << "\n";
+            out << "f " << baseIndex + 2 << " " << baseIndex + 3 << " " << baseIndex + 7 << " " << baseIndex + 6 << "\n";
+            out << "f " << baseIndex + 3 << " " << baseIndex << " " << baseIndex + 4 << " " << baseIndex + 7 << "\n";
+            baseIndex += 8;
         }
     }
 

--- a/MetalCpp Path Tracer/scene.xml
+++ b/MetalCpp Path Tracer/scene.xml
@@ -1,17 +1,21 @@
 <Scene>
+    <!-- Dramatic camera sweep across the scene -->
+    <!-- The camera starts high and to the right before travelling diagonally to the far left -->
+    <Camera start="100,50,200" end="-150,10,-300" />
+
     <!-- Ground -->
     <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
 
     <!-- Large floating sphere -->
-    <!-- Positioned ahead of the camera initially and behind it after the camera moves forward -->
+    <!-- Initially near the camera and swept behind it as the camera follows its diagonal path -->
     <Sphere position="0,100,0" radius="40" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
 
     <!-- Small sphere that emits light -->
-    <!-- Starts in view and ends up behind the camera at the end of the movement -->
+    <!-- Starts in view and ends up far behind the camera at the end of the diagonal movement -->
     <Sphere position="0,20,0" radius="10" albedo="0.0,0.0,0.0" emission="1.0,0.9,0.7" materialType="0" emissionPower="5" />
 
     <!-- Bunny Mesh beside the light sphere -->
-    <!-- Its position ensures it is visible only at the beginning of the camera path -->
+    <!-- Positioned so it is visible only near the camera's starting point -->
     <Mesh
         file="/Users/apollo/Downloads/MetalPathtracing-05e922c76da6c603e7840e71f7b563ad9b7eb4ea/MetalCpp Path Tracer/assets/bunny.obj"
         position="-25,0,0"


### PR DESCRIPTION
## Summary
- Add scene helpers to export TLAS and BLAS bounding boxes as OBJ files
- Invoke OBJ export after BVH build so runs/blas.obj and runs/tlas.obj are written

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68962d5184a0832d89fe694a4c3bc0c6