### PR TITLE
Fix LOD streaming to use current camera pose

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -518,7 +518,7 @@ bool Renderer::updateCamera() {
   return changed;
 }
 
-void Renderer::updateUniforms() {
+void Renderer::updateUniforms(bool cameraChanged) {
   if (!_pUniformsBuffer)
     return;
 
@@ -527,7 +527,6 @@ void Renderer::updateUniforms() {
 
   UniformsData &u = *((UniformsData *)_pUniformsBuffer->contents());
 
-  bool cameraChanged = updateCamera();
   if (cameraChanged || _pendingAccumulationReset) {
     u.frameCount = 0;
     u.randomSeed = {randomFloat(), randomFloat(), randomFloat()};
@@ -551,8 +550,9 @@ void Renderer::updateUniforms() {
 }
 
 void Renderer::draw(MTK::View *pView) {
+  bool cameraChanged = updateCamera();
   updateLODByDistance();
-  updateUniforms();
+  updateUniforms(cameraChanged);
   beginFrameMetrics();
   std::swap(_accumulationTargets[0], _accumulationTargets[1]);
 

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -28,7 +28,7 @@ public:
   void recalculateViewport();
   bool updateCamera();
 
-  void updateUniforms();
+  void updateUniforms(bool cameraChanged);
   void draw(MTK::View *pView);
   void drawableSizeWillChange(MTK::View *pView, CGSize size);
 


### PR DESCRIPTION
## Summary
- update the draw loop to advance the camera before evaluating instance residency so streaming decisions use the current pose
- pass the camera-change flag into the uniform update path so accumulation resets stay in sync

## Testing
- not run (Metal-only project)

------
https://chatgpt.com/codex/tasks/task_e_68d53fb81a1c832da38a92b3f2e32b83