### PR TITLE
Guard against vector size mismatch when dumping primitives

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -581,12 +581,15 @@ void Renderer::dumpAccelerationStructure(const std::string &path) {
   out << "  ],\n";
 
   out << "  \"primitives\": [\n";
-  for (size_t i = 0; i < _allPrimitives.size(); ++i) {
+  size_t primCount = std::min(
+      { _allPrimitives.size(), _activePrimitive.size(), _inactiveFrames.size(),
+        _lastIntersectionCount.size() });
+  for (size_t i = 0; i < primCount; ++i) {
     out << "    {\"index\":" << i
         << ",\"active\":" << (_activePrimitive[i] ? "true" : "false")
         << ",\"inactiveFrames\":" << _inactiveFrames[i]
         << ",\"lastIntersection\":" << _lastIntersectionCount[i] << "}";
-    if (i + 1 < _allPrimitives.size())
+    if (i + 1 < primCount)
       out << ",\n";
     else
       out << "\n";


### PR DESCRIPTION
## Summary
- Prevent out-of-bounds access when exporting primitive info by clamping loop count to available tracking data

## Testing
- `g++ -std=c++17 -c 'MetalCpp Path Tracer/Renderer/Renderer.cpp' -o /tmp/Renderer.o` *(fails: Metal/Metal.hpp: No such file or directory)*
- `sudo apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6899b70b48e8832dacc8b1bb600f9f93