### PR TITLE
Compact buffers on primitive offload to free GPU memory

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -78,15 +78,14 @@ Renderer::Renderer(MTL::Device *pDevice)
   buildTextures();
 
   recalculateViewport();
+  _bufferedPrimitiveCount = _pScene->getPrimitiveCount();
 }
 
 Renderer::~Renderer() {
-  for (MTL::Buffer *b : _sphereBuffers)
-    if (b)
-      b->release();
-  for (MTL::Buffer *b : _sphereMaterialBuffers)
-    if (b)
-      b->release();
+  if (_pSphereBuffer)
+    _pSphereBuffer->release();
+  if (_pSphereMaterialBuffer)
+    _pSphereMaterialBuffer->release();
   if (_pTriangleVertexBuffer)
     _pTriangleVertexBuffer->release();
   if (_pTriangleIndexBuffer)
@@ -195,6 +194,7 @@ void Renderer::updateVisibleScene() {
 
   rebuildAccelerationStructures();
   buildBuffers();
+  _bufferedPrimitiveCount = _pScene->getPrimitiveCount();
 }
 
 void Renderer::recalculateViewport() {
@@ -247,65 +247,49 @@ void Renderer::buildBuffers() {
   _pUniformsBuffer->didModifyRange(NS::Range::Make(0, uniformsDataSize));
 
   // Destroy previous
-  for (MTL::Buffer *b : _sphereBuffers)
-    if (b)
-      b->release();
-  for (MTL::Buffer *b : _sphereMaterialBuffers)
-    if (b)
-      b->release();
-  _sphereBuffers.clear();
-  _sphereMaterialBuffers.clear();
-
-  // Allocate per-primitive buffers
-  _sphereBuffers.resize(primitiveCount, nullptr);
-  _sphereMaterialBuffers.resize(primitiveCount, nullptr);
-  for (size_t i = 0; i < primitiveCount; ++i) {
-    if (!_activePrimitive[i])
-      continue;
-
-    const Primitive &p = _allPrimitives[i];
-    simd::float4 transform[3];
-    if (p.type == PrimitiveType::Sphere) {
-      transform[0] = simd::make_float4(p.sphere.center,
-                                       static_cast<float>(p.type));
-      transform[1] =
-          simd::make_float4(simd::make_float3(p.sphere.radius, 0, 0), 0);
-      transform[2] = simd::make_float4(simd::float3(0), 0);
-    } else if (p.type == PrimitiveType::Rectangle) {
-      transform[0] =
-          simd::make_float4(p.rectangle.center, static_cast<float>(p.type));
-      transform[1] = simd::make_float4(p.rectangle.u, 0);
-      transform[2] = simd::make_float4(p.rectangle.v, 0);
-    } else {
-      transform[0] =
-          simd::make_float4(p.triangle.v0, static_cast<float>(p.type));
-      transform[1] = simd::make_float4(p.triangle.v1, 0);
-      transform[2] = simd::make_float4(p.triangle.v2, 0);
-    }
-
-    simd::float4 material[2];
-    material[0] =
-        simd::make_float4(p.material.albedo, p.material.materialType);
-    material[1] = simd::make_float4(p.material.emissionColor,
-                                    p.material.emissionPower);
-
-    size_t tSize = sizeof(transform);
-    size_t mSize = sizeof(material);
-    if (!ensureBudget(tSize + mSize))
-      return;
-
-    MTL::Buffer *tb =
-        _pDevice->newBuffer(tSize, MTL::ResourceStorageModeManaged);
-    memcpy(tb->contents(), transform, tSize);
-    tb->didModifyRange(NS::Range::Make(0, tSize));
-    _sphereBuffers[i] = tb;
-
-    MTL::Buffer *mb =
-        _pDevice->newBuffer(mSize, MTL::ResourceStorageModeManaged);
-    memcpy(mb->contents(), material, mSize);
-    mb->didModifyRange(NS::Range::Make(0, mSize));
-    _sphereMaterialBuffers[i] = mb;
+  if (_pSphereBuffer) {
+    _pSphereBuffer->release();
+    _pSphereBuffer = nullptr;
   }
+  if (_pSphereMaterialBuffer) {
+    _pSphereMaterialBuffer->release();
+    _pSphereMaterialBuffer = nullptr;
+  }
+
+  simd::float4 *primitiveBuffer = nullptr;
+  simd::float4 *materialBuffer = nullptr;
+  if (primitiveCount > 0) {
+    primitiveBuffer =
+        _pScene->createTransformsBuffer(); // 3 float4s per primitive
+    materialBuffer =
+        _pScene->createMaterialsBuffer(); // 2 float4s per primitive
+  }
+
+  const size_t primitiveSize = primitiveCount * 3 * sizeof(simd::float4);
+  const size_t materialSize = primitiveCount * 2 * sizeof(simd::float4);
+
+  size_t primitiveAlloc =
+      primitiveSize > 0 ? primitiveSize : sizeof(simd::float4);
+  size_t materialAlloc = materialSize > 0 ? materialSize : sizeof(simd::float4);
+  if (!ensureBudget(primitiveAlloc + materialAlloc)) {
+    delete[] primitiveBuffer;
+    delete[] materialBuffer;
+    return;
+  }
+  _pSphereBuffer =
+      _pDevice->newBuffer(primitiveAlloc, MTL::ResourceStorageModeManaged);
+  _pSphereMaterialBuffer =
+      _pDevice->newBuffer(materialAlloc, MTL::ResourceStorageModeManaged);
+
+  if (primitiveCount > 0) {
+    memcpy(_pSphereBuffer->contents(), primitiveBuffer, primitiveSize);
+    memcpy(_pSphereMaterialBuffer->contents(), materialBuffer, materialSize);
+    _pSphereBuffer->didModifyRange(NS::Range::Make(0, primitiveSize));
+    _pSphereMaterialBuffer->didModifyRange(NS::Range::Make(0, materialSize));
+  }
+
+  delete[] primitiveBuffer;
+  delete[] materialBuffer;
 
   // Active mask buffer (1 byte per primitive)
   if (_pActiveBuffer) {
@@ -319,9 +303,7 @@ void Renderer::buildBuffers() {
   _pActiveBuffer =
       _pDevice->newBuffer(activeAlloc, MTL::ResourceStorageModeManaged);
   if (primitiveCount > 0) {
-    std::vector<uint8_t> activeBytes(primitiveCount);
-    for (size_t i = 0; i < primitiveCount; ++i)
-      activeBytes[i] = _activePrimitive[i] ? 1 : 0;
+    std::vector<uint8_t> activeBytes(primitiveCount, 1);
     memcpy(_pActiveBuffer->contents(), activeBytes.data(), activeSize);
     _pActiveBuffer->didModifyRange(NS::Range::Make(0, activeSize));
   }
@@ -447,8 +429,10 @@ void Renderer::draw(MTK::View *pView) {
 
   pEnc->setRenderPipelineState(_pPSO);
 
-  // Always bind static buffers
+  // Always bind something for each slot
   pEnc->setFragmentBuffer(_pBVHBuffer, 0, 0); // New!
+  pEnc->setFragmentBuffer(_pSphereBuffer, 0, 1);
+  pEnc->setFragmentBuffer(_pSphereMaterialBuffer, 0, 2);
   pEnc->setFragmentBuffer(_pUniformsBuffer, 0, 3);
   pEnc->setFragmentBuffer(_pTriangleVertexBuffer, 0, 4);
   pEnc->setFragmentBuffer(_pTriangleIndexBuffer, 0, 5);
@@ -459,24 +443,8 @@ void Renderer::draw(MTK::View *pView) {
   pEnc->setFragmentTexture(_accumulationTargets[0], 0);
   pEnc->setFragmentTexture(_accumulationTargets[1], 1);
 
-  // Render each active primitive buffer individually
-  for (size_t i = 0; i < _sphereBuffers.size(); ++i) {
-    if (!_activePrimitive[i] || !_sphereBuffers[i] ||
-        !_sphereMaterialBuffers[i])
-      continue;
-
-    UniformsData &u = *((UniformsData *)_pUniformsBuffer->contents());
-    u.primitiveIndex = static_cast<int>(i);
-    u.primitiveCount = 1;
-    _pUniformsBuffer->didModifyRange(
-        NS::Range::Make(0, sizeof(UniformsData)));
-
-    pEnc->setFragmentBuffer(_sphereBuffers[i], 0, 1);
-    pEnc->setFragmentBuffer(_sphereMaterialBuffers[i], 0, 2);
-
-    pEnc->drawPrimitives(MTL::PrimitiveType::PrimitiveTypeTriangle,
-                         NS::UInteger(0), NS::UInteger(6));
-  }
+  pEnc->drawPrimitives(MTL::PrimitiveType::PrimitiveTypeTriangle,
+                       NS::UInteger(0), NS::UInteger(6));
 
   pEnc->endEncoding();
 
@@ -494,6 +462,7 @@ void Renderer::updateLODByDistance() {
   // Using a larger threshold prevents the entire scene from being culled
   // when starting far from the origin.
   const float FULL_DETAIL_DISTANCE = 250.0f;
+  bool changed = false;
   size_t activeCount = 0;
   for (size_t g = 0; g < _allPrimitives.size(); ++g) {
     float dist =
@@ -501,23 +470,40 @@ void Renderer::updateLODByDistance() {
         _primitiveBounds[g].radius;
     dist = std::max(dist, 0.0f);
     bool shouldBeActive = dist < FULL_DETAIL_DISTANCE;
-    if (_activePrimitive[g] != shouldBeActive)
-      setPrimitiveActive(g, shouldBeActive);
+    if (_activePrimitive[g] != shouldBeActive) {
+      _activePrimitive[g] = shouldBeActive;
+      changed = true;
+    }
     if (_activePrimitive[g])
       activeCount++;
   }
 
   if (activeCount == 0 && !_activePrimitive.empty()) {
-    // Ensure at least one primitive remains visible to avoid a blank scene
-    setPrimitiveActive(0, true);
+    _activePrimitive[0] = true;
     activeCount = 1;
+    changed = true;
   }
 
-  size_t newActiveNodes = _tlasNodeCount + activeCount;
-  if (newActiveNodes != _activeNodeCount) {
-    _activeNodeCount = newActiveNodes;
-    printf("Active nodes: %zu\n", _activeNodeCount);
-  }
+  if (changed && activeCount != _bufferedPrimitiveCount)
+    syncBuffersToActive();
+}
+
+void Renderer::syncBuffersToActive() {
+  Scene *newScene = new Scene();
+  newScene->screenSize = _pScene->screenSize;
+  newScene->maxRayDepth = _pScene->maxRayDepth;
+  newScene->cameraPath = _pScene->cameraPath;
+
+  for (size_t i = 0; i < _allPrimitives.size(); ++i)
+    if (_activePrimitive[i])
+      newScene->addPrimitive(_allPrimitives[i]);
+
+  delete _pScene;
+  _pScene = newScene;
+
+  rebuildAccelerationStructures();
+  buildBuffers();
+  _bufferedPrimitiveCount = _pScene->getPrimitiveCount();
 }
 
 void Renderer::drawableSizeWillChange(MTK::View *pView, CGSize size) {
@@ -532,75 +518,6 @@ void Renderer::drawableSizeWillChange(MTK::View *pView, CGSize size) {
 }
 
 bool Renderer::hasKeyframes() const { return !_pScene->cameraPath.empty(); }
-
-void Renderer::setPrimitiveActive(size_t index, bool active) {
-  if (index >= _activePrimitive.size())
-    return;
-  if (_activePrimitive[index] == active)
-    return;
-  _activePrimitive[index] = active;
-  if (_pActiveBuffer) {
-    uint8_t *mask = static_cast<uint8_t *>(_pActiveBuffer->contents());
-    mask[index] = active ? 1 : 0;
-    _pActiveBuffer->didModifyRange(NS::Range::Make(index, 1));
-  }
-
-  if (active) {
-    if (!_sphereBuffers[index] || !_sphereMaterialBuffers[index]) {
-      const Primitive &p = _allPrimitives[index];
-      simd::float4 transform[3];
-      if (p.type == PrimitiveType::Sphere) {
-        transform[0] =
-            simd::make_float4(p.sphere.center, static_cast<float>(p.type));
-        transform[1] =
-            simd::make_float4(simd::make_float3(p.sphere.radius, 0, 0), 0);
-        transform[2] = simd::make_float4(simd::float3(0), 0);
-      } else if (p.type == PrimitiveType::Rectangle) {
-        transform[0] =
-            simd::make_float4(p.rectangle.center, static_cast<float>(p.type));
-        transform[1] = simd::make_float4(p.rectangle.u, 0);
-        transform[2] = simd::make_float4(p.rectangle.v, 0);
-      } else {
-        transform[0] =
-            simd::make_float4(p.triangle.v0, static_cast<float>(p.type));
-        transform[1] = simd::make_float4(p.triangle.v1, 0);
-        transform[2] = simd::make_float4(p.triangle.v2, 0);
-      }
-
-      simd::float4 material[2];
-      material[0] =
-          simd::make_float4(p.material.albedo, p.material.materialType);
-      material[1] = simd::make_float4(p.material.emissionColor,
-                                      p.material.emissionPower);
-
-      size_t tSize = sizeof(transform);
-      size_t mSize = sizeof(material);
-      if (!ensureBudget(tSize + mSize))
-        return;
-
-      MTL::Buffer *tb =
-          _pDevice->newBuffer(tSize, MTL::ResourceStorageModeManaged);
-      memcpy(tb->contents(), transform, tSize);
-      tb->didModifyRange(NS::Range::Make(0, tSize));
-      _sphereBuffers[index] = tb;
-
-      MTL::Buffer *mb =
-          _pDevice->newBuffer(mSize, MTL::ResourceStorageModeManaged);
-      memcpy(mb->contents(), material, mSize);
-      mb->didModifyRange(NS::Range::Make(0, mSize));
-      _sphereMaterialBuffers[index] = mb;
-    }
-  } else {
-    if (_sphereBuffers[index]) {
-      _sphereBuffers[index]->release();
-      _sphereBuffers[index] = nullptr;
-    }
-    if (_sphereMaterialBuffers[index]) {
-      _sphereMaterialBuffers[index]->release();
-      _sphereMaterialBuffers[index] = nullptr;
-    }
-  }
-}
 
 void Renderer::rebuildAccelerationStructures() {
   _pScene->buildBVH();

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -31,8 +31,6 @@ public:
   void drawableSizeWillChange(MTK::View *pView, CGSize size);
 
   bool hasKeyframes() const;
-  // Toggle visibility of an individual primitive without rebuilding TLAS.
-  void setPrimitiveActive(size_t index, bool active);
 
   // Dump acceleration structure to a JSON file for debugging.
   void dumpAccelerationStructure(const std::string &path);
@@ -68,10 +66,8 @@ private:
   Scene *_pScene = nullptr;
 
   // Buffers
-  // Per-primitive geometry and material buffers stored individually to allow
-  // releasing or reloading on a per-primitive basis.
-  std::vector<MTL::Buffer *> _sphereBuffers;
-  std::vector<MTL::Buffer *> _sphereMaterialBuffers;
+  MTL::Buffer *_pSphereBuffer = nullptr;
+  MTL::Buffer *_pSphereMaterialBuffer = nullptr;
   MTL::Buffer *_pTriangleVertexBuffer = nullptr;
   MTL::Buffer *_pTriangleIndexBuffer = nullptr;
   MTL::Buffer *_pUniformsBuffer = nullptr;
@@ -102,6 +98,7 @@ private:
   bool isInView(const BoundingSphere &b);
   void rebuildAccelerationStructures();
   void updateLODByDistance();
+  void syncBuffersToActive();
 
   // Performance metrics
   void beginFrameMetrics();
@@ -113,6 +110,10 @@ private:
   size_t _lastRayCount = 0;
 
   size_t _animationFrame = 0;
+
+  // Track how many primitives are currently resident in GPU buffers so we can
+  // rebuild when the active set changes (offloading/onloading).
+  size_t _bufferedPrimitiveCount = 0;
 };
 
 } // namespace MetalCppPathTracer

--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -7,7 +7,7 @@ using metal::raytracing::ray;
 
 float4 fragment fragmentMain(
     v2f in [[stage_in]],
-    device const float4* bvhNodes [[buffer(0)]],          // <--- ADD THIS LINE
+    device const float4* bvhNodes [[buffer(0)]],
     device const float4* primitives [[buffer(1)]],
     device const float4* materials [[buffer(2)]],
     device const UniformsData* uniforms [[buffer(3)]],
@@ -58,7 +58,6 @@ float4 fragment fragmentMain(
         primitives,       // <- Each primitive is 3 float4s
         materials,
         u.primitiveCount,
-        u.primitiveIndex,
         primitiveIndices,
         activeMask,
         seed,

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -62,9 +62,7 @@ inline intersection firstHitBVH(thread const ray &r,
                                 device const float4 *primitives,
                                 device const int *primitiveIndices,
                                 device const uchar *activeMask,
-                                int startNode,
-                                int baseIndex,
-                                int primitiveCount) {
+                                int startNode) {
   intersection in;
   in.t = INFINITY;
   in.primitiveId = -1;
@@ -91,13 +89,9 @@ inline intersection firstHitBVH(thread const ray &r,
       int count = second;
       for (int i = 0; i < count; ++i) {
         int primIdx = primitiveIndices[leftFirst + i];
-        if (primIdx < baseIndex ||
-            primIdx >= baseIndex + primitiveCount)
-          continue;
         if (!activeMask[primIdx])
           continue;
-        int localIdx = primIdx - baseIndex;
-        int base = localIdx * 3;
+        int base = primIdx * 3;
         float4 p0 = primitives[base + 0];
         float4 p1 = primitives[base + 1];
         float4 p2 = primitives[base + 2];
@@ -180,7 +174,7 @@ inline intersection firstHitBVH(thread const ray &r,
 
         if (hitThis && tHit < in.t) {
           in.t = tHit;
-          in.primitiveId = localIdx;
+          in.primitiveId = primIdx;
           in.normal = n;
           in.point = hit;
           in.isTriangle = primitiveType;
@@ -208,7 +202,7 @@ inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
                        uint tlasNodeCount, device const float4 *bvhNodes,
                        device const float4 *primitives,
                        device const float4 *materials, uint primitiveCount,
-                       uint baseIndex, device const int *primitiveIndices,
+                       device const int *primitiveIndices,
                        device const uchar *activeMask,
                        thread uint32_t &seed, uint maxRayDepth,
                        uint debugAS, uint blasNodeCount) {
@@ -234,9 +228,9 @@ inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
       int startNode = as_type<int>(tlasNodes[2 * i + 0].w);
       if (!intersectAABB(r, bmin, bmax, 0.0001, bestHit.t))
         continue;
-      intersection hit = firstHitBVH(r, bvhNodes, primitives,
-                                     primitiveIndices, activeMask, startNode,
-                                     baseIndex, primitiveCount);
+      intersection hit =
+          firstHitBVH(r, bvhNodes, primitives, primitiveIndices, activeMask,
+                     startNode);
       if (hit.primitiveId != -1 && hit.t < bestHit.t)
         bestHit = hit;
     }
@@ -265,9 +259,9 @@ inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
       if (!intersectAABB(r, bmin, bmax, 0.0001, bestHit.t))
         continue;
 
-      intersection hit = firstHitBVH(r, bvhNodes, primitives,
-                                     primitiveIndices, activeMask, startNode,
-                                     baseIndex, primitiveCount);
+      intersection hit =
+          firstHitBVH(r, bvhNodes, primitives, primitiveIndices, activeMask,
+                     startNode);
       if (hit.primitiveId != -1 && hit.t < bestHit.t)
         bestHit = hit;
     }


### PR DESCRIPTION
## Summary
- Track how many primitives are resident on the GPU and rebuild scene buffers when the active set changes
- Recreate scene and buffers on offload/onload to release GPU memory
- Simplify active mask to a compact, all-active array after rebuilding buffers

## Testing
- `apt-get update` *(fails: repository 403 Forbidden)*
- `apt-get install -y clang` *(fails: Unable to locate package clang)*
- `clang++ -fsyntax-only 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c00f9a5f30832dbbb1862aec126443