### PR TITLE
Avoid blocking wait in renderer

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -75,6 +75,7 @@ private:
   void syncSceneWithActivePrimitives();
   void rebuildAccelerationStructures();
   void dumpAccelerationStructure(const std::string &path);
+  void processIntersectionCounts();
 
   size_t _animationFrame = 0;
 };


### PR DESCRIPTION
## Summary
- process intersection counts after the command buffer completes
- remove CPU-side wait for GPU and rebuild buffers asynchronously

## Testing
- `clang++ -std=c++17 -I'MetalCpp Path Tracer' -I'MetalCpp Path Tracer/MetalCpp/metal-cpp' -I'MetalCpp Path Tracer/MetalCpp/metal-cpp-extensions' -c 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899b5f2d3d0832d95124fd0a3da00e2