### PR TITLE
Export acceleration structures to runs folder and expand camera path

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -517,6 +517,7 @@ void Renderer::rebuildAccelerationStructures() {
   delete[] rawIndices;
 
   // Export acceleration structures for visualization
-  _pScene->exportBVHAsOBJ("blas.obj");
-  _pScene->exportTLASAsOBJ("tlas.obj");
+  std::filesystem::create_directories("runs");
+  _pScene->exportBVHAsOBJ("runs/blas.obj");
+  _pScene->exportTLASAsOBJ("runs/tlas.obj");
 }

--- a/MetalCpp Path Tracer/scene.xml
+++ b/MetalCpp Path Tracer/scene.xml
@@ -1,7 +1,13 @@
 <Scene width="1280" height="720" maxRayDepth="32">
     <CameraPath>
+        <!-- Start near the objects -->
         <Keyframe frame="0" position="0,20,50" lookAt="0,20,0" />
-        <Keyframe frame="120" position="0,20,30" lookAt="0,20,0" />
+        <!-- Hold position for a few frames -->
+        <Keyframe frame="10" position="0,20,50" lookAt="0,20,0" />
+        <!-- Quickly move behind the scene so objects leave the view -->
+        <Keyframe frame="20" position="0,20,-300" lookAt="0,20,-400" />
+        <!-- Remain far away for the rest of the animation -->
+        <Keyframe frame="120" position="0,20,-300" lookAt="0,20,-400" />
     </CameraPath>
     <!-- Ground -->
     <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />


### PR DESCRIPTION
## Summary
- add `runs` directory and export BLAS/TLAS OBJ files there
- extend camera path so objects leave view and trigger BLAS node count changes

## Testing
- `clang++ -std=c++17 -fsyntax-only "MetalCpp Path Tracer/Renderer/Renderer.cpp"` *(failed: command not found)*
- `sudo apt-get update` *(failed: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68963766100c832d871fa34876d7a167