### PR TITLE
Allow custom output directory for acceleration structure dumps

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -464,10 +465,14 @@ void Renderer::draw(MTK::View *pView) {
     buildBuffers();
     recalculateViewport();
   }
-  std::string dumpPath =
-      "runs/as_frame_" +
-      std::to_string(_animationFrame > 0 ? _animationFrame - 1 : 0) + ".json";
-  dumpAccelerationStructure(dumpPath);
+  const char *dirEnv = std::getenv("MPT_RUNS_PATH");
+  std::filesystem::path dumpDir =
+      dirEnv ? dirEnv : std::filesystem::path("runs");
+  std::filesystem::path dumpPath =
+      dumpDir /
+      ("as_frame_" +
+       std::to_string(_animationFrame > 0 ? _animationFrame - 1 : 0) + ".json");
+  dumpAccelerationStructure(dumpPath.string());
 
   pPool->release();
 }
@@ -576,9 +581,9 @@ void Renderer::dumpAccelerationStructure(const std::string &path) {
   out << "  ],\n";
 
   out << "  \"primitives\": [\n";
-  size_t primCount = std::min(
-      { _allPrimitives.size(), _activePrimitive.size(), _inactiveFrames.size(),
-        _lastIntersectionCount.size() });
+  size_t primCount =
+      std::min({_allPrimitives.size(), _activePrimitive.size(),
+                _inactiveFrames.size(), _lastIntersectionCount.size()});
   for (size_t i = 0; i < primCount; ++i) {
     out << "    {\"index\":" << i
         << ",\"active\":" << (_activePrimitive[i] ? "true" : "false")


### PR DESCRIPTION
## Summary
- let acceleration-structure JSON dumps be written to a directory specified by the `MPT_RUNS_PATH` environment variable
- fall back to the original `runs` folder when the variable is unset
- include `<cstdlib>` for `std::getenv`

## Testing
- `g++ -std=c++17 -c 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` *(fails: Metal/Metal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899b95a6a48832db6234bdf78e0e80d