### PR TITLE
Add next-event estimation with light sampling

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -29,6 +29,7 @@ static constexpr double kBudgetDecreaseFactor = 0.8;
 static constexpr double kBudgetIncreaseFactor = 1.1;
 static constexpr double kBudgetIncreaseThreshold = 0.6;
 static constexpr double kBudgetDecreaseThreshold = 1.2;
+static constexpr size_t kPrimitiveStride = 4;
 
 struct UniformsData {
   int primitiveIndex;
@@ -53,6 +54,8 @@ struct UniformsData {
   uint32_t debugAS;
   uint32_t residentInstanceCount;
   uint32_t totalInstanceCount;
+  uint32_t lightCount;
+  uint32_t paddingUniforms[3];
 };
 
 struct InstanceMetadataCPU {
@@ -122,6 +125,10 @@ Renderer::~Renderer() {
     _pInstanceArgElementEncoder->release();
   if (_pInstanceArgEncoder)
     _pInstanceArgEncoder->release();
+  if (_pLightBuffer) {
+    _pLightBuffer->release();
+    _pLightBuffer = nullptr;
+  }
 
   for (int i = 0; i < 2; i++)
     if (_accumulationTargets[i])
@@ -515,6 +522,9 @@ void Renderer::updateUniforms() {
   if (!_pUniformsBuffer)
     return;
 
+  if (_lightTableDirty)
+    rebuildLightTable();
+
   UniformsData &u = *((UniformsData *)_pUniformsBuffer->contents());
 
   bool cameraChanged = updateCamera();
@@ -535,6 +545,7 @@ void Renderer::updateUniforms() {
   u.debugAS = InputSystem::debugAS;
   u.residentInstanceCount = static_cast<uint32_t>(_residentInstanceCount);
   u.totalInstanceCount = static_cast<uint32_t>(_instances.size());
+  u.lightCount = static_cast<uint32_t>(_lightTable.size());
 
   _pUniformsBuffer->didModifyRange(NS::Range::Make(0, sizeof(UniformsData)));
 }
@@ -561,6 +572,7 @@ void Renderer::draw(MTK::View *pView) {
   pEnc->setFragmentBuffer(_pInstanceMetaBuffer, 0, 2);
   pEnc->setFragmentBuffer(_pInstanceArgBuffer, 0, 3);
   pEnc->setFragmentBuffer(_pTLASInstanceIndexBuffer, 0, 4);
+  pEnc->setFragmentBuffer(_pLightBuffer, 0, 5);
 
   pEnc->setFragmentTexture(_accumulationTargets[0], 0);
   pEnc->setFragmentTexture(_accumulationTargets[1], 1);
@@ -747,6 +759,7 @@ void Renderer::initializeInstances() {
   _recentVisibleFootprint = 0;
   _lastOffloadedNodeCount = 0;
   _lastOffloadedInstanceCount = 0;
+  markLightTableDirty();
 
   size_t primitiveCount = _allPrimitives.size();
   if (primitiveCount > kMaxInstanceCapacity) {
@@ -1080,6 +1093,7 @@ bool Renderer::streamInInstance(size_t index) {
     updateInstanceArgument(index);
     updateInstanceMetadata(index);
     _pendingAccumulationReset = true;
+    markLightTableDirty();
     return true;
   }
 
@@ -1169,6 +1183,7 @@ bool Renderer::streamInInstance(size_t index) {
   updateInstanceArgument(index);
   updateInstanceMetadata(index);
   _pendingAccumulationReset = true;
+  markLightTableDirty();
   return true;
 }
 
@@ -1191,6 +1206,7 @@ void Renderer::streamOutInstance(size_t index) {
                 index) == _instancesPendingRelease.end())
     _instancesPendingRelease.push_back(index);
   _pendingAccumulationReset = true;
+  markLightTableDirty();
 }
 
 void Renderer::releaseInstanceResources(size_t index) {
@@ -1218,6 +1234,7 @@ void Renderer::releaseInstanceResources(size_t index) {
   inst.gpu.blasNodeCount = 0;
   inst.gpu.rootNodeIndex = 0;
   inst.state = ResidencyState::NotResident;
+  markLightTableDirty();
 }
 
 void Renderer::updateInstanceArgument(size_t index) {
@@ -1270,6 +1287,141 @@ void Renderer::updateInstanceMetadata(size_t index) {
   _pInstanceMetaBuffer->didModifyRange(
       NS::Range::Make(index * sizeof(InstanceMetadataCPU),
                       sizeof(InstanceMetadataCPU)));
+}
+
+void Renderer::markLightTableDirty() {
+  _lightTableDirty = true;
+  _pendingAccumulationReset = true;
+}
+
+static float encodeUInt32(uint32_t value) {
+  float bits = 0.0f;
+  std::memcpy(&bits, &value, sizeof(uint32_t));
+  return bits;
+}
+
+void Renderer::rebuildLightTable() {
+  if (!_lightTableDirty)
+    return;
+
+  if (_pLightBuffer) {
+    _pLightBuffer->release();
+    _pLightBuffer = nullptr;
+  }
+
+  _lightTable.clear();
+  std::vector<float> weights;
+  weights.reserve(_instances.size());
+
+  constexpr float kPi = 3.14159265358979323846f;
+
+  auto primitiveArea = [&](const InstanceRecord &inst,
+                           size_t primIndex) -> float {
+    size_t base = primIndex * kPrimitiveStride;
+    if (base + 3 >= inst.primitiveData.size())
+      return 0.0f;
+    const simd::float4 &p0 = inst.primitiveData[base + 0];
+    const simd::float4 &p1 = inst.primitiveData[base + 1];
+    const simd::float4 &p2 = inst.primitiveData[base + 2];
+    const simd::float4 &p3 = inst.primitiveData[base + 3];
+    int type = static_cast<int>(p0.w);
+    switch (type) {
+    case 0: {
+      float radius = p1.x;
+      return 4.0f * kPi * radius * radius;
+    }
+    case 1: {
+      simd::float3 edge1 = p1.xyz;
+      simd::float3 edge2 = p2.xyz;
+      simd::float3 crossProd = simd::cross(edge1, edge2);
+      float len = simd::length(crossProd);
+      return 0.5f * len;
+    }
+    case 2: {
+      simd::float3 u = p1.xyz;
+      simd::float3 v = p2.xyz;
+      simd::float3 crossProd = simd::cross(u, v);
+      float len = simd::length(crossProd);
+      return 4.0f * len;
+    }
+    default:
+      break;
+    }
+    return 0.0f;
+  };
+
+  double totalWeight = 0.0;
+
+  for (size_t instIndex = 0; instIndex < _instances.size(); ++instIndex) {
+    const InstanceRecord &inst = _instances[instIndex];
+    if (inst.state != ResidencyState::Resident)
+      continue;
+    if (inst.cpuPrimitiveCount == 0)
+      continue;
+
+    for (uint32_t prim = 0; prim < inst.cpuPrimitiveCount; ++prim) {
+      size_t matBase = static_cast<size_t>(prim) * 2;
+      if (matBase + 1 >= inst.materialData.size())
+        continue;
+      const simd::float4 &m1 = inst.materialData[matBase + 1];
+      simd::float3 emissionColor = {m1.x, m1.y, m1.z};
+      float emissionPower = m1.w;
+      if (emissionPower <= 0.0f)
+        continue;
+
+      simd::float3 radiance = emissionColor * emissionPower;
+      float luminance = 0.2126f * radiance.x + 0.7152f * radiance.y +
+                        0.0722f * radiance.z;
+      if (luminance <= 0.0f)
+        continue;
+
+      float area = primitiveArea(inst, prim);
+      if (area <= 0.0f)
+        continue;
+
+      GPULightData light{};
+      light.meta = simd::make_float4(encodeUInt32(static_cast<uint32_t>(instIndex)),
+                                     encodeUInt32(static_cast<uint32_t>(prim)),
+                                     area, 0.0f);
+      light.emission = simd::make_float4(emissionColor, emissionPower);
+      light.cdf = simd::make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+
+      _lightTable.push_back(light);
+      float weight = luminance * area;
+      weights.push_back(weight);
+      totalWeight += static_cast<double>(weight);
+    }
+  }
+
+  if (_lightTable.empty() || totalWeight <= 0.0) {
+    _lightTable.clear();
+    _lightTableDirty = false;
+    return;
+  }
+
+  float cumulative = 0.0f;
+  for (size_t i = 0; i < _lightTable.size(); ++i) {
+    float weight = weights[i];
+    float pdf = weight > 0.0f ? static_cast<float>(weight / totalWeight) : 0.0f;
+    cumulative += pdf;
+    _lightTable[i].meta.w = pdf;
+    _lightTable[i].cdf.x = cumulative;
+  }
+  _lightTable.back().cdf.x = 1.0f;
+
+  size_t bufferSize = _lightTable.size() * sizeof(GPULightData);
+  if (!ensureBudget(bufferSize)) {
+    _lightTable.clear();
+    _lightTableDirty = false;
+    return;
+  }
+
+  _pLightBuffer =
+      _pDevice->newBuffer(bufferSize, MTL::ResourceStorageModeManaged);
+  std::memcpy(_pLightBuffer->contents(), _lightTable.data(), bufferSize);
+  _pLightBuffer->didModifyRange(NS::Range::Make(0, bufferSize));
+
+  _lightTableDirty = false;
 }
 
 std::pair<size_t, size_t> Renderer::calculateOffloadedResidency() const {

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -131,6 +131,12 @@ private:
     uint32_t rootNodeIndex = 0;
   };
 
+  struct GPULightData {
+    simd::float4 meta;
+    simd::float4 emission;
+    simd::float4 cdf;
+  };
+
   struct InstanceRecord {
     size_t primitiveIndex = 0;
     uint32_t meshId = kInvalidMeshId;
@@ -151,12 +157,15 @@ private:
 
   std::vector<InstanceRecord> _instances;
   std::vector<size_t> _instancesPendingRelease;
+  std::vector<GPULightData> _lightTable;
 
   bool streamInInstance(size_t index);
   void streamOutInstance(size_t index);
   void releaseInstanceResources(size_t index);
   void updateInstanceArgument(size_t index);
   void updateInstanceMetadata(size_t index);
+  void rebuildLightTable();
+  void markLightTableDirty();
   void rebuildTLAS();
   void refreshActiveNodeCount();
   std::pair<size_t, size_t> calculateOffloadedResidency() const;
@@ -172,6 +181,9 @@ private:
                            MTL::Buffer **outBuffer);
 
   bool _pendingAccumulationReset = false;
+  bool _lightTableDirty = true;
+
+  MTL::Buffer *_pLightBuffer = nullptr;
 
   void updateLODByDistance();
 

--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -12,6 +12,7 @@ float4 fragment fragmentMain(
     constant InstanceMetadata* instanceMetadata [[buffer(2)]],
     device InstanceArgumentBuffer& instanceArgs [[buffer(3)]],
     device const int* tlasInstanceIndices [[buffer(4)]],
+    device const Light* lights [[buffer(5)]],
     texture2d<float, access::read_write> lastFrame [[texture(0)]],
     texture2d<float, access::read_write> currentFrame [[texture(1)]])
 
@@ -53,6 +54,8 @@ float4 fragment fragmentMain(
         u.tlasNodeCount,
         instanceArgs,
         instanceMetadata,
+        lights,
+        u.lightCount,
         seed,
         u.maxRayDepth,
         u.debugAS,

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -64,13 +64,16 @@ inline intersection firstHitBVH(thread const ray &r,
                                 device const int *primitiveIndices,
                                 uint primitiveCount,
                                 int startNode,
-                                int instanceId) {
+                                int instanceId,
+                                float tMax = INFINITY) {
   intersection in;
-  in.t = INFINITY;
+  in.t = tMax;
   in.primitiveId = -1;
   in.isTriangle = 0;
   in.nodeIndex = -1;
   in.instanceId = instanceId;
+
+  bool foundHit = false;
 
   constexpr int stackSize = 64;
   int stack[stackSize];
@@ -85,7 +88,8 @@ inline intersection firstHitBVH(thread const ray &r,
     int leftFirst = as_type<int>(bvhNodes[2 * nodeIdx + 0].w);
     int second = as_type<int>(bvhNodes[2 * nodeIdx + 1].w);
 
-    if (!intersectAABB(r, bmin, bmax, 0.0001, in.t))
+    float currentMax = foundHit ? in.t : tMax;
+    if (!intersectAABB(r, bmin, bmax, 0.0001, currentMax))
       continue;
 
     if (second > 0) {
@@ -184,13 +188,14 @@ inline intersection firstHitBVH(thread const ray &r,
           }
         }
 
-        if (hitThis && tHit < in.t) {
+        if (hitThis && tHit < in.t && tHit < tMax) {
           in.t = tHit;
           in.primitiveId = primIdx;
           in.normal = n;
           in.point = hit;
           in.isTriangle = primitiveType;
           in.nodeIndex = nodeIdx;
+          foundHit = true;
         }
       }
     } else {
@@ -198,6 +203,10 @@ inline intersection firstHitBVH(thread const ray &r,
       stack[stackPtr++] = leftFirst;
       stack[stackPtr++] = rightChild;
     }
+  }
+
+  if (!foundHit) {
+    in.t = INFINITY;
   }
 
   if (in.primitiveId != -1) {
@@ -209,12 +218,148 @@ inline intersection firstHitBVH(thread const ray &r,
   return in;
 }
 
+inline bool isOccluded(const ray &shadowRay, float maxDistance,
+                       device const float4 *tlasNodes,
+                       device const int *tlasInstanceIndices,
+                       uint tlasNodeCount,
+                       device InstanceArgumentBuffer &instanceArgs,
+                       constant InstanceMetadata *instanceMetadata,
+                       uint targetInstance,
+                       int targetPrimitive) {
+  if (tlasNodeCount == 0)
+    return false;
+
+  constexpr int stackSize = 128;
+  int stack[stackSize];
+  int stackPtr = 0;
+  stack[stackPtr++] = 0;
+
+  while (stackPtr > 0) {
+    int nodeIdx = stack[--stackPtr];
+    float3 bmin = tlasNodes[2 * nodeIdx + 0].xyz;
+    float3 bmax = tlasNodes[2 * nodeIdx + 1].xyz;
+    int leftFirst = as_type<int>(tlasNodes[2 * nodeIdx + 0].w);
+    int second = as_type<int>(tlasNodes[2 * nodeIdx + 1].w);
+
+    if (!intersectAABB(shadowRay, bmin, bmax, 0.0001, maxDistance))
+      continue;
+
+    if (second > 0) {
+      for (int i = 0; i < second; ++i) {
+        int instanceId = tlasInstanceIndices[leftFirst + i];
+        if (instanceId < 0 || instanceId >= MAX_INSTANCE_COUNT)
+          continue;
+        const constant InstanceMetadata &meta = instanceMetadata[instanceId];
+        if (meta.primitiveCount == 0)
+          continue;
+        const device InstanceResources &resources =
+            instanceArgs.instances[instanceId];
+
+        intersection hit = firstHitBVH(shadowRay, resources.blasNodes,
+                                       resources.primitives,
+                                       resources.primitiveIndices,
+                                       meta.primitiveCount,
+                                       int(meta.rootNodeIndex), instanceId,
+                                       maxDistance);
+        if (hit.primitiveId != -1) {
+          if (instanceId == int(targetInstance) &&
+              targetPrimitive >= 0 &&
+              hit.primitiveId == targetPrimitive) {
+            // Ignore the sampled light itself when it is exactly at the
+            // maximum distance.
+            if (hit.t >= maxDistance * 0.999f)
+              continue;
+          }
+          return true;
+        }
+      }
+    } else {
+      int rightChild = -second;
+      stack[stackPtr++] = leftFirst;
+      stack[stackPtr++] = rightChild;
+    }
+  }
+
+  return false;
+}
+
+inline bool sampleLightPrimitive(int primitiveType,
+                                 device const float4 *primitives,
+                                 int baseIndex,
+                                 thread uint32_t &seed,
+                                 thread float3 &position,
+                                 thread float3 &normal) {
+  float4 p0 = primitives[baseIndex + 0];
+  float4 p1 = primitives[baseIndex + 1];
+  float4 p2 = primitives[baseIndex + 2];
+  float4 p3 = primitives[baseIndex + 3];
+
+  if (primitiveType == 0) {
+    float3 center = p0.xyz;
+    float radius = p1.x;
+    float u1 = randomFloat(seed);
+    seed = random(seed);
+    float u2 = randomFloat(seed);
+    seed = random(seed);
+    float z = 1.0 - 2.0 * u1;
+    float r = sqrt(fmax(0.0, 1.0 - z * z));
+    float phi = 2.0 * M_PI * u2;
+    float x = r * cos(phi);
+    float y = r * sin(phi);
+    normal = normalize(float3(x, y, z));
+    position = center + radius * normal;
+    return true;
+  } else if (primitiveType == 1) {
+    float3 v0 = p0.xyz;
+    float3 edge1 = p1.xyz;
+    float3 edge2 = p2.xyz;
+    float u1 = randomFloat(seed);
+    seed = random(seed);
+    float u2 = randomFloat(seed);
+    seed = random(seed);
+    float su1 = sqrt(u1);
+    float b0 = 1.0 - su1;
+    float b1 = su1 * (1.0 - u2);
+    float b2 = su1 * u2;
+    position = v0 + b1 * edge1 + b2 * edge2;
+    normal = p3.xyz;
+    float lenSq = dot(normal, normal);
+    if (lenSq < 1e-12)
+      normal = normalize(cross(edge1, edge2));
+    else
+      normal = normalize(normal);
+    return true;
+  } else if (primitiveType == 2) {
+    float3 center = p0.xyz;
+    float3 u = p1.xyz;
+    float3 v = p2.xyz;
+    float u1 = randomFloat(seed);
+    seed = random(seed);
+    float u2 = randomFloat(seed);
+    seed = random(seed);
+    float sx = 2.0 * u1 - 1.0;
+    float sy = 2.0 * u2 - 1.0;
+    position = center + sx * u + sy * v;
+    normal = p3.xyz;
+    float lenSq = dot(normal, normal);
+    if (lenSq < 1e-12)
+      normal = normalize(cross(u, v));
+    else
+      normal = normalize(normal);
+    return true;
+  }
+
+  return false;
+}
+
 inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
                        device const float4 *tlasNodes,
                        device const int *tlasInstanceIndices,
                        uint tlasNodeCount,
                        device InstanceArgumentBuffer &instanceArgs,
                        constant InstanceMetadata *instanceMetadata,
+                       device const Light *lights,
+                       uint lightCount,
                        thread uint32_t &seed, uint maxRayDepth,
                        uint debugAS, uint blasNodeCount) {
   float footprint = length(cross(rayDx, rayDy));
@@ -303,8 +448,8 @@ inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
     return float4(0.0, 0.0, 0.0, 1.0);
   }
 
-  float4 absorption = float4(1.0);
-  float4 light = float4(0.0);
+  float3 throughput = float3(1.0);
+  float3 radiance = float3(0.0);
 
   for (uint depth = 0; depth < maxRayDepth; ++depth) {
     intersection bestHit;
@@ -363,7 +508,7 @@ inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
       float3 unitDir = normalize(r.direction);
       float t = 0.5 * (unitDir.y + 1.0);
       float3 skyColor = mix(float3(1.0), float3(0.6, 0.7, 1.0), t);
-      light += absorption * float4(skyColor, 1.0);
+      radiance += throughput * skyColor;
       break;
     }
     int matIndex = bestHit.primitiveId * 2;
@@ -381,27 +526,123 @@ inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
     float3 emissionColor = m1.xyz;
     float emissionPower = m1.w;
 
-    if (emissionPower > 0.0 || materialType == 2) {
-      light += absorption * float4(emissionColor, 1.0) * emissionPower;
+    bool isEmitter = (emissionPower > 0.0 || materialType == 2);
+    if (isEmitter) {
+      radiance += throughput * (emissionColor * emissionPower);
+    }
+
+    if (lightCount > 0 && lights != nullptr && materialType == 0.0 &&
+        !isEmitter) {
+      float selectXi = randomFloat(seed);
+      seed = random(seed);
+
+      uint chosen = 0;
+      if (lightCount > 1) {
+        uint left = 0;
+        uint right = lightCount;
+        while (left < right) {
+          uint mid = (left + right) / 2;
+          float cdf = lights[mid].cdf.x;
+          if (selectXi < cdf)
+            right = mid;
+          else
+            left = mid + 1;
+        }
+        chosen = min(left, lightCount - 1);
+      }
+
+      const device Light &lightEntry = lights[chosen];
+      float lightPdf = lightEntry.meta.w;
+      float area = lightEntry.meta.z;
+      if (lightPdf > 0.0 && area > 0.0) {
+        uint lightInstance = as_type<uint>(lightEntry.meta.x);
+        uint lightPrimitive = as_type<uint>(lightEntry.meta.y);
+        if (lightInstance < MAX_INSTANCE_COUNT) {
+          const constant InstanceMetadata &lightMeta =
+              instanceMetadata[lightInstance];
+          if (lightPrimitive < lightMeta.primitiveCount) {
+            const device InstanceResources &lightResources =
+                instanceArgs.instances[lightInstance];
+            if (lightResources.primitives != nullptr &&
+                lightResources.materials != nullptr) {
+              int baseIndex = int(lightPrimitive) * PRIMITIVE_STRIDE;
+              int maxIndex = int(lightMeta.primitiveCount) * PRIMITIVE_STRIDE;
+              if (baseIndex + 3 < maxIndex) {
+                float3 lightPos;
+                float3 lightNormal;
+                bool sampled = sampleLightPrimitive(
+                    int(lightResources.primitives[baseIndex].w),
+                    lightResources.primitives, baseIndex, seed, lightPos,
+                    lightNormal);
+                if (sampled) {
+                  float3 toLight = lightPos - bestHit.point;
+                  float distSq = dot(toLight, toLight);
+                  float dist = sqrt(distSq);
+                  if (dist > 1e-4) {
+                    float3 wi = toLight / dist;
+                    float cosSurface = fmax(0.0, dot(bestHit.normal, wi));
+                    float cosLight = fmax(0.0, dot(lightNormal, -wi));
+                    if (cosSurface > 0.0 && cosLight > 0.0) {
+                      float shadowMax = dist - 0.001;
+                      bool blocked = false;
+                      if (shadowMax > 0.0) {
+                        ray shadowRay{bestHit.point + bestHit.normal * 0.0005f,
+                                      wi};
+                        shadowRay.min_distance = 0.0001f;
+                        shadowRay.max_distance = shadowMax;
+                        blocked = isOccluded(
+                            shadowRay, shadowMax, tlasNodes, tlasInstanceIndices,
+                            tlasNodeCount, instanceArgs, instanceMetadata,
+                            lightInstance, int(lightPrimitive));
+                      }
+                      if (!blocked) {
+                        float3 emission = lightEntry.emission.xyz *
+                                          lightEntry.emission.w;
+                        float pdfArea = lightPdf / area;
+                        if (pdfArea > 0.0) {
+                          float3 bsdfVal = evaluateBSDF(-r.direction, wi,
+                                                        bestHit.normal,
+                                                        materialType, albedo);
+                          float geometry = cosLight / max(distSq, 1e-6f);
+                          float3 direct = emission * bsdfVal * cosSurface *
+                                          geometry / pdfArea;
+                          radiance += throughput * direct;
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
 
     float3 offsetNormal = bestHit.frontFace ? bestHit.normal : -bestHit.normal;
     r.origin = bestHit.point + 0.0001 * offsetNormal;
-    scatter(r, bestHit, materialType, seed);
-    seed = random(seed);
-    absorption *= float4(albedo, 1.0);
+    BSDFSample sample = sampleBSDF(r.direction, bestHit.normal,
+                                   bestHit.frontFace, materialType, albedo,
+                                   seed);
+    if (sample.pdf <= 0.0 || all(sample.weight <= float3(0.0)))
+      break;
+
+    throughput *= sample.weight;
+    r.direction = sample.direction;
+    r.min_distance = 0.0001;
+    r.max_distance = INFINITY;
 
     if (depth >= 5) {
-      float p = max(absorption.x, max(absorption.y, absorption.z));
+      float p = max(throughput.x, max(throughput.y, throughput.z));
       float randVal = randomFloat(seed);
       seed = random(seed);
       if (randVal >= p)
         break;
-      absorption /= p;
+      throughput /= p;
     }
   }
 
-  return clamp(light, 0.0, 1.0);
+  return float4(clamp(radiance, 0.0, 1.0), 1.0);
 }
 
 #endif

--- a/MetalCpp Path Tracer/Renderer/Shaders/Scatter.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Scatter.h
@@ -7,39 +7,103 @@
 #include "Random.h"
 #include "Structs.h"
 
-inline bool mirrorAngle(float refractionIndex, thread const float3 &normal, thread const float3 &rayDir, thread uint32_t &seed)
-{
-    const float cosTheta = dot(-1*rayDir, normal);
-    const float sinTheta = sqrt(1.0 - cosTheta*cosTheta);
-    
-    auto r0 =  (1 - refractionIndex) / (1 + refractionIndex);
-    r0 = r0*r0;
-    const float reflectance = r0 + (1-r0)*pow((1 - cosTheta),5);
+struct BSDFSample {
+  float3 direction;
+  float3 weight; // bsdf * cos(theta) / pdf contribution
+  float pdf;
+  bool isDelta;
+};
 
-    return ((refractionIndex * sinTheta > 1.0) || (reflectance > randomFloat(seed)));
+inline bool mirrorAngle(float refractionIndex, thread const float3 &normal,
+                        thread const float3 &rayDir, thread uint32_t &seed) {
+  const float cosTheta = dot(-1 * rayDir, normal);
+  const float sinTheta = sqrt(fmax(0.0, 1.0 - cosTheta * cosTheta));
+
+  float r0 = (1 - refractionIndex) / (1 + refractionIndex);
+  r0 = r0 * r0;
+  const float reflectance = r0 + (1 - r0) * pow((1 - cosTheta), 5.0);
+
+  return ((refractionIndex * sinTheta > 1.0) ||
+          (reflectance > randomFloat(seed)));
 }
 
-inline void scatter(thread ray &r, thread const intersection &i, float materialType, thread uint32_t &seed)
-{
-    if(!materialType)
-    {
-        r.direction = i.normal + normalize(randomFloat3(seed));
-    }
-    else if(materialType < 0)
-    {
-        r.direction = reflect(r.direction, i.normal);
-    }
-    else
-    {
-        float rIndex = materialType;
-        rIndex = i.frontFace ? 1 / rIndex : rIndex;
+inline void buildOrthonormalBasis(const float3 &n, thread float3 &t,
+                                  thread float3 &b) {
+  if (fabs(n.z) < 0.999) {
+    t = normalize(cross(n, float3(0.0, 0.0, 1.0)));
+  } else {
+    t = normalize(cross(n, float3(0.0, 1.0, 0.0)));
+  }
+  b = cross(n, t);
+}
 
-        r.direction = mirrorAngle(rIndex, i.normal, r.direction, seed) ?
-                                    reflect(r.direction, i.normal) :
-                                    refract(r.direction, i.normal, rIndex);
-    }
+inline BSDFSample sampleBSDF(const float3 &inDir, const float3 &normal,
+                             bool frontFace, float materialType,
+                             const float3 &albedo, thread uint32_t &seed) {
+  BSDFSample s;
+  s.direction = normal;
+  s.weight = float3(0.0);
+  s.pdf = 0.0;
+  s.isDelta = false;
 
-    r.direction = normalize(r.direction);
+  if (materialType == 0.0) {
+    // Diffuse (Lambertian)
+    float u1 = randomFloat(seed);
+    seed = random(seed);
+    float u2 = randomFloat(seed);
+    seed = random(seed);
+
+    float r = sqrt(u1);
+    float theta = 2.0 * M_PI * u2;
+    float x = r * cos(theta);
+    float y = r * sin(theta);
+    float z = sqrt(fmax(0.0, 1.0 - u1));
+
+    float3 tangent, bitangent;
+    buildOrthonormalBasis(normal, tangent, bitangent);
+    float3 sampled = tangent * x + bitangent * y + normal * z;
+    s.direction = normalize(sampled);
+
+    float cosTheta = fmax(0.0, dot(s.direction, normal));
+    s.pdf = cosTheta / M_PI;
+    if (s.pdf > 0.0) {
+      s.weight = albedo;
+    }
+  } else if (materialType < 0.0) {
+    // Perfect mirror
+    float3 dir = reflect(inDir, normal);
+    s.direction = normalize(dir);
+    s.pdf = 1.0;
+    s.weight = albedo;
+    s.isDelta = true;
+  } else {
+    // Dielectric with simple Fresnel reflection/refraction
+    float eta = materialType;
+    eta = frontFace ? (1.0 / eta) : eta;
+    bool reflectDir = mirrorAngle(eta, normal, inDir, seed);
+    float3 dir = reflectDir ? reflect(inDir, normal)
+                            : refract(inDir, normal, eta);
+    s.direction = normalize(dir);
+    s.pdf = 1.0;
+    s.weight = albedo;
+    s.isDelta = true;
+    seed = random(seed);
+  }
+
+  return s;
+}
+
+inline float3 evaluateBSDF(const float3 &inDir, const float3 &outDir,
+                           const float3 &normal, float materialType,
+                           const float3 &albedo) {
+  if (materialType == 0.0) {
+    float cosTheta = fmax(0.0, dot(outDir, normal));
+    if (cosTheta <= 0.0)
+      return float3(0.0);
+    return albedo / M_PI;
+  }
+  // Delta materials have zero contribution for arbitrary directions
+  return float3(0.0);
 }
 
 #endif

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -45,6 +45,13 @@ struct InstanceArgumentBuffer
     metal::array<InstanceResources, MAX_INSTANCE_COUNT> instances;
 };
 
+struct Light
+{
+    float4 meta;     // instanceId bits, primitiveIndex bits, area, light selection PDF
+    float4 emission; // emissionColor, emissionPower
+    float4 cdf;      // cumulative probability, padding
+};
+
 
 struct UniformsData
 {
@@ -70,6 +77,8 @@ struct UniformsData
     uint debugAS;
     uint residentInstanceCount;
     uint totalInstanceCount;
+    uint lightCount;
+    uint paddingUniforms[3];
 };
 
 


### PR DESCRIPTION
## Summary
- collect emissive primitives on the CPU, build a weighted light table, and upload it through a dedicated buffer
- extend uniforms and fragment bindings so the GPU path tracer can sample lights and check visibility per bounce
- refactor BSDF sampling/evaluation to return weights and PDFs, enabling direct-light estimates alongside throughput updates

## Testing
- not run (Metal toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d5321f3204832d931f42882fcd3813