### PR TITLE
Track active nodes without rebuilding acceleration structure

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -74,7 +74,6 @@ private:
   std::vector<BoundingSphere> _primitiveBounds;
 
   bool isInView(const BoundingSphere &b);
-  void syncSceneWithActivePrimitives();
   void rebuildAccelerationStructures();
   void dumpAccelerationStructure(const std::string &path);
   void updateLODByDistance();


### PR DESCRIPTION
## Summary
- drop syncSceneWithActivePrimitives and avoid scene rebuilds when primitives toggle on/off
- maintain TLAS/BLAS once at scene load while offloading primitives via active mask

## Testing
- `g++ -std=c++17 -I'MetalCpp Path Tracer' -I'MetalCpp Path Tracer/MetalCpp/metal-cpp' -c 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` *(fails: CoreFoundation/CoreFoundation.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b59d40894832dbf635268d0d95904