### PR TITLE
Refine instance grouping to follow mesh boundaries

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -15,12 +15,13 @@
 #include <chrono>
 #include <simd/simd.h>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <CoreFoundation/CoreFoundation.h>
 
 using namespace MetalCppPathTracer;
 
 static constexpr size_t kMaxInstanceCapacity = 16384;
-static constexpr size_t kMaxPrimitivesPerInstance = 64;
 static constexpr size_t kTLASNodeFootprintBytes = sizeof(simd::float4) * 2;
 static constexpr int kMaxTLASLeafInstances = 8;
 static constexpr size_t kDefaultBudgetBytes = 256ull * 1024ull * 1024ull;
@@ -844,41 +845,83 @@ void Renderer::initializeInstances() {
     inst.cpuPrimitiveCount++;
   };
 
-  InstanceRecord triangleBatch;
-  size_t batchSize = 0;
+  std::unordered_map<uint32_t, std::vector<size_t>> meshPrimitiveMap;
+  meshPrimitiveMap.reserve(primitiveCount);
 
-  auto flushTriangleBatch = [&]() {
-    if (batchSize == 0)
-      return;
-    finalizeInstance(triangleBatch);
-    _instances.push_back(std::move(triangleBatch));
-    triangleBatch = InstanceRecord{};
-    batchSize = 0;
-  };
+  size_t fallbackTriangleCount = 0;
+  size_t nonTriangleCount = 0;
 
   for (size_t i = 0; i < primitiveCount; ++i) {
     const Primitive &p = _allPrimitives[i];
     if (p.type == PrimitiveType::Triangle) {
-      if (batchSize == 0) {
-        triangleBatch = InstanceRecord{};
-        triangleBatch.primitiveIndex = i;
-      }
-      appendPrimitive(triangleBatch, p);
-      batchSize++;
-      if (batchSize >= kMaxPrimitivesPerInstance) {
-        flushTriangleBatch();
+      if (p.meshId != kInvalidMeshId) {
+        auto &indices = meshPrimitiveMap[p.meshId];
+        indices.push_back(i);
+      } else {
+        fallbackTriangleCount++;
       }
     } else {
-      flushTriangleBatch();
+      nonTriangleCount++;
+    }
+  }
+
+  size_t potentialInstanceCount = meshPrimitiveMap.size() + fallbackTriangleCount +
+                                  nonTriangleCount;
+  if (potentialInstanceCount > kMaxInstanceCapacity) {
+    printf(
+        "Warning: Scene has %zu potential instances but only %zu are supported; "
+        "excess instances will be ignored.\n",
+        potentialInstanceCount, kMaxInstanceCapacity);
+  }
+
+  _instances.reserve(std::min(potentialInstanceCount, kMaxInstanceCapacity));
+
+  auto buildInstanceFromIndices = [&](const std::vector<size_t> &indices,
+                                      uint32_t meshId) {
+    if (indices.empty() || _instances.size() >= kMaxInstanceCapacity)
+      return;
+    InstanceRecord inst;
+    inst.meshId = meshId;
+    inst.primitiveIndex = indices.front();
+    for (size_t idx : indices) {
+      appendPrimitive(inst, _allPrimitives[idx]);
+    }
+    finalizeInstance(inst);
+    _instances.push_back(std::move(inst));
+  };
+
+  std::unordered_set<uint32_t> processedMeshes;
+  processedMeshes.reserve(meshPrimitiveMap.size());
+
+  for (size_t i = 0; i < primitiveCount; ++i) {
+    const Primitive &p = _allPrimitives[i];
+    if (_instances.size() >= kMaxInstanceCapacity)
+      break;
+
+    if (p.type == PrimitiveType::Triangle) {
+      if (p.meshId != kInvalidMeshId) {
+        if (processedMeshes.insert(p.meshId).second) {
+          auto it = meshPrimitiveMap.find(p.meshId);
+          if (it != meshPrimitiveMap.end())
+            buildInstanceFromIndices(it->second, p.meshId);
+        }
+      } else {
+        InstanceRecord inst;
+        inst.meshId = kInvalidMeshId;
+        inst.primitiveIndex = i;
+        appendPrimitive(inst, p);
+        finalizeInstance(inst);
+        _instances.push_back(std::move(inst));
+      }
+    } else {
       InstanceRecord inst;
+      inst.meshId = kInvalidMeshId;
       inst.primitiveIndex = i;
       appendPrimitive(inst, p);
       finalizeInstance(inst);
       _instances.push_back(std::move(inst));
     }
   }
-
-  flushTriangleBatch();
 
   size_t totalBlas = 0;
   for (const auto &inst : _instances)

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -119,6 +119,7 @@ private:
 
   struct InstanceRecord {
     size_t primitiveIndex = 0;
+    uint32_t meshId = kInvalidMeshId;
     BoundingSphere bounds;
     simd::float3 aabbMin;
     simd::float3 aabbMax;

--- a/MetalCpp Path Tracer/Scene/Primitive.h
+++ b/MetalCpp Path Tracer/Scene/Primitive.h
@@ -5,6 +5,7 @@
 #include "Sphere.h"
 #include "Triangle.h"
 #include "Rectangle.h"
+#include <cstdint>
 
 namespace MetalCppPathTracer {
 
@@ -14,9 +15,12 @@ enum class PrimitiveType {
     Rectangle = 2
 };
 
+static constexpr uint32_t kInvalidMeshId = 0;
+
 struct Primitive {
     PrimitiveType type;
     Material material;
+    uint32_t meshId = kInvalidMeshId;
     union {
         Sphere sphere;
         Triangle triangle;

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -95,6 +95,8 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
     scene->screenSize.y = root->FloatAttribute("height", scene->screenSize.y);
     scene->maxRayDepth = root->UnsignedAttribute("maxRayDepth", scene->maxRayDepth);
 
+    uint32_t nextMeshId = kInvalidMeshId + 1;
+
     for (auto* e = root->FirstChildElement(); e; e = e->NextSiblingElement()) {
         std::string tag = e->Name();
         if (tag == "Sphere") {
@@ -142,6 +144,7 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             m.materialType = e->FloatAttribute("materialType", 0);
             m.emissionPower = e->FloatAttribute("emissionPower", 0);
 
+            uint32_t meshId = nextMeshId++;
             for (const auto& tri : tris) {
                 Primitive p{};
                 p.type = PrimitiveType::Triangle;
@@ -149,6 +152,7 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
                 p.triangle.v1 = pos + scale * verts[tri.y];
                 p.triangle.v2 = pos + scale * verts[tri.z];
                 p.material = m;
+                p.meshId = meshId;
                 scene->addPrimitive(p);
             }
         }


### PR DESCRIPTION
## Summary
- tag primitives with mesh identifiers and assign IDs while loading mesh geometry
- rebuild instance initialization to batch triangles per mesh and mirror mainstream renderer grouping
- record mesh IDs on instances so streaming and LOD decisions operate on whole meshes

## Testing
- not run (Metal toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d52408b208832dafcc5141782d6093