### PR TITLE
Avoid rebuilding BLAS when toggling LOD

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -55,6 +55,7 @@ private:
   MTL::Buffer *_pBVHBuffer = nullptr;
   MTL::Buffer *_pPrimitiveIndexBuffer = nullptr;
   MTL::Buffer *_pTLASBuffer = nullptr;
+  MTL::Buffer *_pActivePrimitiveBuffer = nullptr;
   size_t _blasNodeCount = 0;
   size_t _tlasNodeCount = 0;
   // Accumulation framebuffers

--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -15,6 +15,7 @@ float4 fragment fragmentMain(
     device const uint3* indexBuffer [[buffer(5)]],
     device const int* primitiveIndices [[buffer(6)]],
     device const float4* tlasNodes [[buffer(7)]],
+    device const uchar* activeFlags [[buffer(8)]],
     texture2d<float, access::read_write> lastFrame [[texture(0)]],
     texture2d<float, access::read_write> currentFrame [[texture(1)]])
 
@@ -57,6 +58,7 @@ float4 fragment fragmentMain(
         materials,
         u.primitiveCount,
         primitiveIndices,
+        activeFlags,
         seed,
         u.maxRayDepth,
         u.debugAS,


### PR DESCRIPTION
## Summary
- track per-primitive residency with a dedicated Metal buffer
- bind and update the residency buffer instead of rebuilding BLAS when distance changes
- skip inactive primitives in the Metal path tracing shaders

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b3eaf03bc832dbe78de5db651a05f