### PR TITLE
Expose acceleration structure dump

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -32,6 +32,9 @@ public:
   // Toggle visibility of an individual primitive without rebuilding TLAS.
   void setPrimitiveActive(size_t index, bool active);
 
+  // Dump acceleration structure to a JSON file for debugging.
+  void dumpAccelerationStructure(const std::string &path);
+
   std::vector<std::pair<simd::float3, float>> _allSpheres;
 
   struct Chunk {
@@ -75,7 +78,6 @@ private:
 
   bool isInView(const BoundingSphere &b);
   void rebuildAccelerationStructures();
-  void dumpAccelerationStructure(const std::string &path);
   void updateLODByDistance();
 
   size_t _animationFrame = 0;


### PR DESCRIPTION
## Summary
- expose Renderer::dumpAccelerationStructure so ViewDelegate can call it

## Testing
- `g++ -std=c++17 -fsyntax-only 'MetalCpp Path Tracer/Window/ViewDelegate.cpp'` *(fails: fatal error: Metal/Metal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b66a41700832d80e4ecec2d761000