### PR TITLE
Implement pixel footprint based LOD activation

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -13,6 +13,7 @@
 #include <filesystem>
 #include <fstream>
 #include <chrono>
+#include <limits>
 #include <simd/simd.h>
 #include <string>
 
@@ -65,6 +66,26 @@ bool Renderer::isInView(const BoundingSphere &b) {
   float halfFov = (Camera::verticalFov * M_PI / 180.0f) * 0.5f;
   float radiusAngle = asinf(std::min(b.radius / dist, 1.0f));
   return angle <= halfFov + radiusAngle;
+}
+
+float Renderer::estimatePixelFootprint(const BoundingSphere &b) const {
+  if (Camera::screenSize.y <= 0.0f)
+    return std::numeric_limits<float>::infinity();
+
+  simd::float3 toCenter = b.center - Camera::position;
+  float forwardDist = simd::dot(simd::normalize(Camera::forward), toCenter);
+  if (forwardDist <= 0.0f)
+    return 0.0f;
+
+  float halfFov = (Camera::verticalFov * M_PI / 180.0f) * 0.5f;
+  float tanHalfFov = tanf(halfFov);
+  if (tanHalfFov <= 0.0f)
+    return std::numeric_limits<float>::infinity();
+
+  float pixelsPerWorldUnit = Camera::screenSize.y /
+                             (2.0f * forwardDist * tanHalfFov);
+  float radiusPixels = b.radius * pixelsPerWorldUnit;
+  return static_cast<float>(M_PI) * radiusPixels * radiusPixels;
 }
 
 Renderer::Renderer(MTL::Device *pDevice)
@@ -459,17 +480,27 @@ void Renderer::draw(MTK::View *pView) {
 }
 
 void Renderer::updateLODByDistance() {
-  // Keep primitives active until the camera is reasonably far away.
-  // Using a larger threshold prevents the entire scene from being culled
-  // when starting far from the origin.
+  // Maintain full detail for nearby primitives, otherwise fall back to an
+  // estimate of the primitive's screen-space footprint.
   const float FULL_DETAIL_DISTANCE = 250.0f;
+  const float MIN_PIXEL_FOOTPRINT = 1.0f; // area in pixels^2
+
   size_t activeCount = 0;
   for (size_t g = 0; g < _allPrimitives.size(); ++g) {
-    float dist =
-        simd::length(_primitiveBounds[g].center - Camera::position) -
-        _primitiveBounds[g].radius;
-    dist = std::max(dist, 0.0f);
-    bool shouldBeActive = dist < FULL_DETAIL_DISTANCE;
+    const BoundingSphere &bound = _primitiveBounds[g];
+
+    float distToSurface =
+        simd::length(bound.center - Camera::position) - bound.radius;
+    distToSurface = std::max(distToSurface, 0.0f);
+
+    bool shouldBeActive = true;
+    if (!isInView(bound)) {
+      shouldBeActive = false;
+    } else if (distToSurface > FULL_DETAIL_DISTANCE) {
+      float footprint = estimatePixelFootprint(bound);
+      shouldBeActive = footprint >= MIN_PIXEL_FOOTPRINT;
+    }
+
     if (_activePrimitive[g] != shouldBeActive)
       setPrimitiveActive(g, shouldBeActive);
     if (_activePrimitive[g])

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -98,6 +98,7 @@ private:
   std::vector<BoundingSphere> _primitiveBounds;
 
   bool isInView(const BoundingSphere &b);
+  float estimatePixelFootprint(const BoundingSphere &b) const;
   void rebuildAccelerationStructures();
   void updateLODByDistance();
 


### PR DESCRIPTION
## Summary
- add a helper that estimates a primitive's pixel footprint based on the camera configuration
- switch LOD activation to keep distant primitives only when their screen-space footprint exceeds a minimum threshold
- skip activating primitives that fall outside the current camera frustum while preserving at least one visible primitive

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3ca7b5f9c832db4a9fbff67b80e24