### PR TITLE
Add GPU memory budgeting system

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -238,6 +238,8 @@ void Renderer::buildBuffers() {
   // Uniforms
   if (_pUniformsBuffer)
     _pUniformsBuffer->release();
+  if (!ensureBudget(uniformsDataSize))
+    return;
   _pUniformsBuffer =
       _pDevice->newBuffer(uniformsDataSize, MTL::ResourceStorageModeManaged);
   _pUniformsBuffer->didModifyRange(NS::Range::Make(0, uniformsDataSize));
@@ -268,7 +270,11 @@ void Renderer::buildBuffers() {
   size_t primitiveAlloc =
       primitiveSize > 0 ? primitiveSize : sizeof(simd::float4);
   size_t materialAlloc = materialSize > 0 ? materialSize : sizeof(simd::float4);
-
+  if (!ensureBudget(primitiveAlloc + materialAlloc)) {
+    delete[] primitiveBuffer;
+    delete[] materialBuffer;
+    return;
+  }
   _pSphereBuffer =
       _pDevice->newBuffer(primitiveAlloc, MTL::ResourceStorageModeManaged);
   _pSphereMaterialBuffer =
@@ -291,6 +297,8 @@ void Renderer::buildBuffers() {
   }
   size_t activeSize = primitiveCount * sizeof(uint8_t);
   size_t activeAlloc = activeSize > 0 ? activeSize : sizeof(uint8_t);
+  if (!ensureBudget(activeAlloc))
+    return;
   _pActiveBuffer =
       _pDevice->newBuffer(activeAlloc, MTL::ResourceStorageModeManaged);
   if (primitiveCount > 0) {
@@ -304,9 +312,12 @@ void Renderer::buildBuffers() {
   // Dummy triangle buffer bindings
   simd::float3 dummyVertex = {0, 0, 0};
   simd::uint3 dummyIndex = {0, 0, 0};
-
+  if (!ensureBudget(sizeof(simd::float3)))
+    return;
   _pTriangleVertexBuffer = _pDevice->newBuffer(
       &dummyVertex, sizeof(simd::float3), MTL::ResourceStorageModeManaged);
+  if (!ensureBudget(sizeof(simd::uint3)))
+    return;
   _pTriangleIndexBuffer = _pDevice->newBuffer(&dummyIndex, sizeof(simd::uint3),
                                               MTL::ResourceStorageModeManaged);
 }
@@ -322,9 +333,16 @@ void Renderer::buildTextures() {
   textureDescriptor->setStorageMode(MTL::StorageMode::StorageModePrivate);
   textureDescriptor->setUsage(MTL::TextureUsageShaderRead |
                               MTL::TextureUsageShaderWrite);
-
-  for (uint i = 0; i < 2; i++)
+  size_t texSize = static_cast<size_t>(Camera::screenSize.x * Camera::screenSize.y *
+                                       4 * sizeof(float));
+  for (uint i = 0; i < 2; i++) {
+    if (!ensureBudget(texSize)) {
+      textureDescriptor->release();
+      return;
+    }
     _accumulationTargets[i] = _pDevice->newTexture(textureDescriptor);
+  }
+  textureDescriptor->release();
 }
 
 bool Renderer::updateCamera() {
@@ -506,9 +524,13 @@ void Renderer::rebuildAccelerationStructures() {
   simd::float4 *bvhData = _pScene->createBVHBuffer();
   if (_pBVHBuffer)
     _pBVHBuffer->release();
+  size_t bvhSize = sizeof(simd::float4) * newBlasCount * 2;
+  if (!ensureBudget(bvhSize)) {
+    delete[] bvhData;
+    return;
+  }
   _pBVHBuffer =
-      _pDevice->newBuffer(bvhData, sizeof(simd::float4) * newBlasCount * 2,
-                          MTL::ResourceStorageModeManaged);
+      _pDevice->newBuffer(bvhData, bvhSize, MTL::ResourceStorageModeManaged);
   _pBVHBuffer->didModifyRange(NS::Range::Make(0, _pBVHBuffer->length()));
   delete[] bvhData;
 
@@ -528,11 +550,19 @@ void Renderer::rebuildAccelerationStructures() {
   if (_pTLASBuffer)
     _pTLASBuffer->release();
   if (tlasData && tlasCount > 0) {
+    size_t tlasSize = sizeof(simd::float4) * tlasCount * 2;
+    if (!ensureBudget(tlasSize)) {
+      delete[] tlasData;
+      return;
+    }
     _pTLASBuffer =
-        _pDevice->newBuffer(tlasData, sizeof(simd::float4) * tlasCount * 2,
-                            MTL::ResourceStorageModeManaged);
+        _pDevice->newBuffer(tlasData, tlasSize, MTL::ResourceStorageModeManaged);
     _pTLASBuffer->didModifyRange(NS::Range::Make(0, _pTLASBuffer->length()));
   } else {
+    if (!ensureBudget(1)) {
+      delete[] tlasData;
+      return;
+    }
     _pTLASBuffer = _pDevice->newBuffer(1, MTL::ResourceStorageModeManaged);
   }
   delete[] tlasData;
@@ -542,12 +572,16 @@ void Renderer::rebuildAccelerationStructures() {
   if (_pPrimitiveIndexBuffer)
     _pPrimitiveIndexBuffer->release();
   if (indexCount > 0) {
+    if (!ensureBudget(indexSize))
+      return;
     int *rawIndices = _pScene->createPrimitiveIndexBuffer();
     _pPrimitiveIndexBuffer = _pDevice->newBuffer(
         rawIndices, indexSize, MTL::ResourceStorageModeManaged);
     _pPrimitiveIndexBuffer->didModifyRange(NS::Range::Make(0, indexSize));
     delete[] rawIndices;
   } else {
+    if (!ensureBudget(sizeof(int)))
+      return;
     _pPrimitiveIndexBuffer =
         _pDevice->newBuffer(sizeof(int), MTL::ResourceStorageModeManaged);
   }
@@ -614,6 +648,25 @@ void Renderer::dumpAccelerationStructure(const std::string &path) {
 double Renderer::currentGPUMemoryMB() const {
   return static_cast<double>(_pDevice->currentAllocatedSize()) /
          (1024.0 * 1024.0);
+}
+
+void Renderer::setGPUMemoryBudgetMB(double mb) {
+  if (mb <= 0.0)
+    _gpuMemoryBudget = std::numeric_limits<size_t>::max();
+  else
+    _gpuMemoryBudget = static_cast<size_t>(mb * 1024.0 * 1024.0);
+}
+
+bool Renderer::ensureBudget(size_t bytes) const {
+  if (_gpuMemoryBudget == std::numeric_limits<size_t>::max())
+    return true;
+  size_t current = _pDevice->currentAllocatedSize();
+  if (current + bytes > _gpuMemoryBudget) {
+    printf("GPU memory budget exceeded: requested %zu bytes (current %zu, budget %zu)\n",
+           bytes, current, _gpuMemoryBudget);
+    return false;
+  }
+  return true;
 }
 
 void Renderer::beginFrameMetrics() {

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -5,6 +5,7 @@
 #include <MetalKit/MetalKit.hpp>
 #include <cstdint>
 #include <chrono>
+#include <limits>
 #include <simd/simd.h>
 #include <vector>
 
@@ -38,6 +39,10 @@ public:
 
   // Return the amount of GPU memory currently allocated by the device in MB.
   double currentGPUMemoryMB() const;
+
+  // Set a maximum GPU memory budget in megabytes. A value of 0 disables the
+  // budget and allows unlimited allocations.
+  void setGPUMemoryBudgetMB(double mb);
 
   // Expose last recorded performance metrics.
   double lastCPUTime() const;
@@ -78,6 +83,10 @@ private:
   size_t _totalNodeCount = 0;
   // Accumulation framebuffers
   MTL::Texture *_accumulationTargets[2] = {nullptr, nullptr};
+
+  // GPU memory budgeting
+  size_t _gpuMemoryBudget = std::numeric_limits<size_t>::max();
+  bool ensureBudget(size_t bytes) const;
 
   struct BoundingSphere {
     simd::float3 center;

--- a/MetalCpp Path Tracer/Window/ViewDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.cpp
@@ -24,6 +24,8 @@ ViewDelegate::ViewDelegate(MTL::Device *pDevice)
       _lastTime(std::chrono::steady_clock::now()) {
   if (const char *env = std::getenv("MPT_MAX_FRAMES"))
     _maxFrames = std::strtoul(env, nullptr, 10);
+  if (const char *budget = std::getenv("MPT_GPU_BUDGET_MB"))
+    _pRenderer->setGPUMemoryBudgetMB(std::strtod(budget, nullptr));
   if (const char *runs = std::getenv("MPT_RUNS_PATH")) {
     std::filesystem::path base(runs);
     std::filesystem::create_directories(base);

--- a/visualize_performance_plot.py
+++ b/visualize_performance_plot.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
-"""Plot per-frame performance metrics with optional active node counts.
+"""Plot per-frame performance metrics, one plot per metric.
 
 This script reads the ``perf.csv`` log produced when the renderer is run
 with ``MPT_RUNS_PATH`` set. The CSV must contain a ``frame`` column and
 may contain additional metrics such as ``fps`` or ``rays_per_second``.
 If a directory or JSON file of acceleration-structure dumps is supplied,
-the number of loaded BLAS nodes per frame is computed and plotted on a
-secondary axis for comparison.
+the number of loaded BLAS nodes per frame is computed and plotted as the
+``active_nodes`` metric. Each metric is written to its own interactive
+Plotly HTML file for easy comparison.
 """
 from __future__ import annotations
 
@@ -18,15 +19,12 @@ from typing import Any, Dict, List, Tuple
 
 import plotly.graph_objects as go
 import plotly.io as pio
-from plotly.subplots import make_subplots
 
 pio.renderers.default = "browser"
 
 
-def _load_perf_csv(
-    path: Path,
-) -> Tuple[List[int], Dict[str, List[float]], List[int] | None, List[int] | None]:
-    """Return frame numbers, metric columns, and node counts from ``path``."""
+def _load_perf_csv(path: Path) -> Tuple[List[int], Dict[str, List[float]]]:
+    """Return frame numbers and metric columns from ``path``."""
     frames: List[int] = []
     metrics: Dict[str, List[float]] = {}
     with path.open("r", encoding="utf-8") as f:
@@ -37,9 +35,7 @@ def _load_perf_csv(
                 if key == "frame":
                     continue
                 metrics.setdefault(key, []).append(float(value))
-    active = metrics.pop("active_nodes", None)
-    offloaded = metrics.pop("offloaded_nodes", None)
-    return frames, metrics, active, offloaded
+    return frames, metrics
 
 
 # The following helpers are adapted from ``visualize_active_nodes_plot.py``
@@ -99,53 +95,17 @@ def _count_active_nodes(frames: List[Dict[str, Any]]) -> List[int]:
     return [sum(1 for n in f.get("nodes", []) if n.get("loaded", True)) for f in frames]
 
 
-def _create_figure(
-    frames: List[int],
-    metrics: Dict[str, List[float]],
-    active_nodes: List[int] | None,
-    offloaded_nodes: List[int] | None,
+def _create_metric_figure(
+    frames: List[int], values: List[float], name: str
 ) -> go.Figure:
-    if active_nodes is not None or offloaded_nodes is not None:
-        fig = make_subplots(specs=[[{"secondary_y": True}]])
-    else:
-        fig = go.Figure()
-
-    for name, values in metrics.items():
-        if active_nodes is not None or offloaded_nodes is not None:
-            fig.add_trace(
-                go.Scatter(x=frames, y=values, mode="lines+markers", name=name),
-                secondary_y=False,
-            )
-        else:
-            fig.add_trace(go.Scatter(x=frames, y=values, mode="lines+markers", name=name))
-
-    if active_nodes is not None:
-        fig.add_trace(
-            go.Scatter(
-                x=list(range(len(active_nodes))),
-                y=active_nodes,
-                mode="lines+markers",
-                name="active_nodes",
-            ),
-            secondary_y=True,
-        )
-    if offloaded_nodes is not None:
-        fig.add_trace(
-            go.Scatter(
-                x=list(range(len(offloaded_nodes))),
-                y=offloaded_nodes,
-                mode="lines+markers",
-                name="offloaded_nodes",
-            ),
-            secondary_y=True,
-        )
-    if active_nodes is not None or offloaded_nodes is not None:
-        fig.update_yaxes(title_text="Performance", secondary_y=False)
-        fig.update_yaxes(title_text="Nodes", secondary_y=True)
-    else:
-        fig.update_yaxes(title_text="Value")
-
-    fig.update_layout(title="Per-frame performance metrics", xaxis_title="Frame")
+    """Return a Plotly line chart for a single metric."""
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=frames, y=values, mode="lines+markers", name=name))
+    fig.update_layout(
+        title=f"{name} per frame",
+        xaxis_title="Frame",
+        yaxis_title=name,
+    )
     return fig
 
 
@@ -168,22 +128,27 @@ def main() -> None:
     parser.add_argument(
         "--output",
         type=Path,
-        default=Path("performance.html"),
-        help="Output HTML file",
+        default=Path("performance_plots"),
+        help="Output directory for HTML files",
     )
     parser.add_argument(
         "--no-open", action="store_true", help="Do not automatically open the browser"
     )
     args = parser.parse_args()
 
-    frames, metrics, csv_active, csv_offloaded = _load_perf_csv(args.csv)
-    active = csv_active
-    offloaded = csv_offloaded
-    if active is None and args.as_path is not None:
-        active = _count_active_nodes(_load_frames(args.as_path))
-    fig = _create_figure(frames, metrics, active, offloaded)
-    fig.write_html(args.output, auto_open=not args.no_open)
-    print(f"Wrote {args.output}")
+    frames, metrics = _load_perf_csv(args.csv)
+    if "active_nodes" not in metrics and args.as_path is not None:
+        metrics["active_nodes"] = _count_active_nodes(_load_frames(args.as_path))
+
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    print("Metrics:", ", ".join(metrics.keys()))
+
+    for name, values in metrics.items():
+        fig = _create_metric_figure(frames, values, name)
+        out_file = args.output / f"{name}.html"
+        fig.write_html(out_file, auto_open=not args.no_open)
+        print(f"Wrote {out_file} for metric '{name}'")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Allow setting a GPU memory budget via `setGPUMemoryBudgetMB`
- Guard buffer and texture allocations with budget checks
- Read `MPT_GPU_BUDGET_MB` env var in `ViewDelegate` to configure budget
- Split performance metrics into separate Plotly plots, logging each metric individually

## Testing
- `g++ -std=c++17 -fsyntax-only 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` *(fails: Metal/Metal.hpp: No such file or directory)*
- `python -m py_compile visualize_performance_plot.py`


------
https://chatgpt.com/codex/tasks/task_e_68c005ca53e4832da1b843afb4dd031a