### PR TITLE
Log actual offloaded node counts

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -572,6 +572,8 @@ void Renderer::initializeInstances() {
   _cpuBlasNodeCount = 0;
   _totalNodeCount = 0;
   _minInstanceFootprint = 0;
+  _lastOffloadedNodeCount = 0;
+  _lastOffloadedInstanceCount = 0;
 
   size_t primitiveCount = _allPrimitives.size();
   if (primitiveCount > kMaxInstanceCapacity) {
@@ -1029,16 +1031,34 @@ void Renderer::updateInstanceMetadata(size_t index) {
                       sizeof(InstanceMetadataCPU)));
 }
 
+std::pair<size_t, size_t> Renderer::calculateOffloadedResidency() const {
+  size_t offloadedNodes = 0;
+  size_t offloadedInstances = 0;
+  for (const auto &inst : _instances) {
+    if (inst.state != ResidencyState::Resident) {
+      offloadedNodes += inst.cpuBlasNodeCount;
+      offloadedInstances++;
+    }
+  }
+  return {offloadedNodes, offloadedInstances};
+}
+
 void Renderer::refreshActiveNodeCount() {
   size_t previousActive = _activeNodeCount;
+  size_t previousOffloadedNodes = _lastOffloadedNodeCount;
+  size_t previousOffloadedInstances = _lastOffloadedInstanceCount;
   _activeNodeCount = _tlasNodeCount + _currentBlasNodeCount;
   size_t total = _tlasNodeCount + _cpuBlasNodeCount;
   if (_totalNodeCount != total)
     _totalNodeCount = total;
-  if (_activeNodeCount != previousActive) {
-    size_t offloaded = total > _activeNodeCount ? total - _activeNodeCount : 0;
-    printf("Active nodes: %zu (offloaded: %zu)\n", _activeNodeCount,
-           offloaded);
+  auto [offloadedNodes, offloadedInstances] = calculateOffloadedResidency();
+  _lastOffloadedNodeCount = offloadedNodes;
+  _lastOffloadedInstanceCount = offloadedInstances;
+  if (_activeNodeCount != previousActive ||
+      offloadedNodes != previousOffloadedNodes ||
+      offloadedInstances != previousOffloadedInstances) {
+    printf("Active nodes: %zu (offloaded: %zu across %zu instances)\n",
+           _activeNodeCount, offloadedNodes, offloadedInstances);
   }
 }
 
@@ -1417,13 +1437,11 @@ void Renderer::completeFrameMetrics(MTL::CommandBuffer *pCmd) {
   }
   processPendingReleases();
   adjustBudgetForPerformance();
-  size_t offloaded = _totalNodeCount > _activeNodeCount ?
-                         _totalNodeCount - _activeNodeCount :
-                         0;
+  auto [offloadedNodes, offloadedInstances] = calculateOffloadedResidency();
   printf(
-      "Nodes active: %zu offloaded: %zu CPU: %.3f ms GPU: %.3f ms Rays/s: %.2f\n",
-      _activeNodeCount, offloaded, _lastCPUTime * 1000.0,
-      _lastGPUTime * 1000.0, _lastRaysPerSecond);
+      "Nodes active: %zu offloaded: %zu (instances: %zu) CPU: %.3f ms GPU: %.3f ms Rays/s: %.2f\n",
+      _activeNodeCount, offloadedNodes, offloadedInstances,
+      _lastCPUTime * 1000.0, _lastGPUTime * 1000.0, _lastRaysPerSecond);
 }
 
 double Renderer::lastCPUTime() const { return _lastCPUTime; }
@@ -1431,4 +1449,11 @@ double Renderer::lastGPUTime() const { return _lastGPUTime; }
 double Renderer::lastRaysPerSecond() const { return _lastRaysPerSecond; }
 size_t Renderer::activeNodeCount() const { return _activeNodeCount; }
 size_t Renderer::totalNodeCount() const { return _totalNodeCount; }
+size_t Renderer::offloadedNodeCount() const {
+  return calculateOffloadedResidency().first;
+}
+
+size_t Renderer::offloadedInstanceCount() const {
+  return calculateOffloadedResidency().second;
+}
 

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <limits>
 #include <simd/simd.h>
+#include <utility>
 #include <vector>
 
 #include "Scene.h"
@@ -50,6 +51,8 @@ public:
   double lastRaysPerSecond() const;
   size_t activeNodeCount() const;
   size_t totalNodeCount() const;
+  size_t offloadedNodeCount() const;
+  size_t offloadedInstanceCount() const;
 
 private:
   MTL::Device *_pDevice = nullptr;
@@ -140,6 +143,7 @@ private:
   void updateInstanceMetadata(size_t index);
   void rebuildTLAS();
   void refreshActiveNodeCount();
+  std::pair<size_t, size_t> calculateOffloadedResidency() const;
   void initializeInstances();
   void processPendingReleases();
   size_t instanceFootprintBytes(const InstanceRecord &inst) const;
@@ -162,6 +166,8 @@ private:
   double _lastGPUTime = 0.0;
   double _lastRaysPerSecond = 0.0;
   size_t _lastRayCount = 0;
+  size_t _lastOffloadedNodeCount = 0;
+  size_t _lastOffloadedInstanceCount = 0;
 
   size_t _animationFrame = 0;
 };

--- a/MetalCpp Path Tracer/Window/ViewDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.cpp
@@ -59,9 +59,7 @@ void ViewDelegate::drawInMTKView(MTK::View *pView) {
     double gpu_ms = _pRenderer->lastGPUTime() * 1000.0;
     double rays = _pRenderer->lastRaysPerSecond();
     size_t active = _pRenderer->activeNodeCount();
-    size_t offloaded = _pRenderer->totalNodeCount() > active
-                           ? _pRenderer->totalNodeCount() - active
-                           : 0;
+    size_t offloaded = _pRenderer->offloadedNodeCount();
     double gpu_mem = _pRenderer->currentGPUMemoryMB();
     _perfLog << _frameCount << "," << fps << "," << cpu_ms << ","
              << gpu_ms << "," << rays << "," << active << "," << offloaded


### PR DESCRIPTION
## Summary
- calculate offloaded node and instance counts directly from residency state
- print the richer residency information in renderer logs each time it changes
- expose the new stats so the view delegate records accurate offloaded nodes in perf logs

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d415aef658832da8bcf694441c62c1