### PR TITLE
Log GPU memory usage in unified perf.csv

### DIFF
--- a/MetalCpp Path Tracer/Window/ViewDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.cpp
@@ -36,18 +36,12 @@ ViewDelegate::ViewDelegate(MTL::Device *pDevice)
     std::filesystem::path perf = base / "perf.csv";
     _perfLog.open(perf);
     if (_perfLog.is_open())
-      _perfLog << "frame,fps,cpu_ms,gpu_ms,rays_per_second,active_nodes,offloaded_nodes\n";
-
-    std::filesystem::path gpu = base / "gpu_mem.csv";
-    _gpuMemLog.open(gpu);
-    if (_gpuMemLog.is_open())
-      _gpuMemLog << "frame,gpu_memory_mb\n";
+      _perfLog <<
+          "frame,fps,cpu_ms,gpu_ms,rays_per_second,active_nodes,offloaded_nodes,gpu_memory_mb\n";
   }
 }
 
 ViewDelegate::~ViewDelegate() {
-  if (_gpuMemLog.is_open())
-    _gpuMemLog.close();
   if (_perfLog.is_open())
     _perfLog.close();
   delete _pRenderer;
@@ -68,15 +62,11 @@ void ViewDelegate::drawInMTKView(MTK::View *pView) {
     size_t offloaded = _pRenderer->totalNodeCount() > active
                            ? _pRenderer->totalNodeCount() - active
                            : 0;
+    double gpu_mem = _pRenderer->currentGPUMemoryMB();
     _perfLog << _frameCount << "," << fps << "," << cpu_ms << ","
              << gpu_ms << "," << rays << "," << active << "," << offloaded
-             << "\n";
+             << "," << gpu_mem << "\n";
     _perfLog.flush();
-  }
-  if (_gpuMemLog.is_open()) {
-    _gpuMemLog << _frameCount << "," << _pRenderer->currentGPUMemoryMB()
-               << "\n";
-    _gpuMemLog.flush();
   }
   if (!_dumpPath.empty()) {
     char file[256];

--- a/MetalCpp Path Tracer/Window/ViewDelegate.h
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.h
@@ -25,7 +25,6 @@ private:
   std::size_t _maxFrames = 0;
   std::chrono::steady_clock::time_point _lastTime;
   std::string _dumpPath;
-  std::ofstream _gpuMemLog;
   std::ofstream _perfLog;
 };
 

--- a/visualize_performance_plot.py
+++ b/visualize_performance_plot.py
@@ -3,7 +3,8 @@
 
 This script reads the ``perf.csv`` log produced when the renderer is run
 with ``MPT_RUNS_PATH`` set. The CSV must contain a ``frame`` column and
-may contain additional metrics such as ``fps`` or ``rays_per_second``.
+may contain additional metrics such as ``fps``, ``rays_per_second``, or
+``gpu_memory_mb`` for GPU memory usage.
 If a directory or JSON file of acceleration-structure dumps is supplied,
 the number of loaded BLAS nodes per frame is computed and plotted as the
 ``active_nodes`` metric. Each metric is written to its own interactive


### PR DESCRIPTION
## Summary
- log GPU memory usage alongside other frame metrics in `perf.csv`
- note `gpu_memory_mb` metric in the performance plotting helper

## Testing
- `python3 -m py_compile visualize_performance_plot.py`
- `g++ -fsyntax-only 'MetalCpp Path Tracer/Window/ViewDelegate.cpp'` *(fails: Metal/Metal.hpp: No such file or directory)*
- `pip install plotly` *(fails: Could not find a version that satisfies the requirement plotly)*

------
https://chatgpt.com/codex/tasks/task_e_68c0276c0994832da844368ef9a58786