### PR TITLE
Fix keyframe autoplay and add scene without keyframes

### DIFF
--- a/MetalCpp Path Tracer/Window/ApplicationDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ApplicationDelegate.cpp
@@ -52,10 +52,9 @@ void ApplicationDelegate::applicationDidFinishLaunching(
   _pMtkView->setClearColor(MTL::ClearColor::Make(0.0, 0.0, 0.0, 1.0));
   _pMtkView->setPreferredFramesPerSecond(60);
   _pMtkView->setEnableSetNeedsDisplay(false);
-  _pMtkView->setPaused(false);
-
   _pViewDelegate = new ViewDelegate(_pDevice);
   _pMtkView->setDelegate(_pViewDelegate);
+  _pMtkView->setPaused(false);
 
   _pWindow->setContentView(_pMtkView);
   _pWindow->setTitle(NS::String::string(

--- a/MetalCpp Path Tracer/scene_no_keyframes.xml
+++ b/MetalCpp Path Tracer/scene_no_keyframes.xml
@@ -1,0 +1,24 @@
+<Scene width="1280" height="720" maxRayDepth="32">
+    <!-- Ground -->
+    <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Large floating sphere -->
+    <Sphere position="0,100,-100" radius="40" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Small sphere that emits light -->
+    <Sphere position="0,20,-100" radius="10" albedo="0.0,0.0,0.0" emission="1.0,0.9,0.7" materialType="0" emissionPower="5" />
+
+    <!-- Mirror behind the bunny, facing the camera -->
+    <Rectangle position="15,10,-120" u="10,0,0" v="0,10,0" albedo="1.0,1.0,1.0" emission="0,0,0" materialType="-1" emissionPower="0" />
+
+    <!-- Bunny Mesh beside the mirror -->
+    <Mesh
+        file="assets/bunny.obj"
+        position="15,0,-100"
+        scale="10.0"
+        albedo="0.9,0.5,0.3"
+        emission="0,0,0"
+        materialType="0"
+        emissionPower="0" />
+</Scene>
+


### PR DESCRIPTION
## Summary
- ensure MTK view unpauses only after delegate is set so camera keyframes play automatically
- add a scene file identical to the original but without camera keyframes

## Testing
- `python -m py_compile visualize_bvh.py visualize_intersections_html.py visualize_intersections_plot.py visualize_residency_html.py`


------
https://chatgpt.com/codex/tasks/task_e_689b23fb5b9c832d93b5e47b93a85a0b