### PR TITLE
Limit frame cap to keyframed scenes

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -9,9 +9,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <dispatch/dispatch.h>
 #include <filesystem>
 #include <fstream>
-#include <dispatch/dispatch.h>
 #include <simd/simd.h>
 #include <string>
 
@@ -288,7 +288,8 @@ void Renderer::buildBuffers() {
   const size_t primitiveSize = primitiveCount * 3 * sizeof(simd::float4);
   const size_t materialSize = primitiveCount * 2 * sizeof(simd::float4);
 
-  size_t primitiveAlloc = primitiveSize > 0 ? primitiveSize : sizeof(simd::float4);
+  size_t primitiveAlloc =
+      primitiveSize > 0 ? primitiveSize : sizeof(simd::float4);
   size_t materialAlloc = materialSize > 0 ? materialSize : sizeof(simd::float4);
 
   _pSphereBuffer =
@@ -450,15 +451,15 @@ void Renderer::draw(MTK::View *pView) {
 
 void Renderer::processIntersectionCounts() {
   size_t activeCount = _activeToGlobalIndex.size();
-  uint32_t *counts = _pIntersectionCountBuffer
-                          ? reinterpret_cast<uint32_t *>(
-                                _pIntersectionCountBuffer->contents())
-                          : nullptr;
+  uint32_t *counts =
+      _pIntersectionCountBuffer
+          ? reinterpret_cast<uint32_t *>(_pIntersectionCountBuffer->contents())
+          : nullptr;
   bool changed = false;
   // Thrashing control constants
-  const int OFFLOAD_THRESHOLD = 5;       // frames without hits before offload
-  const int REACTIVATE_DELAY = 30;       // cooldown frames before reload
-  const int RELOAD_BUDGET = 8;           // max primitives to reload per frame
+  const int OFFLOAD_THRESHOLD = 5; // frames without hits before offload
+  const int REACTIVATE_DELAY = 30; // cooldown frames before reload
+  const int RELOAD_BUDGET = 8;     // max primitives to reload per frame
   int reloadBudget = RELOAD_BUDGET;
 
   if (counts) {
@@ -527,6 +528,8 @@ void Renderer::drawableSizeWillChange(MTK::View *pView, CGSize size) {
   buildTextures();
   recalculateViewport();
 }
+
+bool Renderer::hasKeyframes() const { return !_pScene->cameraPath.empty(); }
 
 void Renderer::rebuildAccelerationStructures() {
   _pScene->buildBVH();

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -28,6 +28,8 @@ public:
   void draw(MTK::View *pView);
   void drawableSizeWillChange(MTK::View *pView, CGSize size);
 
+  bool hasKeyframes() const;
+
   std::vector<std::pair<simd::float3, float>> _allSpheres;
 
   struct Chunk {

--- a/MetalCpp Path Tracer/Window/ViewDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.cpp
@@ -4,27 +4,21 @@
 
 using namespace MetalCppPathTracer;
 
-ViewDelegate::ViewDelegate( MTL::Device* pDevice )
-: MTK::ViewDelegate()
-, _pRenderer(new Renderer(pDevice))
-{
-    if(const char* env = std::getenv("MPT_MAX_FRAMES"))
-        _maxFrames = std::strtoul(env, nullptr, 10);
+ViewDelegate::ViewDelegate(MTL::Device *pDevice)
+    : MTK::ViewDelegate(), _pRenderer(new Renderer(pDevice)) {
+  if (const char *env = std::getenv("MPT_MAX_FRAMES"))
+    _maxFrames = std::strtoul(env, nullptr, 10);
 }
 
-ViewDelegate::~ViewDelegate()
-{
-    delete _pRenderer;
+ViewDelegate::~ViewDelegate() { delete _pRenderer; }
+
+void ViewDelegate::drawInMTKView(MTK::View *pView) {
+  _pRenderer->draw(pView);
+  if (_maxFrames > 0 && _pRenderer->hasKeyframes() &&
+      ++_frameCount >= _maxFrames)
+    NS::Application::sharedApplication()->terminate(nullptr);
 }
 
-void ViewDelegate::drawInMTKView( MTK::View* pView )
-{
-    _pRenderer->draw(pView);
-    if(_maxFrames > 0 && ++_frameCount >= _maxFrames)
-        NS::Application::sharedApplication()->terminate(nullptr);
-}
-
-void ViewDelegate::drawableSizeWillChange(MTK::View *pView, CGSize size)
-{
-    _pRenderer->drawableSizeWillChange(pView, size);
+void ViewDelegate::drawableSizeWillChange(MTK::View *pView, CGSize size) {
+  _pRenderer->drawableSizeWillChange(pView, size);
 }


### PR DESCRIPTION
## Summary
- Add Renderer::hasKeyframes to detect animated camera paths
- Apply MPT_MAX_FRAMES only when the scene contains keyframes

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b2705b6f8832d9618734f48cb98fe