### PR TITLE
Track and log active node count changes

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -506,11 +506,6 @@ void Renderer::rebuildAccelerationStructures() {
   _pScene->buildBVH();
 
   size_t newBlasCount = _pScene->getBVHNodeCount();
-  if (newBlasCount != _blasNodeCount)
-    printf("BLAS node count changed: %zu -> %zu\n", _blasNodeCount,
-           newBlasCount);
-  else
-    printf("BLAS node count: %zu\n", newBlasCount);
   _blasNodeCount = newBlasCount;
 
   simd::float4 *bvhData = _pScene->createBVHBuffer();
@@ -524,11 +519,12 @@ void Renderer::rebuildAccelerationStructures() {
 
   size_t tlasCount = 0;
   simd::float4 *tlasData = _pScene->createTLASBuffer(tlasCount);
-  if (tlasCount != _tlasNodeCount)
-    printf("TLAS node count changed: %zu -> %zu\n", _tlasNodeCount, tlasCount);
-  else
-    printf("TLAS node count: %zu\n", tlasCount);
   _tlasNodeCount = tlasCount;
+  size_t oldActiveCount = _activeNodeCount;
+  _activeNodeCount = _blasNodeCount + _tlasNodeCount;
+  if (_activeNodeCount != oldActiveCount) {
+    printf("Active nodes: %zu\n", _activeNodeCount);
+  }
   if (_pTLASBuffer)
     _pTLASBuffer->release();
   if (tlasData && tlasCount > 0) {

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -60,6 +60,7 @@ private:
   MTL::Buffer *_pActiveBuffer = nullptr;
   size_t _blasNodeCount = 0;
   size_t _tlasNodeCount = 0;
+  size_t _activeNodeCount = 0;
   // Accumulation framebuffers
   MTL::Texture *_accumulationTargets[2] = {nullptr, nullptr};
 


### PR DESCRIPTION
## Summary
- Track total active BVH nodes by summing TLAS and BLAS counts
- Report active node count whenever it changes during acceleration structure rebuilds

## Testing
- `g++ -std=c++17 -I'MetalCpp Path Tracer' -c 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` *(fails: Metal/Metal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b53744370832dbcbf903b715a75c0