### PR TITLE
Restore offloading and consolidate GPU metrics

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -462,19 +462,13 @@ void Renderer::draw(MTK::View *pView) {
 }
 
 void Renderer::updateLODByDistance() {
-  // Keep primitives active until the camera is reasonably far away.
-  // Using a larger threshold prevents the entire scene from being culled
-  // when starting far from the origin.
-  const float FULL_DETAIL_DISTANCE = 250.0f;
+  // Determine residency based solely on whether primitives are visible.
+  // Primitives outside the camera frustum are offloaded and will be
+  // reloaded once they come back into view.
   bool changed = false;
   size_t activeCount = 0;
   for (size_t g = 0; g < _allPrimitives.size(); ++g) {
-    float dist =
-        simd::length(_primitiveBounds[g].center - Camera::position) -
-        _primitiveBounds[g].radius;
-    dist = std::max(dist, 0.0f);
-    bool shouldBeActive =
-        dist < FULL_DETAIL_DISTANCE || isInView(_primitiveBounds[g]);
+    bool shouldBeActive = isInView(_primitiveBounds[g]);
     if (_activePrimitive[g] != shouldBeActive) {
       _activePrimitive[g] = shouldBeActive;
       changed = true;

--- a/MetalCpp Path Tracer/Window/ViewDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.cpp
@@ -36,18 +36,11 @@ ViewDelegate::ViewDelegate(MTL::Device *pDevice)
     std::filesystem::path perf = base / "perf.csv";
     _perfLog.open(perf);
     if (_perfLog.is_open())
-      _perfLog << "frame,fps,cpu_ms,gpu_ms,rays_per_second,active_nodes,offloaded_nodes\n";
-
-    std::filesystem::path gpu = base / "gpu_mem.csv";
-    _gpuMemLog.open(gpu);
-    if (_gpuMemLog.is_open())
-      _gpuMemLog << "frame,gpu_memory_mb\n";
+      _perfLog << "frame,fps,cpu_ms,gpu_ms,rays_per_second,active_nodes,offloaded_nodes,gpu_memory_mb\n";
   }
 }
 
 ViewDelegate::~ViewDelegate() {
-  if (_gpuMemLog.is_open())
-    _gpuMemLog.close();
   if (_perfLog.is_open())
     _perfLog.close();
   delete _pRenderer;
@@ -68,15 +61,11 @@ void ViewDelegate::drawInMTKView(MTK::View *pView) {
     size_t offloaded = _pRenderer->totalNodeCount() > active
                            ? _pRenderer->totalNodeCount() - active
                            : 0;
-    _perfLog << _frameCount << "," << fps << "," << cpu_ms << ","
-             << gpu_ms << "," << rays << "," << active << "," << offloaded
-             << "\n";
+    double gpu_mem = _pRenderer->currentGPUMemoryMB();
+    _perfLog << _frameCount << "," << fps << "," << cpu_ms << "," << gpu_ms
+             << "," << rays << "," << active << "," << offloaded << ","
+             << gpu_mem << "\n";
     _perfLog.flush();
-  }
-  if (_gpuMemLog.is_open()) {
-    _gpuMemLog << _frameCount << "," << _pRenderer->currentGPUMemoryMB()
-               << "\n";
-    _gpuMemLog.flush();
   }
   if (!_dumpPath.empty()) {
     char file[256];

--- a/MetalCpp Path Tracer/Window/ViewDelegate.h
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.h
@@ -25,7 +25,6 @@ private:
   std::size_t _maxFrames = 0;
   std::chrono::steady_clock::time_point _lastTime;
   std::string _dumpPath;
-  std::ofstream _gpuMemLog;
   std::ofstream _perfLog;
 };
 

--- a/visualize_gpu_memory_plot.py
+++ b/visualize_gpu_memory_plot.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Plot GPU memory usage per frame.
 
-This script reads the ``gpu_mem.csv`` log produced when the renderer is
-run with ``MPT_RUNS_PATH`` set.  The CSV should contain ``frame`` and
-``gpu_memory_mb`` columns.  An interactive Plotly plot is written to an
+This script reads the ``perf.csv`` log produced when the renderer is run
+with ``MPT_RUNS_PATH`` set. The CSV should contain ``frame`` and
+``gpu_memory_mb`` columns. An interactive Plotly plot is written to an
 HTML file for inspection.
 """
 from __future__ import annotations
@@ -47,7 +47,7 @@ def main() -> None:
         description="Plot GPU memory usage over frames"
     )
     parser.add_argument(
-        "path", type=Path, help="CSV file from MPT_RUNS_PATH/gpu_mem.csv"
+        "path", type=Path, help="CSV file from MPT_RUNS_PATH/perf.csv"
     )
     parser.add_argument(
         "--output", type=Path, default=Path("gpu_memory.html"),

--- a/visualize_performance_plot.py
+++ b/visualize_performance_plot.py
@@ -6,7 +6,8 @@ with ``MPT_RUNS_PATH`` set. The CSV must contain a ``frame`` column and
 may contain additional metrics such as ``fps`` or ``rays_per_second``.
 If a directory or JSON file of acceleration-structure dumps is supplied,
 the number of loaded BLAS nodes per frame is computed and plotted as the
-``active_nodes`` metric. Each metric is written to its own interactive
+``active_nodes`` metric. Each metric, including GPU memory usage if the
+``gpu_memory_mb`` column is present, is written to its own interactive
 Plotly HTML file for easy comparison.
 """
 from __future__ import annotations
@@ -36,18 +37,6 @@ def _load_perf_csv(path: Path) -> Tuple[List[int], Dict[str, List[float]]]:
                     continue
                 metrics.setdefault(key, []).append(float(value))
     return frames, metrics
-
-
-def _load_gpu_mem_csv(path: Path) -> Tuple[List[int], List[float]]:
-    """Return frame numbers and GPU memory usage from ``path``."""
-    frames: List[int] = []
-    mem: List[float] = []
-    with path.open("r", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            frames.append(int(row["frame"]))
-            mem.append(float(row["gpu_memory_mb"]))
-    return frames, mem
 
 
 # The following helpers are adapted from ``visualize_active_nodes_plot.py``
@@ -138,12 +127,6 @@ def main() -> None:
         ),
     )
     parser.add_argument(
-        "--gpu-mem-csv",
-        type=Path,
-        default=None,
-        help="CSV file from MPT_RUNS_PATH/gpu_mem.csv to include GPU memory usage",
-    )
-    parser.add_argument(
         "--output",
         type=Path,
         default=Path("performance_plots"),
@@ -157,11 +140,6 @@ def main() -> None:
     frames, metrics = _load_perf_csv(args.csv)
     if "active_nodes" not in metrics and args.as_path is not None:
         metrics["active_nodes"] = _count_active_nodes(_load_frames(args.as_path))
-    if args.gpu_mem_csv is not None:
-        mem_frames, mem = _load_gpu_mem_csv(args.gpu_mem_csv)
-        if mem_frames != frames:
-            print("Warning: frame mismatch between perf.csv and gpu_mem.csv")
-        metrics["gpu_memory_mb"] = mem
 
     args.output.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- Reactivate primitive offloading by basing residency strictly on camera visibility
- Log GPU memory usage alongside existing frame metrics in `perf.csv`
- Update visualization scripts to consume combined metrics file and plot GPU memory

## Testing
- `python3 -m py_compile visualize_performance_plot.py visualize_gpu_memory_plot.py`
- `python3 visualize_performance_plot.py --help` *(fails: No module named 'plotly')*
- `pip install plotly` *(fails: Could not find a version that satisfies the requirement plotly)*
- `python3 visualize_gpu_memory_plot.py --help` *(fails: No module named 'plotly')*
- `clang++ -std=c++17 -fsyntax-only 'MetalCpp Path Tracer/Window/ViewDelegate.cpp' 'MetalCpp Path Tracer/Renderer/Renderer.cpp'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c01d34b46c832daac7fe0f41530a72