### PR TITLE
Ensure performance logs use post-release GPU memory

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1475,6 +1475,15 @@ double Renderer::currentGPUMemoryMB() const {
          (1024.0 * 1024.0);
 }
 
+bool Renderer::popCompletedFrameMetrics(FrameMetrics &outMetrics) {
+  std::lock_guard<std::mutex> lock(_metricsMutex);
+  if (!_hasPendingMetrics)
+    return false;
+  outMetrics = _pendingFrameMetrics;
+  _hasPendingMetrics = false;
+  return true;
+}
+
 void Renderer::setGPUMemoryBudgetMB(double mb) {
   _manualBudget = true;
   if (mb <= 0.0) {
@@ -1562,6 +1571,20 @@ void Renderer::completeFrameMetrics(MTL::CommandBuffer *pCmd) {
   processPendingReleases();
   adjustBudgetForPerformance();
   auto [offloadedNodes, offloadedInstances] = calculateOffloadedResidency();
+  double gpuMemoryMB = currentGPUMemoryMB();
+
+  {
+    std::lock_guard<std::mutex> lock(_metricsMutex);
+    _pendingFrameMetrics.cpuTime = _lastCPUTime;
+    _pendingFrameMetrics.gpuTime = _lastGPUTime;
+    _pendingFrameMetrics.raysPerSecond = _lastRaysPerSecond;
+    _pendingFrameMetrics.activeNodes = _activeNodeCount;
+    _pendingFrameMetrics.offloadedNodes = offloadedNodes;
+    _pendingFrameMetrics.offloadedInstances = offloadedInstances;
+    _pendingFrameMetrics.gpuMemoryMB = gpuMemoryMB;
+    _hasPendingMetrics = true;
+  }
+
   printf(
       "Nodes active: %zu offloaded: %zu (instances: %zu) CPU: %.3f ms GPU: %.3f ms Rays/s: %.2f\n",
       _activeNodeCount, offloadedNodes, offloadedInstances,

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <chrono>
 #include <limits>
+#include <mutex>
 #include <simd/simd.h>
 #include <utility>
 #include <vector>
@@ -38,8 +39,21 @@ public:
   // Dump acceleration structure to a JSON file for debugging.
   void dumpAccelerationStructure(const std::string &path);
 
+  struct FrameMetrics {
+    double cpuTime = 0.0;
+    double gpuTime = 0.0;
+    double raysPerSecond = 0.0;
+    size_t activeNodes = 0;
+    size_t offloadedNodes = 0;
+    size_t offloadedInstances = 0;
+    double gpuMemoryMB = 0.0;
+  };
+
   // Return the amount of GPU memory currently allocated by the device in MB.
   double currentGPUMemoryMB() const;
+
+  // Retrieve the most recently completed frame metrics, if available.
+  bool popCompletedFrameMetrics(FrameMetrics &outMetrics);
 
   // Set a maximum GPU memory budget in megabytes. A value of 0 disables the
   // budget and allows unlimited allocations.
@@ -170,6 +184,9 @@ private:
   size_t _lastRayCount = 0;
   size_t _lastOffloadedNodeCount = 0;
   size_t _lastOffloadedInstanceCount = 0;
+  FrameMetrics _pendingFrameMetrics;
+  bool _hasPendingMetrics = false;
+  mutable std::mutex _metricsMutex;
 
   size_t _animationFrame = 0;
 };

--- a/MetalCpp Path Tracer/Window/ViewDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.cpp
@@ -53,19 +53,25 @@ void ViewDelegate::drawInMTKView(MTK::View *pView) {
   _lastTime = current;
   updateFPS(fps);
   updateMemoryUsage(getMemoryUsageMB());
-  _pRenderer->draw(pView);
+
   if (_perfLog.is_open()) {
-    double cpu_ms = _pRenderer->lastCPUTime() * 1000.0;
-    double gpu_ms = _pRenderer->lastGPUTime() * 1000.0;
-    double rays = _pRenderer->lastRaysPerSecond();
-    size_t active = _pRenderer->activeNodeCount();
-    size_t offloaded = _pRenderer->offloadedNodeCount();
-    double gpu_mem = _pRenderer->currentGPUMemoryMB();
-    _perfLog << _frameCount << "," << fps << "," << cpu_ms << ","
-             << gpu_ms << "," << rays << "," << active << "," << offloaded
-             << "," << gpu_mem << "\n";
-    _perfLog.flush();
+    Renderer::FrameMetrics metrics;
+    while (_pRenderer->popCompletedFrameMetrics(metrics)) {
+      double cpu_ms = metrics.cpuTime * 1000.0;
+      double gpu_ms = metrics.gpuTime * 1000.0;
+      double rays = metrics.raysPerSecond;
+      size_t active = metrics.activeNodes;
+      size_t offloaded = metrics.offloadedNodes;
+      double gpu_mem = metrics.gpuMemoryMB;
+      _perfLog << _loggedFrameCount << "," << fps << "," << cpu_ms << ","
+               << gpu_ms << "," << rays << "," << active << ","
+               << offloaded << "," << gpu_mem << "\n";
+      _perfLog.flush();
+      ++_loggedFrameCount;
+    }
   }
+
+  _pRenderer->draw(pView);
   if (!_dumpPath.empty()) {
     char file[256];
     std::snprintf(file, sizeof(file), "%s/frame_%04zu.json", _dumpPath.c_str(),

--- a/MetalCpp Path Tracer/Window/ViewDelegate.h
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.h
@@ -22,6 +22,7 @@ public:
 private:
   Renderer *_pRenderer;
   std::size_t _frameCount = 0;
+  std::size_t _loggedFrameCount = 0;
   std::size_t _maxFrames = 0;
   std::chrono::steady_clock::time_point _lastTime;
   std::string _dumpPath;


### PR DESCRIPTION
## Summary
- add a FrameMetrics handoff on Renderer completion that records GPU memory usage after pending releases are processed
- have ViewDelegate log performance rows only when completed frame metrics are available so GPU memory reflects post-release values

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5277879dc832db38d9912cc740cd7