### PR TITLE
Switch to distance-based LOD for BVH nodes

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -55,7 +55,6 @@ private:
   MTL::Buffer *_pBVHBuffer = nullptr;
   MTL::Buffer *_pPrimitiveIndexBuffer = nullptr;
   MTL::Buffer *_pTLASBuffer = nullptr;
-  MTL::Buffer *_pIntersectionCountBuffer = nullptr;
   size_t _blasNodeCount = 0;
   size_t _tlasNodeCount = 0;
   // Accumulation framebuffers
@@ -68,16 +67,13 @@ private:
 
   std::vector<Primitive> _allPrimitives;
   std::vector<bool> _activePrimitive;
-  std::vector<int> _inactiveFrames;
-  std::vector<uint32_t> _lastIntersectionCount;
-  std::vector<size_t> _activeToGlobalIndex;
   std::vector<BoundingSphere> _primitiveBounds;
 
   bool isInView(const BoundingSphere &b);
   void syncSceneWithActivePrimitives();
   void rebuildAccelerationStructures();
   void dumpAccelerationStructure(const std::string &path);
-  void processIntersectionCounts();
+  void updateLODByDistance();
 
   size_t _animationFrame = 0;
 };

--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -15,7 +15,6 @@ float4 fragment fragmentMain(
     device const uint3* indexBuffer [[buffer(5)]],
     device const int* primitiveIndices [[buffer(6)]],
     device const float4* tlasNodes [[buffer(7)]],
-    device atomic_uint* hitCounts [[buffer(8)]],
     texture2d<float, access::read_write> lastFrame [[texture(0)]],
     texture2d<float, access::read_write> currentFrame [[texture(1)]])
 
@@ -61,8 +60,7 @@ float4 fragment fragmentMain(
         seed,
         u.maxRayDepth,
         u.debugAS,
-        u.blasNodeCount,
-        hitCounts
+        u.blasNodeCount
     );
 
 

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -3,7 +3,6 @@
 
 #include <metal_raytracing>
 #include <metal_stdlib>
-#include <metal_atomic>
 
 #define M_PI 3.14159265358979323846
 
@@ -201,8 +200,7 @@ inline float4 rayColor(ray r, device const float4 *tlasNodes,
                        device const float4 *materials, uint primitiveCount,
                        device const int *primitiveIndices,
                        thread uint32_t &seed, uint maxRayDepth,
-                       uint debugAS, uint blasNodeCount,
-                       device atomic_uint *hitCounts) {
+                       uint debugAS, uint blasNodeCount) {
   if (debugAS == 1) {
     for (uint i = 0; i < tlasNodeCount; ++i) {
       float3 bmin = tlasNodes[2 * i + 0].xyz;
@@ -266,8 +264,6 @@ inline float4 rayColor(ray r, device const float4 *tlasNodes,
       light += absorption * float4(skyColor, 1.0);
       break;
     }
-    atomic_fetch_add_explicit(&hitCounts[bestHit.primitiveId], 1,
-                              memory_order_relaxed);
     int matIndex = bestHit.primitiveId * 2;
     if (matIndex + 1 >= int(primitiveCount) * 2)
       break;


### PR DESCRIPTION
## Summary
- Replace intersection-count residency with distance-based level of detail
- Represent far primitives with proxy spheres and drop hit count buffers
- Simplify shaders by removing atomic hit counters

## Testing
- `clang++ -c 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` *(fails: command not found)*
- `python -m py_compile visualize_bvh.py`


------
https://chatgpt.com/codex/tasks/task_e_689b385d5540832db43bd64a1bb07632