### PR TITLE
Avoid BLAS rebuild on primitive reload

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -56,6 +56,7 @@ private:
   MTL::Buffer *_pPrimitiveIndexBuffer = nullptr;
   MTL::Buffer *_pTLASBuffer = nullptr;
   MTL::Buffer *_pIntersectionCountBuffer = nullptr;
+  MTL::Buffer *_pActivePrimitiveBuffer = nullptr;
   size_t _blasNodeCount = 0;
   size_t _tlasNodeCount = 0;
   // Accumulation framebuffers
@@ -70,11 +71,10 @@ private:
   std::vector<bool> _activePrimitive;
   std::vector<int> _inactiveFrames;
   std::vector<uint32_t> _lastIntersectionCount;
-  std::vector<size_t> _activeToGlobalIndex;
   std::vector<BoundingSphere> _primitiveBounds;
 
   bool isInView(const BoundingSphere &b);
-  void syncSceneWithActivePrimitives();
+  void uploadActivePrimitiveBuffer();
   void rebuildAccelerationStructures();
   void dumpAccelerationStructure(const std::string &path);
   void processIntersectionCounts();

--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -15,7 +15,8 @@ float4 fragment fragmentMain(
     device const uint3* indexBuffer [[buffer(5)]],
     device const int* primitiveIndices [[buffer(6)]],
     device const float4* tlasNodes [[buffer(7)]],
-    device atomic_uint* hitCounts [[buffer(8)]],
+    device const uint* activePrims [[buffer(8)]],
+    device atomic_uint* hitCounts [[buffer(9)]],
     texture2d<float, access::read_write> lastFrame [[texture(0)]],
     texture2d<float, access::read_write> currentFrame [[texture(1)]])
 
@@ -58,6 +59,7 @@ float4 fragment fragmentMain(
         materials,
         u.primitiveCount,
         primitiveIndices,
+        activePrims,
         seed,
         u.maxRayDepth,
         u.debugAS,

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -62,6 +62,7 @@ inline intersection firstHitBVH(thread const ray &r,
                                 device const float4 *bvhNodes,
                                 device const float4 *primitives,
                                 device const int *primitiveIndices,
+                                device const uint *activePrims,
                                 int startNode) {
   intersection in;
   in.t = INFINITY;
@@ -89,6 +90,8 @@ inline intersection firstHitBVH(thread const ray &r,
       int count = second;
       for (int i = 0; i < count; ++i) {
         int primIdx = primitiveIndices[leftFirst + i];
+        if (!activePrims[primIdx])
+          continue;
         int base = primIdx * 3;
         float4 p0 = primitives[base + 0];
         float4 p1 = primitives[base + 1];
@@ -200,6 +203,7 @@ inline float4 rayColor(ray r, device const float4 *tlasNodes,
                        device const float4 *primitives,
                        device const float4 *materials, uint primitiveCount,
                        device const int *primitiveIndices,
+                       device const uint *activePrims,
                        thread uint32_t &seed, uint maxRayDepth,
                        uint debugAS, uint blasNodeCount,
                        device atomic_uint *hitCounts) {
@@ -224,7 +228,8 @@ inline float4 rayColor(ray r, device const float4 *tlasNodes,
       if (!intersectAABB(r, bmin, bmax, 0.0001, bestHit.t))
         continue;
       intersection hit =
-          firstHitBVH(r, bvhNodes, primitives, primitiveIndices, startNode);
+          firstHitBVH(r, bvhNodes, primitives, primitiveIndices, activePrims,
+                      startNode);
       if (hit.primitiveId != -1 && hit.t < bestHit.t)
         bestHit = hit;
     }
@@ -254,7 +259,8 @@ inline float4 rayColor(ray r, device const float4 *tlasNodes,
         continue;
 
       intersection hit =
-          firstHitBVH(r, bvhNodes, primitives, primitiveIndices, startNode);
+          firstHitBVH(r, bvhNodes, primitives, primitiveIndices, activePrims,
+                      startNode);
       if (hit.primitiveId != -1 && hit.t < bestHit.t)
         bestHit = hit;
     }


### PR DESCRIPTION
## Summary
- Track primitive residency with a GPU buffer instead of rebuilding BLAS
- Skip inactive primitives in shaders using active flag checks
- Update residency counters without reconstructing acceleration structures

## Testing
- `python -m py_compile visualize_bvh.py visualize_residency_html.py visualize_intersections_html.py visualize_intersections_plot.py`


------
https://chatgpt.com/codex/tasks/task_e_689b449d4708832d862a3132bc9ea1ba