### PR TITLE
Fix instance argument buffer indexing

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -92,6 +92,8 @@ Renderer::~Renderer() {
     _pInstanceMetaBuffer->release();
   if (_pInstanceArgBuffer)
     _pInstanceArgBuffer->release();
+  if (_pInstanceArgElementEncoder)
+    _pInstanceArgElementEncoder->release();
   if (_pInstanceArgEncoder)
     _pInstanceArgEncoder->release();
 
@@ -142,8 +144,27 @@ void Renderer::buildShaders() {
     _pInstanceArgEncoder->release();
     _pInstanceArgEncoder = nullptr;
   }
+  if (_pInstanceArgElementEncoder) {
+    _pInstanceArgElementEncoder->release();
+    _pInstanceArgElementEncoder = nullptr;
+  }
+  _instanceArgStride = 0;
   _pInstanceArgEncoder =
       pFragFn->newArgumentEncoder(NS::UInteger(3));
+  if (_pInstanceArgEncoder) {
+    _pInstanceArgElementEncoder =
+        _pInstanceArgEncoder->newArgumentEncoder(NS::UInteger(0));
+    if (_pInstanceArgElementEncoder) {
+      size_t elementLength = _pInstanceArgElementEncoder->encodedLength();
+      size_t elementAlignment = _pInstanceArgElementEncoder->alignment();
+      if (elementAlignment > 0) {
+        size_t remainder = elementLength % elementAlignment;
+        if (remainder != 0)
+          elementLength += elementAlignment - remainder;
+      }
+      _instanceArgStride = elementLength;
+    }
+  }
 
   pVertexFn->release();
   pFragFn->release();
@@ -655,25 +676,33 @@ void Renderer::releaseInstanceResources(size_t index) {
 }
 
 void Renderer::updateInstanceArgument(size_t index) {
-  if (!_pInstanceArgEncoder || !_pInstanceArgBuffer)
+  if (!_pInstanceArgEncoder || !_pInstanceArgElementEncoder ||
+      !_pInstanceArgBuffer || _instanceArgStride == 0)
     return;
   if (index >= kMaxInstanceCapacity)
     return;
 
-  NS::UInteger arrayIndex = NS::UInteger(index);
-  _pInstanceArgEncoder->setArgumentBuffer(_pInstanceArgBuffer, 0, arrayIndex);
+  size_t offset = index * _instanceArgStride;
+  if (offset + _instanceArgStride > _pInstanceArgEncoder->encodedLength())
+    return;
+
+  _pInstanceArgElementEncoder->setArgumentBuffer(_pInstanceArgBuffer,
+                                                 NS::UInteger(offset));
   const InstanceRecord &inst = _instances[index];
   if (inst.state == ResidencyState::Resident) {
-    _pInstanceArgEncoder->setBuffer(inst.gpu.blasNodes, 0, NS::UInteger(0));
-    _pInstanceArgEncoder->setBuffer(inst.gpu.primitives, 0, NS::UInteger(1));
-    _pInstanceArgEncoder->setBuffer(inst.gpu.materials, 0, NS::UInteger(2));
-    _pInstanceArgEncoder->setBuffer(inst.gpu.primitiveIndices, 0,
-                                    NS::UInteger(3));
+    _pInstanceArgElementEncoder->setBuffer(inst.gpu.blasNodes, 0,
+                                           NS::UInteger(0));
+    _pInstanceArgElementEncoder->setBuffer(inst.gpu.primitives, 0,
+                                           NS::UInteger(1));
+    _pInstanceArgElementEncoder->setBuffer(inst.gpu.materials, 0,
+                                           NS::UInteger(2));
+    _pInstanceArgElementEncoder->setBuffer(inst.gpu.primitiveIndices, 0,
+                                           NS::UInteger(3));
   } else {
-    _pInstanceArgEncoder->setBuffer(nullptr, 0, NS::UInteger(0));
-    _pInstanceArgEncoder->setBuffer(nullptr, 0, NS::UInteger(1));
-    _pInstanceArgEncoder->setBuffer(nullptr, 0, NS::UInteger(2));
-    _pInstanceArgEncoder->setBuffer(nullptr, 0, NS::UInteger(3));
+    _pInstanceArgElementEncoder->setBuffer(nullptr, 0, NS::UInteger(0));
+    _pInstanceArgElementEncoder->setBuffer(nullptr, 0, NS::UInteger(1));
+    _pInstanceArgElementEncoder->setBuffer(nullptr, 0, NS::UInteger(2));
+    _pInstanceArgElementEncoder->setBuffer(nullptr, 0, NS::UInteger(3));
   }
 }
 

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -67,6 +67,8 @@ private:
   MTL::Buffer *_pInstanceMetaBuffer = nullptr;
   MTL::Buffer *_pInstanceArgBuffer = nullptr;
   MTL::ArgumentEncoder *_pInstanceArgEncoder = nullptr;
+  MTL::ArgumentEncoder *_pInstanceArgElementEncoder = nullptr;
+  size_t _instanceArgStride = 0;
   size_t _blasNodeCount = 0;
   size_t _tlasNodeCount = 0;
   size_t _activeNodeCount = 0;


### PR DESCRIPTION
## Summary
- add a dedicated argument encoder for individual instance resources and compute its stride
- use the element encoder to bind per-instance buffers at the proper offsets in the argument buffer
- release the additional encoder when rebuilding shaders or destroying the renderer

## Testing
- not run (not supported in container)

------
https://chatgpt.com/codex/tasks/task_e_68d3f12cb644832d83d1d48ed9c89f1a