### PR TITLE
Add test scene showcasing active node changes

### DIFF
--- a/MetalCpp Path Tracer/scene_active_nodes.xml
+++ b/MetalCpp Path Tracer/scene_active_nodes.xml
@@ -1,0 +1,19 @@
+<Scene width="1280" height="720" maxRayDepth="32">
+    <CameraPath>
+        <!-- Start near cluster A, then travel to cluster B to exercise node activation -->
+        <Keyframe frame="0" position="0,20,50" lookAt="0,20,0" />
+        <Keyframe frame="40" position="0,20,50" lookAt="0,20,0" />
+        <Keyframe frame="80" position="300,20,50" lookAt="300,20,0" />
+    </CameraPath>
+
+    <!-- Ground -->
+    <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Cluster A of mesh primitives -->
+    <Mesh file="assets/bunny.obj" position="0,0,0" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="30,0,0" scale="10.0" albedo="0.3,0.5,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Cluster B of mesh primitives far away -->
+    <Mesh file="assets/bunny.obj" position="300,0,0" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="330,0,0" scale="10.0" albedo="0.3,0.9,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+</Scene>


### PR DESCRIPTION
## Summary
- add `scene_active_nodes.xml` featuring two mesh clusters so camera movement toggles node activation

## Testing
- `python - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('MetalCpp Path Tracer/scene_active_nodes.xml')
print('Parsed OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689b56d9d018832da4a42da700b15d20