### PR TITLE
Handle scenes without emissive lights

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1403,6 +1403,23 @@ void Renderer::rebuildLightTable() {
   if (_lightTable.empty() || totalWeight <= 0.0) {
     _lightTable.clear();
     _lightTableDirty = false;
+
+    // Ensure the shader always has a valid buffer bound even when no emissive
+    // primitives are present. Metal validation requires that all buffer slots
+    // used by the shader are populated, so create a small dummy buffer in this
+    // case instead of leaving it null.
+    GPULightData emptyLight{};
+    size_t bufferSize = sizeof(GPULightData);
+    if (!_pLightBuffer) {
+      _pLightBuffer =
+          _pDevice->newBuffer(bufferSize, MTL::ResourceStorageModeManaged);
+    }
+
+    if (_pLightBuffer && _pLightBuffer->length() >= bufferSize) {
+      std::memcpy(_pLightBuffer->contents(), &emptyLight, bufferSize);
+      _pLightBuffer->didModifyRange(NS::Range::Make(0, bufferSize));
+    }
+
     return;
   }
 


### PR DESCRIPTION
## Summary
- ensure the renderer always binds a valid light buffer even when no emissive primitives exist
- populate a small dummy light buffer so Metal validation is satisfied for lightless scenes

## Testing
- not run (not specified)


------
https://chatgpt.com/codex/tasks/task_e_68d53e9f9370832d86f082bd907acaaf