### PR TITLE
Rebuild acceleration structures on LOD updates

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -457,14 +457,17 @@ void Renderer::updateLODByDistance() {
   // when starting far from the origin.
   const float FULL_DETAIL_DISTANCE = 250.0f;
   size_t activeCount = 0;
+  bool changed = false;
   for (size_t g = 0; g < _allPrimitives.size(); ++g) {
     float dist =
         simd::length(_primitiveBounds[g].center - Camera::position) -
         _primitiveBounds[g].radius;
     dist = std::max(dist, 0.0f);
     bool shouldBeActive = dist < FULL_DETAIL_DISTANCE;
-    if (_activePrimitive[g] != shouldBeActive)
+    if (_activePrimitive[g] != shouldBeActive) {
       setPrimitiveActive(g, shouldBeActive);
+      changed = true;
+    }
     if (_activePrimitive[g])
       activeCount++;
   }
@@ -473,6 +476,12 @@ void Renderer::updateLODByDistance() {
     // Ensure at least one primitive remains visible to avoid a blank scene
     setPrimitiveActive(0, true);
     activeCount = 1;
+    changed = true;
+  }
+
+  if (changed) {
+    syncSceneWithActivePrimitives();
+    rebuildAccelerationStructures();
   }
 }
 


### PR DESCRIPTION
## Summary
- Rebuild acceleration structures whenever LOD culling activates/deactivates primitives
- Sync scene objects before rebuild so active node count prints reflect current state

## Testing
- `clang++ -fsyntax-only 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b57e4c048832da3c9c307d151c75f