### PR TITLE
Improve FPS counter visibility

### DIFF
--- a/MetalCpp Path Tracer/Window/ControllerView.mm
+++ b/MetalCpp Path Tracer/Window/ControllerView.mm
@@ -25,9 +25,10 @@ MTK::View *MetalCppPathTracer::ControllerView::get(CGRect frame) {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     adapter = [[self alloc] initWithFrame:frame];
     [adapter init];
-    fpsLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(10, 10, 100, 20)];
+    fpsLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(10, frame.size.height - 30, 120, 20)];
     [fpsLabel setBezeled:NO];
-    [fpsLabel setDrawsBackground:NO];
+    [fpsLabel setDrawsBackground:YES];
+    [fpsLabel setBackgroundColor:[NSColor colorWithCalibratedWhite:0 alpha:0.5]];
     [fpsLabel setEditable:NO];
     [fpsLabel setSelectable:NO];
     [fpsLabel setTextColor:[NSColor whiteColor]];


### PR DESCRIPTION
## Summary
- Move FPS label to top-left and add semi-transparent background for readability

## Testing
- `clang++ -fsyntax-only 'MetalCpp Path Tracer/Window/ControllerView.mm'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c54d7f1a0832d9ee2a0b5cbf26d1c