### PR TITLE
Defer buffer compaction to reduce frame drops

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -414,6 +414,10 @@ void Renderer::updateUniforms() {
 
 void Renderer::draw(MTK::View *pView) {
   updateLODByDistance();
+  if (_pendingSync && ++_framesSinceSyncRequest >= kSyncDelayFrames) {
+    syncBuffersToActive();
+    _pendingSync = false;
+  }
   updateUniforms();
   beginFrameMetrics();
   std::swap(_accumulationTargets[0], _accumulationTargets[1]);
@@ -484,8 +488,10 @@ void Renderer::updateLODByDistance() {
     changed = true;
   }
 
-  if (changed && activeCount != _bufferedPrimitiveCount)
-    syncBuffersToActive();
+  if (changed && activeCount != _bufferedPrimitiveCount) {
+    _pendingSync = true;
+    _framesSinceSyncRequest = 0;
+  }
 }
 
 void Renderer::syncBuffersToActive() {

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -114,6 +114,11 @@ private:
   // Track how many primitives are currently resident in GPU buffers so we can
   // rebuild when the active set changes (offloading/onloading).
   size_t _bufferedPrimitiveCount = 0;
+
+  // Defer buffer compaction to avoid frame drops from frequent rebuilds.
+  bool _pendingSync = false;
+  uint32_t _framesSinceSyncRequest = 0;
+  static constexpr uint32_t kSyncDelayFrames = 30; // frames to wait before sync
 };
 
 } // namespace MetalCppPathTracer


### PR DESCRIPTION
## Summary
- Defer buffer compaction by waiting 30 frames after residency changes
- Track pending buffer sync to avoid repeated rebuilds during camera motion

## Testing
- `g++ -fsyntax-only -std=c++17 'MetalCpp Path Tracer/Renderer/Renderer.cpp' -I'MetalCpp Path Tracer'` *(fails: Metal/Metal.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c01933d3a0832dae0a2e24f7654b7b