### PR TITLE
Prevent culling entire scene by expanding LOD distance

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -453,11 +453,16 @@ void Renderer::draw(MTK::View *pView) {
 
 void Renderer::updateLODByDistance() {
   bool changed = false;
-  const float FULL_DETAIL_DISTANCE = 50.0f;
+  // Keep primitives active until the camera is reasonably far away.
+  // Using a larger threshold prevents the entire scene from being culled
+  // when starting far from the origin.
+  const float FULL_DETAIL_DISTANCE = 250.0f;
   size_t activeCount = 0;
   for (size_t g = 0; g < _allPrimitives.size(); ++g) {
     float dist =
-        simd::length(_primitiveBounds[g].center - Camera::position);
+        simd::length(_primitiveBounds[g].center - Camera::position) -
+        _primitiveBounds[g].radius;
+    dist = std::max(dist, 0.0f);
     bool shouldBeActive = dist < FULL_DETAIL_DISTANCE;
     if (_activePrimitive[g] != shouldBeActive) {
       _activePrimitive[g] = shouldBeActive;

--- a/MetalCpp Path Tracer/scene_lod_far.xml
+++ b/MetalCpp Path Tracer/scene_lod_far.xml
@@ -1,0 +1,20 @@
+<Scene width="1280" height="720" maxRayDepth="32">
+    <CameraPath>
+        <!-- Start well beyond full-detail distance to ensure primitives remain visible -->
+        <Keyframe frame="0" position="0,20,400" lookAt="0,20,0" />
+        <!-- Move closer to bring additional primitives into view -->
+        <Keyframe frame="100" position="0,20,-100" lookAt="0,20,-150" />
+    </CameraPath>
+
+    <!-- Ground -->
+    <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Near sphere to verify early activation -->
+    <Sphere position="0,20,-50" radius="10" albedo="0.8,0.2,0.2" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Mesh that should load as camera approaches -->
+    <Mesh file="assets/bunny.obj" position="0,0,-200" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Distant sphere to remain off until very close -->
+    <Sphere position="0,20,-350" radius="10" albedo="0.2,0.2,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
+</Scene>


### PR DESCRIPTION
## Summary
- Avoid deactivating all primitives when the camera starts far from the scene
- Compute LOD distance to primitive surfaces and increase threshold to 250 units

## Testing
- `g++ -std=c++17 -fsyntax-only 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` *(fails: Metal/Metal.hpp: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_689b4bd84c88832d9f420afa3b8f4450