### PR TITLE
Improve frame sampling stability

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1323,7 +1323,6 @@ void Renderer::rebuildLightTable() {
     const simd::float4 &p0 = inst.primitiveData[base + 0];
     const simd::float4 &p1 = inst.primitiveData[base + 1];
     const simd::float4 &p2 = inst.primitiveData[base + 2];
-    const simd::float4 &p3 = inst.primitiveData[base + 3];
     int type = static_cast<int>(p0.w);
     switch (type) {
     case 0: {

--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -25,7 +25,12 @@ float4 fragment fragmentMain(
         lastFrame.write(0, coord);
     }
 
-    uint32_t seed = random(in.uv, u.randomSeed.xyz) * ((uint32_t)-1);
+    uint seed = uint(random(in.uv, u.randomSeed.xyz) * 4294967295.0);
+
+    ulong frameIndex = u.frameCount;
+    uint frameHash = uint((frameIndex & 0xfffffffful) ^ (frameIndex >> 32));
+    seed ^= frameHash * 747796405u + 2891336453u;
+    seed = random(seed);
 
     float xOff = (randomFloat(seed) - 0.5) / u.screenSize.x;
     seed = random(seed);

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -318,7 +318,6 @@ inline bool sampleLightPrimitive(int primitiveType,
     float u2 = randomFloat(seed);
     seed = random(seed);
     float su1 = sqrt(u1);
-    float b0 = 1.0 - su1;
     float b1 = su1 * (1.0 - u2);
     float b2 = su1 * u2;
     position = v0 + b1 * edge1 + b2 * edge2;


### PR DESCRIPTION
## Summary
- mix the frame counter into the fragment shader seed so each accumulation adds a fresh Monte Carlo sample
- remove unused variables flagged by the compiler in both the shader sampler and light-table setup

## Testing
- Not run (platform-specific project)


------
https://chatgpt.com/codex/tasks/task_e_68d53a8ee6f8832da2773e257e8690cf