### PR TITLE
Refine camera path for gradual object exit

### DIFF
--- a/MetalCpp Path Tracer/scene.xml
+++ b/MetalCpp Path Tracer/scene.xml
@@ -4,10 +4,10 @@
         <Keyframe frame="0" position="0,20,50" lookAt="0,20,0" />
         <!-- Hold position for a few frames -->
         <Keyframe frame="10" position="0,20,50" lookAt="0,20,0" />
-        <!-- Quickly move behind the scene so objects leave the view -->
-        <Keyframe frame="20" position="0,20,-300" lookAt="0,20,-400" />
-        <!-- Remain far away for the rest of the animation -->
-        <Keyframe frame="120" position="0,20,-300" lookAt="0,20,-400" />
+        <!-- Nudge to the side so primitives start leaving the frame -->
+        <Keyframe frame="20" position="20,20,50" lookAt="0,20,0" />
+        <!-- Drift further to the right and look away so objects exit the view -->
+        <Keyframe frame="120" position="100,20,50" lookAt="200,20,0" />
     </CameraPath>
     <!-- Ground -->
     <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />


### PR DESCRIPTION
## Summary
- Nudge third keyframe to the side so primitives begin leaving the frame instead of vanishing
- Drift the camera further right and look away to let objects fully exit the view

## Testing
- `python3 - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('MetalCpp Path Tracer/scene.xml')
print('XML parsed')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689b30d434bc832d8c5b219fe96b0aad