### PR TITLE
Add on-screen FPS counter

### DIFF
--- a/MetalCpp Path Tracer/Window/ControllerView.hpp
+++ b/MetalCpp Path Tracer/Window/ControllerView.hpp
@@ -12,6 +12,9 @@ public:
   virtual MTK::View* get(CGRect frame);
 };
 
+// Update the FPS text overlay on the rendering view.
+void updateFPS(double fps);
+
 };
 
 #endif

--- a/MetalCpp Path Tracer/Window/ControllerView.mm
+++ b/MetalCpp Path Tracer/Window/ControllerView.mm
@@ -1,5 +1,6 @@
 #import "ControllerView.hpp"
 #import <MetalKit/MetalKit.h>
+#import <AppKit/AppKit.h>
 
 #include "InputSystem.h"
 
@@ -7,9 +8,11 @@
 }
 + (void)load:(CGRect)frame;
 + (ViewBridge *)get;
++ (void)updateFPS:(double)fps;
 @end
 
 ViewBridge *adapter;
+NSTextField *fpsLabel;
 
 MTK::View *MetalCppPathTracer::ControllerView::get(CGRect frame) {
     [ViewBridge load: frame];
@@ -22,11 +25,23 @@ MTK::View *MetalCppPathTracer::ControllerView::get(CGRect frame) {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     adapter = [[self alloc] initWithFrame:frame];
     [adapter init];
+    fpsLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(10, 10, 100, 20)];
+    [fpsLabel setBezeled:NO];
+    [fpsLabel setDrawsBackground:NO];
+    [fpsLabel setEditable:NO];
+    [fpsLabel setSelectable:NO];
+    [fpsLabel setTextColor:[NSColor whiteColor]];
+    [fpsLabel setStringValue:@"0 FPS"];
+    [adapter addSubview:fpsLabel];
     [pool release];
 }
 
 + (ViewBridge *)get {
     return adapter;
+}
+
++ (void)updateFPS:(double)fps {
+    [fpsLabel setStringValue:[NSString stringWithFormat:@"%.1f FPS", fps]];
 }
 
 - (id)init {
@@ -80,3 +95,7 @@ MTK::View *MetalCppPathTracer::ControllerView::get(CGRect frame) {
 }
 
 @end
+
+void MetalCppPathTracer::updateFPS(double fps) {
+    [ViewBridge updateFPS:fps];
+}

--- a/MetalCpp Path Tracer/Window/ViewDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.cpp
@@ -1,11 +1,14 @@
 #include "ViewDelegate.h"
 #include <AppKit/AppKit.hpp>
 #include <cstdlib>
+#include <chrono>
+#include "ControllerView.hpp"
 
 using namespace MetalCppPathTracer;
 
 ViewDelegate::ViewDelegate(MTL::Device *pDevice)
-    : MTK::ViewDelegate(), _pRenderer(new Renderer(pDevice)) {
+    : MTK::ViewDelegate(), _pRenderer(new Renderer(pDevice)),
+      _lastTime(std::chrono::steady_clock::now()) {
   if (const char *env = std::getenv("MPT_MAX_FRAMES"))
     _maxFrames = std::strtoul(env, nullptr, 10);
 }
@@ -13,6 +16,11 @@ ViewDelegate::ViewDelegate(MTL::Device *pDevice)
 ViewDelegate::~ViewDelegate() { delete _pRenderer; }
 
 void ViewDelegate::drawInMTKView(MTK::View *pView) {
+  auto current = std::chrono::steady_clock::now();
+  double fps =
+      1.0 / std::chrono::duration<double>(current - _lastTime).count();
+  _lastTime = current;
+  updateFPS(fps);
   _pRenderer->draw(pView);
   if (_maxFrames > 0 && _pRenderer->hasKeyframes() &&
       ++_frameCount >= _maxFrames)

--- a/MetalCpp Path Tracer/Window/ViewDelegate.h
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.h
@@ -4,6 +4,7 @@
 #include <Metal/Metal.hpp>
 #include <MetalKit/MetalKit.hpp>
 #include <cstddef>
+#include <chrono>
 
 #include "Renderer.h"
 
@@ -22,6 +23,7 @@ class ViewDelegate : public MTK::ViewDelegate
     Renderer* _pRenderer;
     std::size_t _frameCount = 0;
     std::size_t _maxFrames = 0;
+    std::chrono::steady_clock::time_point _lastTime;
 };
 
 };


### PR DESCRIPTION
## Summary
- Add `updateFPS` helper and overlay text field to display frame rate.
- Compute FPS each frame in `ViewDelegate` and update on-screen counter.

## Testing
- `clang++ -std=c++17 -fsyntax-only 'MetalCpp Path Tracer/Window/ViewDelegate.cpp'` *(failed: command not found)*
- `apt-get update` *(failed: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b63036560832da8e95a0bac971ff1