### PR TITLE
Add residency stress test bunny scene

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -596,6 +596,7 @@ void Renderer::draw(MTK::View *pView) {
 
 void Renderer::updateLODByDistance() {
   const float FULL_DETAIL_DISTANCE = 250.0f;
+  const float EVICT_DISTANCE = FULL_DETAIL_DISTANCE * 1.5f;
 
   if (_instances.empty()) {
     _minInstanceFootprint = 0;
@@ -617,12 +618,12 @@ void Renderer::updateLODByDistance() {
     dist = std::max(dist, 0.0f);
     bool within = dist < FULL_DETAIL_DISTANCE;
     if (!within && _instances[i].state == ResidencyState::Resident) {
-      // Keep instances that are already resident even if they fall outside of
-      // the full-detail distance. Without this, meshes that were streamed in
-      // during preload immediately become candidates for eviction on the next
-      // frame and disappear even when there is enough budget to keep them
-      // resident.
-      within = true;
+      // Allow previously resident instances to linger while the camera remains
+      // nearby, but release them once they move far enough away. This
+      // hysteresis avoids thrashing at the distance threshold yet enables large
+      // memory drops after the viewer travels to a different region.
+      if (dist <= EVICT_DISTANCE)
+        within = true;
     }
     candidates.push_back({i, dist, within});
   }

--- a/MetalCpp Path Tracer/scene_residency_hysteresis.xml
+++ b/MetalCpp Path Tracer/scene_residency_hysteresis.xml
@@ -1,0 +1,46 @@
+<Scene width="1280" height="720" maxRayDepth="32">
+    <CameraPath>
+        <!-- Begin inside the dense bunny cluster so everything is resident -->
+        <Keyframe frame="0" position="0,40,140" lookAt="0,20,0" />
+        <Keyframe frame="40" position="-40,35,120" lookAt="0,20,0" />
+        <!-- Cruise sideways across the field to keep the cluster fully visible -->
+        <Keyframe frame="120" position="60,35,150" lookAt="0,20,0" />
+        <!-- Accelerate far beyond the eviction radius toward an isolated bunny -->
+        <Keyframe frame="200" position="0,30,-420" lookAt="0,20,-520" />
+        <!-- Settle near the distant bunny to verify only it remains resident -->
+        <Keyframe frame="260" position="0,25,-460" lookAt="0,15,-560" />
+    </CameraPath>
+
+    <!-- Infinite ground plane -->
+    <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Warm area light hovering above the cluster -->
+    <Sphere position="0,120,0" radius="18" albedo="0,0,0" emission="1.2,1.1,0.9" materialType="0" emissionPower="15" />
+
+    <!-- Reflective backstop behind the cluster to keep the lighting stable -->
+    <Rectangle position="0,20,-160" u="200,0,0" v="0,120,0" albedo="0.95,0.95,0.95" emission="0,0,0" materialType="-1" emissionPower="0" />
+
+    <!-- Dense grid of bunnies that should stream out once the camera departs -->
+    <Mesh file="assets/bunny.obj" position="-60,0,40" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-20,0,40" scale="10.0" albedo="0.8,0.6,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="20,0,40" scale="10.0" albedo="0.7,0.7,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="60,0,40" scale="10.0" albedo="0.6,0.8,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <Mesh file="assets/bunny.obj" position="-60,0,0" scale="10.0" albedo="0.9,0.4,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-20,0,0" scale="10.0" albedo="0.8,0.5,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="20,0,0" scale="10.0" albedo="0.7,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="60,0,0" scale="10.0" albedo="0.6,0.7,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <Mesh file="assets/bunny.obj" position="-60,0,-40" scale="10.0" albedo="0.9,0.3,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-20,0,-40" scale="10.0" albedo="0.8,0.4,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="20,0,-40" scale="10.0" albedo="0.7,0.5,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="60,0,-40" scale="10.0" albedo="0.6,0.6,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <Mesh file="assets/bunny.obj" position="-60,0,-80" scale="10.0" albedo="0.9,0.2,0.6" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-20,0,-80" scale="10.0" albedo="0.8,0.3,0.6" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="20,0,-80" scale="10.0" albedo="0.7,0.4,0.6" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="60,0,-80" scale="10.0" albedo="0.6,0.5,0.6" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Isolated bunny far along the path that should be the only resident mesh at the end -->
+    <Mesh file="assets/bunny.obj" position="0,0,-520" scale="12.0" albedo="0.85,0.55,0.35" emission="0,0,0" materialType="0" emissionPower="0" />
+</Scene>


### PR DESCRIPTION
## Summary
- introduce an eviction distance hysteresis in `updateLODByDistance`
- allow previously resident instances to stay loaded when the camera is nearby but release them once it moves far away
- add a bunny-cluster residency test scene that forces a large GPU-memory drop after moving away

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d547affb84832d96c213b1fe6b0a64