### PR TITLE
Avoid blocking on command buffer

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -75,6 +75,7 @@ private:
   void syncSceneWithActivePrimitives();
   void rebuildAccelerationStructures();
   void dumpAccelerationStructure(const std::string &path);
+  void processIntersectionCounts();
 
   size_t _animationFrame = 0;
 };


### PR DESCRIPTION
## Summary
- stop waiting on the command buffer in draw and use a completion handler instead
- handle intersection counts asynchronously after GPU work completes

## Testing
- `clang++ -std=c++20 -I 'MetalCpp Path Tracer' -I 'MetalCpp Path Tracer/MetalCpp' -fsyntax-only 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` *(failed: command not found)*
- `apt-get update` *(failed: repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6899ddd047e0832db630c1fc7598b328