### PR TITLE
Add ray differential-based footprint for shading

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -26,6 +26,8 @@ struct UniformsData {
   simd::float3 viewportU;
   simd::float3 viewportV;
   simd::float3 firstPixelPosition;
+  simd::float3 rayDx;
+  simd::float3 rayDy;
 
   simd::float3 randomSeed;
 
@@ -209,11 +211,16 @@ void Renderer::recalculateViewport() {
   simd::float3 firstPixelPosition =
       Camera::position - w - (viewportU * 0.5f) - (viewportV * 0.5f);
 
+  simd::float3 rayDx = viewportU / Camera::screenSize.x;
+  simd::float3 rayDy = viewportV / Camera::screenSize.y;
+
   UniformsData *uData = (UniformsData *)_pUniformsBuffer->contents();
   uData->cameraPosition = Camera::position;
   uData->viewportU = viewportU;
   uData->viewportV = viewportV;
   uData->firstPixelPosition = firstPixelPosition;
+  uData->rayDx = rayDx;
+  uData->rayDy = rayDy;
   uData->screenSize = Camera::screenSize;
 
   _pUniformsBuffer->didModifyRange(NS::Range::Make(0, sizeof(UniformsData)));

--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -44,13 +44,14 @@ float4 fragment fragmentMain(
     ray r{u.cameraPosition, normalize(rayDir)};
     r.min_distance = 0.0001;
     r.max_distance = INFINITY; // or INFINITY
-    
-    
 
-    
+    float3 rayDx = u.rayDx;
+    float3 rayDy = u.rayDy;
 
     float4 color = rayColor(
         r,
+        rayDx,
+        rayDy,
         tlasNodes,
         u.tlasNodeCount,
         bvhNodes,

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -197,7 +197,8 @@ inline intersection firstHitBVH(thread const ray &r,
   return in;
 }
 
-inline float4 rayColor(ray r, device const float4 *tlasNodes,
+inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
+                       device const float4 *tlasNodes,
                        uint tlasNodeCount, device const float4 *bvhNodes,
                        device const float4 *primitives,
                        device const float4 *materials, uint primitiveCount,
@@ -205,6 +206,8 @@ inline float4 rayColor(ray r, device const float4 *tlasNodes,
                        device const uchar *activeMask,
                        thread uint32_t &seed, uint maxRayDepth,
                        uint debugAS, uint blasNodeCount) {
+  float footprint = length(cross(rayDx, rayDy));
+  float lodAtten = 1.0 / (1.0 + footprint);
   if (debugAS == 1) {
     for (uint i = 0; i < tlasNodeCount; ++i) {
       float3 bmin = tlasNodes[2 * i + 0].xyz;
@@ -276,7 +279,7 @@ inline float4 rayColor(ray r, device const float4 *tlasNodes,
     float4 m0 = materials[matIndex + 0];
     float4 m1 = materials[matIndex + 1];
 
-    float3 albedo = m0.xyz;
+    float3 albedo = m0.xyz * lodAtten;
     float materialType = m0.w;
     float3 emissionColor = m1.xyz;
     float emissionPower = m1.w;

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -30,6 +30,8 @@ struct UniformsData
     simd::float3 viewportU;
     simd::float3 viewportV;
     simd::float3 firstPixelPosition;
+    simd::float3 rayDx;
+    simd::float3 rayDy;
 
     simd::float3 randomSeed;
 


### PR DESCRIPTION
## Summary
- extend uniform data with ray direction differentials
- compute per-pixel ray differentials in `recalculateViewport`
- pass differential vectors to shaders and use them for LOD-based attenuation

## Testing
- `g++ -std=c++17 -fsyntax-only 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` *(fails: Metal/Metal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c00464c260832d97bb12746d9964df