### PR TITLE
Optimize primitive data layout for faster shading

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -704,26 +704,37 @@ void Renderer::initializeInstances() {
 
     switch (p.type) {
     case PrimitiveType::Sphere: {
+      const float radius = p.sphere.radius;
+      const float radiusSq = radius * radius;
       simd::float3 center = p.sphere.center;
-      simd::float3 radius =
-          simd::make_float3(p.sphere.radius, p.sphere.radius, p.sphere.radius);
-      pMin = center - radius;
-      pMax = center + radius;
+      simd::float3 radiusVec = simd::make_float3(radius, radius, radius);
+      pMin = center - radiusVec;
+      pMax = center + radiusVec;
       inst.primitiveData.push_back(
           simd::make_float4(center, static_cast<float>(p.type)));
       inst.primitiveData.push_back(
-          simd::make_float4(simd::make_float3(p.sphere.radius, 0, 0), 0));
-      inst.primitiveData.push_back(simd::make_float4(simd::float3(0), 0));
+          simd::make_float4(radius, radiusSq, 0.0f, 0.0f));
+      inst.primitiveData.push_back(simd::make_float4(simd::float3(0.0f), 0.0f));
+      inst.primitiveData.push_back(simd::make_float4(simd::float3(0.0f), 0.0f));
       break;
     }
     case PrimitiveType::Triangle: {
       const auto &tri = p.triangle;
       pMin = simd::min(tri.v0, simd::min(tri.v1, tri.v2));
       pMax = simd::max(tri.v0, simd::max(tri.v1, tri.v2));
+      simd::float3 edge1 = tri.v1 - tri.v0;
+      simd::float3 edge2 = tri.v2 - tri.v0;
+      simd::float3 normal = simd::cross(edge1, edge2);
+      float lenSq = simd::dot(normal, normal);
+      if (lenSq > 1e-12f)
+        normal *= 1.0f / std::sqrt(lenSq);
+      else
+        normal = simd::make_float3(0.0f, 0.0f, 0.0f);
       inst.primitiveData.push_back(
           simd::make_float4(tri.v0, static_cast<float>(p.type)));
-      inst.primitiveData.push_back(simd::make_float4(tri.v1, 0));
-      inst.primitiveData.push_back(simd::make_float4(tri.v2, 0));
+      inst.primitiveData.push_back(simd::make_float4(edge1, 0.0f));
+      inst.primitiveData.push_back(simd::make_float4(edge2, 0.0f));
+      inst.primitiveData.push_back(simd::make_float4(normal, 0.0f));
       break;
     }
     case PrimitiveType::Rectangle: {
@@ -738,10 +749,25 @@ void Renderer::initializeInstances() {
         pMin = simd::min(pMin, corners[k]);
         pMax = simd::max(pMax, corners[k]);
       }
+      simd::float3 normal = simd::cross(rect.u, rect.v);
+      float lenSq = simd::dot(normal, normal);
+      if (lenSq > 1e-12f)
+        normal *= 1.0f / std::sqrt(lenSq);
+      else
+        normal = simd::make_float3(0.0f, 0.0f, 0.0f);
+      float invDotU = 0.0f;
+      float invDotV = 0.0f;
+      float dotU = simd::dot(rect.u, rect.u);
+      float dotV = simd::dot(rect.v, rect.v);
+      if (dotU > 1e-12f)
+        invDotU = 1.0f / dotU;
+      if (dotV > 1e-12f)
+        invDotV = 1.0f / dotV;
       inst.primitiveData.push_back(
           simd::make_float4(rect.center, static_cast<float>(p.type)));
-      inst.primitiveData.push_back(simd::make_float4(rect.u, 0));
-      inst.primitiveData.push_back(simd::make_float4(rect.v, 0));
+      inst.primitiveData.push_back(simd::make_float4(rect.u, invDotU));
+      inst.primitiveData.push_back(simd::make_float4(rect.v, invDotV));
+      inst.primitiveData.push_back(simd::make_float4(normal, 0.0f));
       break;
     }
     }

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -5,6 +5,7 @@
 #include <metal_stdlib>
 
 #define M_PI 3.14159265358979323846
+#define PRIMITIVE_STRIDE 4
 
 #include "Intersect.h"
 #include "Random.h"
@@ -93,10 +94,11 @@ inline intersection firstHitBVH(thread const ray &r,
         int primIdx = primitiveIndices[leftFirst + i];
         if (primIdx >= int(primitiveCount))
           continue;
-        int base = primIdx * 3;
+        int base = primIdx * PRIMITIVE_STRIDE;
         float4 p0 = primitives[base + 0];
         float4 p1 = primitives[base + 1];
         float4 p2 = primitives[base + 2];
+        float4 p3 = primitives[base + 3];
 
         int primitiveType = int(p0.w);
         float tHit = INFINITY;
@@ -107,10 +109,11 @@ inline intersection firstHitBVH(thread const ray &r,
         if (primitiveType == 0) {
           float3 center = p0.xyz;
           float radius = p1.x;
+          float radiusSq = p1.y > 0.0 ? p1.y : radius * radius;
           float3 oc = r.origin - center;
           float a = dot(r.direction, r.direction);
           float b = dot(oc, r.direction);
-          float c = dot(oc, oc) - radius * radius;
+          float c = dot(oc, oc) - radiusSq;
           float discriminant = b * b - a * c;
 
           if (discriminant > 0.0) {
@@ -125,11 +128,9 @@ inline intersection firstHitBVH(thread const ray &r,
           }
         } else if (primitiveType == 1) {
           float3 v0 = p0.xyz;
-          float3 v1 = p1.xyz;
-          float3 v2 = p2.xyz;
-
-          float3 edge1 = v1 - v0;
-          float3 edge2 = v2 - v0;
+          float3 edge1 = p1.xyz;
+          float3 edge2 = p2.xyz;
+          float3 storedNormal = p3.xyz;
           float3 h = cross(r.direction, edge2);
           float a = dot(edge1, h);
           if (abs(a) > 1e-5) {
@@ -144,7 +145,11 @@ inline intersection firstHitBVH(thread const ray &r,
                 if (tt > 0.0001 && tt < in.t) {
                   tHit = tt;
                   hit = r.origin + tHit * r.direction;
-                  n = normalize(cross(edge1, edge2));
+                  float normalLenSq = dot(storedNormal, storedNormal);
+                  if (normalLenSq > 1e-12)
+                    n = storedNormal;
+                  else
+                    n = normalize(cross(edge1, edge2));
                   hitThis = true;
                   in.isTriangle = 1;
                 }
@@ -155,15 +160,20 @@ inline intersection firstHitBVH(thread const ray &r,
           float3 center = p0.xyz;
           float3 e1 = p1.xyz;
           float3 e2 = p2.xyz;
-          float3 normal = normalize(cross(e1, e2));
+          float invDotU = p1.w;
+          float invDotV = p2.w;
+          float3 normal = p3.xyz;
+          float normalLenSq = dot(normal, normal);
+          if (normalLenSq < 1e-12)
+            normal = normalize(cross(e1, e2));
           float denom = dot(normal, r.direction);
           if (fabs(denom) > 1e-5) {
             float tt = dot(center - r.origin, normal) / denom;
             if (tt > 0.0001 && tt < in.t) {
               float3 hitPoint = r.origin + tt * r.direction;
               float3 rel = hitPoint - center;
-              float u = dot(rel, e1) / dot(e1, e1);
-              float v = dot(rel, e2) / dot(e2, e2);
+              float u = invDotU > 0.0 ? dot(rel, e1) * invDotU : 0.0;
+              float v = invDotV > 0.0 ? dot(rel, e2) * invDotV : 0.0;
               if (fabs(u) <= 1.0 && fabs(v) <= 1.0) {
                 tHit = tt;
                 hit = hitPoint;


### PR DESCRIPTION
## Summary
- expand primitive GPU payloads to include cached triangle edges, normals and rectangle precomputations
- adjust CPU scene build to emit the new layout for every primitive type
- update the Metal shader BVH traversal to use the cached data via a shared stride constant, reducing per-ray math

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d418223e7c832db96fa3fb8d883d98