### PR TITLE
Add per-primitive visibility mask updates

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -29,6 +29,8 @@ public:
   void drawableSizeWillChange(MTK::View *pView, CGSize size);
 
   bool hasKeyframes() const;
+  // Toggle visibility of an individual primitive without rebuilding TLAS.
+  void setPrimitiveActive(size_t index, bool active);
 
   std::vector<std::pair<simd::float3, float>> _allSpheres;
 


### PR DESCRIPTION
## Summary
- Add `setPrimitiveActive` to toggle primitives via instance masks without rebuilding TLAS
- Update distance-based LOD to use new per-primitive visibility updates

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b51e117d4832d916d37cc058366e4