### PR TITLE
Fix offloaded node metric

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -582,7 +582,13 @@ void Renderer::rebuildAccelerationStructures() {
   }
   delete[] tlasData;
 
-  _totalNodeCount = _tlasNodeCount + _pScene->getPrimitiveCount();
+  // The total node count should include primitives that have been
+  // offloaded from the scene.  ``_allPrimitives`` retains the full set
+  // of primitives, whereas ``_pScene->getPrimitiveCount()`` only counts
+  // those currently resident.  Using the scene's count would cause the
+  // total to shrink when primitives are offloaded, hiding the number of
+  // offloaded nodes in performance metrics.
+  _totalNodeCount = _tlasNodeCount + _allPrimitives.size();
   size_t oldActiveCount = _activeNodeCount;
   size_t activePrim = 0;
   for (bool a : _activePrimitive)


### PR DESCRIPTION
## Summary
- include offloaded primitives when calculating total node count so performance logs report offloaded nodes

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c025add3d8832dadec29753bd0e651