### PR TITLE
Add test scenes for distance-based LOD evaluation

### DIFF
--- a/MetalCpp Path Tracer/scene_lod_clusters.xml
+++ b/MetalCpp Path Tracer/scene_lod_clusters.xml
@@ -9,13 +9,13 @@
     <!-- Ground -->
     <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
 
-    <!-- Cluster A of spheres -->
+    <!-- Cluster A of primitives -->
     <Sphere position="-20,20,0" radius="10" albedo="0.9,0.3,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Sphere position="0,20,0" radius="10" albedo="0.3,0.9,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="0,0,0" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
     <Sphere position="20,20,0" radius="10" albedo="0.3,0.3,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
 
-    <!-- Cluster B of spheres positioned far away -->
+    <!-- Cluster B of primitives positioned far away -->
     <Sphere position="280,20,0" radius="10" albedo="0.9,0.3,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Sphere position="300,20,0" radius="10" albedo="0.9,0.9,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="300,0,0" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
     <Sphere position="320,20,0" radius="10" albedo="0.3,0.9,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
 </Scene>

--- a/MetalCpp Path Tracer/scene_lod_clusters.xml
+++ b/MetalCpp Path Tracer/scene_lod_clusters.xml
@@ -1,0 +1,21 @@
+<Scene width="1280" height="720" maxRayDepth="32">
+    <CameraPath>
+        <!-- Start near cluster A, then travel to cluster B to observe node on/off loading -->
+        <Keyframe frame="0" position="0,20,50" lookAt="0,20,0" />
+        <Keyframe frame="20" position="0,20,50" lookAt="0,20,0" />
+        <Keyframe frame="100" position="300,20,50" lookAt="300,20,0" />
+    </CameraPath>
+
+    <!-- Ground -->
+    <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Cluster A of spheres -->
+    <Sphere position="-20,20,0" radius="10" albedo="0.9,0.3,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="0,20,0" radius="10" albedo="0.3,0.9,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="20,20,0" radius="10" albedo="0.3,0.3,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Cluster B of spheres positioned far away -->
+    <Sphere position="280,20,0" radius="10" albedo="0.9,0.3,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="300,20,0" radius="10" albedo="0.9,0.9,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="320,20,0" radius="10" albedo="0.3,0.9,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
+</Scene>

--- a/MetalCpp Path Tracer/scene_lod_linear.xml
+++ b/MetalCpp Path Tracer/scene_lod_linear.xml
@@ -1,0 +1,17 @@
+<Scene width="1280" height="720" maxRayDepth="32">
+    <CameraPath>
+        <!-- Move the camera through a line of spheres to exercise distance-based LOD -->
+        <Keyframe frame="0" position="0,20,50" lookAt="0,20,0" />
+        <Keyframe frame="40" position="0,20,-100" lookAt="0,20,-150" />
+        <Keyframe frame="80" position="0,20,-250" lookAt="0,20,-300" />
+    </CameraPath>
+
+    <!-- Ground -->
+    <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Row of spheres to trigger LOD on/off as the camera moves -->
+    <Sphere position="0,20,-50" radius="10" albedo="0.8,0.2,0.2" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="0,20,-150" radius="10" albedo="0.2,0.8,0.2" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="0,20,-250" radius="10" albedo="0.2,0.2,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="0,20,-350" radius="10" albedo="0.8,0.8,0.2" emission="0,0,0" materialType="0" emissionPower="0" />
+</Scene>

--- a/MetalCpp Path Tracer/scene_lod_linear.xml
+++ b/MetalCpp Path Tracer/scene_lod_linear.xml
@@ -1,6 +1,6 @@
 <Scene width="1280" height="720" maxRayDepth="32">
     <CameraPath>
-        <!-- Move the camera through a line of spheres to exercise distance-based LOD -->
+        <!-- Move the camera through a line of primitives to exercise distance-based LOD -->
         <Keyframe frame="0" position="0,20,50" lookAt="0,20,0" />
         <Keyframe frame="40" position="0,20,-100" lookAt="0,20,-150" />
         <Keyframe frame="80" position="0,20,-250" lookAt="0,20,-300" />
@@ -9,9 +9,9 @@
     <!-- Ground -->
     <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
 
-    <!-- Row of spheres to trigger LOD on/off as the camera moves -->
+    <!-- Row of primitives to trigger LOD on/off as the camera moves -->
     <Sphere position="0,20,-50" radius="10" albedo="0.8,0.2,0.2" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Sphere position="0,20,-150" radius="10" albedo="0.2,0.8,0.2" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="0,0,-150" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
     <Sphere position="0,20,-250" radius="10" albedo="0.2,0.2,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Sphere position="0,20,-350" radius="10" albedo="0.8,0.8,0.2" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="0,0,-350" scale="10.0" albedo="0.3,0.5,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
 </Scene>


### PR DESCRIPTION
## Summary
- Add a linear camera path scene with spheres at increasing distances
- Add a two-cluster scene to test node loading/unloading during camera travel

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b3c1ae554832daf72a9f1708bead3