### PR TITLE
Avoid BVH rebuild on camera movement

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -364,9 +364,8 @@ bool Renderer::updateCamera() {
     Camera::up = {0, 1, 0};
     InputSystem::clearInputs();
 
-    // Rebuild view dependant data for the new camera transform
+    // Update view dependent data for the new camera transform
     recalculateViewport();
-    rebuildAccelerationStructures();
 
     // Move to the next keyframe for the following frame
     _animationFrame++;
@@ -377,7 +376,6 @@ bool Renderer::updateCamera() {
   bool changed = Camera::transformWithInputs();
   if (changed) {
     recalculateViewport();
-    rebuildAccelerationStructures();
   }
   return changed;
 }


### PR DESCRIPTION
## Summary
- Recalculate viewport without rebuilding acceleration structures during camera updates

## Testing
- `g++ 'MetalCpp Path Tracer/main.cpp' -c` *(fails: fatal error: Metal/Metal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b2e850f68832dbc6db170d00059fd