### PR TITLE
Fix Metal argument buffer usage

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -143,7 +143,7 @@ void Renderer::buildShaders() {
     _pInstanceArgEncoder = nullptr;
   }
   _pInstanceArgEncoder =
-      pFragFn->newArgumentEncoderWithBufferIndex(NS::UInteger(3));
+      pFragFn->newArgumentEncoder(NS::UInteger(3));
 
   pVertexFn->release();
   pFragFn->release();
@@ -660,23 +660,20 @@ void Renderer::updateInstanceArgument(size_t index) {
   if (index >= kMaxInstanceCapacity)
     return;
 
-  _pInstanceArgEncoder->setArgumentBuffer(_pInstanceArgBuffer, 0);
-  const InstanceRecord &inst = _instances[index];
   NS::UInteger arrayIndex = NS::UInteger(index);
+  _pInstanceArgEncoder->setArgumentBuffer(_pInstanceArgBuffer, 0, arrayIndex);
+  const InstanceRecord &inst = _instances[index];
   if (inst.state == ResidencyState::Resident) {
-    _pInstanceArgEncoder->setBuffer(inst.gpu.blasNodes, 0, NS::UInteger(0),
-                                    arrayIndex);
-    _pInstanceArgEncoder->setBuffer(inst.gpu.primitives, 0, NS::UInteger(1),
-                                    arrayIndex);
-    _pInstanceArgEncoder->setBuffer(inst.gpu.materials, 0, NS::UInteger(2),
-                                    arrayIndex);
+    _pInstanceArgEncoder->setBuffer(inst.gpu.blasNodes, 0, NS::UInteger(0));
+    _pInstanceArgEncoder->setBuffer(inst.gpu.primitives, 0, NS::UInteger(1));
+    _pInstanceArgEncoder->setBuffer(inst.gpu.materials, 0, NS::UInteger(2));
     _pInstanceArgEncoder->setBuffer(inst.gpu.primitiveIndices, 0,
-                                    NS::UInteger(3), arrayIndex);
+                                    NS::UInteger(3));
   } else {
-    _pInstanceArgEncoder->setBuffer(nullptr, 0, NS::UInteger(0), arrayIndex);
-    _pInstanceArgEncoder->setBuffer(nullptr, 0, NS::UInteger(1), arrayIndex);
-    _pInstanceArgEncoder->setBuffer(nullptr, 0, NS::UInteger(2), arrayIndex);
-    _pInstanceArgEncoder->setBuffer(nullptr, 0, NS::UInteger(3), arrayIndex);
+    _pInstanceArgEncoder->setBuffer(nullptr, 0, NS::UInteger(0));
+    _pInstanceArgEncoder->setBuffer(nullptr, 0, NS::UInteger(1));
+    _pInstanceArgEncoder->setBuffer(nullptr, 0, NS::UInteger(2));
+    _pInstanceArgEncoder->setBuffer(nullptr, 0, NS::UInteger(3));
   }
 }
 

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -42,7 +42,7 @@ struct InstanceResources
 
 struct InstanceArgumentBuffer
 {
-    array<InstanceResources, MAX_INSTANCE_COUNT> instances;
+    metal::array<InstanceResources, MAX_INSTANCE_COUNT> instances;
 };
 
 


### PR DESCRIPTION
## Summary
- create the fragment argument encoder with `newArgumentEncoder` to match the metal-cpp API
- set instance resources through the argument encoder using the per-element binding API
- declare the shader argument buffer array with `metal::array`

## Testing
- not run (Metal toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d3efb7dce4832d817046372b9d223e