### PR TITLE
Log detailed performance metrics and extend visualization

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -631,3 +631,9 @@ void Renderer::completeFrameMetrics(MTL::CommandBuffer *pCmd) {
       _activeNodeCount, offloaded, _lastCPUTime * 1000.0,
       _lastGPUTime * 1000.0, _lastRaysPerSecond);
 }
+
+double Renderer::lastCPUTime() const { return _lastCPUTime; }
+double Renderer::lastGPUTime() const { return _lastGPUTime; }
+double Renderer::lastRaysPerSecond() const { return _lastRaysPerSecond; }
+size_t Renderer::activeNodeCount() const { return _activeNodeCount; }
+size_t Renderer::totalNodeCount() const { return _totalNodeCount; }

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -39,6 +39,13 @@ public:
   // Return the amount of GPU memory currently allocated by the device in MB.
   double currentGPUMemoryMB() const;
 
+  // Expose last recorded performance metrics.
+  double lastCPUTime() const;
+  double lastGPUTime() const;
+  double lastRaysPerSecond() const;
+  size_t activeNodeCount() const;
+  size_t totalNodeCount() const;
+
   std::vector<std::pair<simd::float3, float>> _allSpheres;
 
   struct Chunk {


### PR DESCRIPTION
## Summary
- Expose CPU/GPU timings, ray throughput, and node counts from renderer
- Record detailed per-frame metrics to perf.csv for plotting
- Expand performance visualiser to read node counts from CSV and chart them

## Testing
- `python -m py_compile visualize_performance_plot.py`
- `pip install plotly` *(fails: Tunnel connection failed: 403 Forbidden)*
- `clang++ -std=c++17 -c 'MetalCpp Path Tracer/Renderer/Renderer.cpp' -I'MetalCpp Path Tracer'` *(fails: command not found: clang++)*


------
https://chatgpt.com/codex/tasks/task_e_689c633b7998832d82172271458cd18b