### PR TITLE
Keep resident meshes from being evicted immediately

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -613,6 +613,14 @@ void Renderer::updateLODByDistance() {
     float dist = simd::length(bounds.center - Camera::position) - bounds.radius;
     dist = std::max(dist, 0.0f);
     bool within = dist < FULL_DETAIL_DISTANCE;
+    if (!within && _instances[i].state == ResidencyState::Resident) {
+      // Keep instances that are already resident even if they fall outside of
+      // the full-detail distance. Without this, meshes that were streamed in
+      // during preload immediately become candidates for eviction on the next
+      // frame and disappear even when there is enough budget to keep them
+      // resident.
+      within = true;
+    }
     candidates.push_back({i, dist, within});
   }
 


### PR DESCRIPTION
## Summary
- keep already-resident instances marked as within the full-detail distance so they are not dropped on the next frame
- prevent preloaded meshes from disappearing despite sufficient GPU budget

## Testing
- not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_e_68d53cc48f78832daba2208c58a5b6b9