### PR TITLE
Fix instance argument buffer sizing

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -309,8 +309,11 @@ void Renderer::buildBuffers() {
   _pInstanceMetaBuffer->didModifyRange(NS::Range::Make(0, metaSize));
 
   releaseBuffer(_pInstanceArgBuffer, _instanceArgBufferSize);
-  if (_pInstanceArgEncoder) {
-    size_t argLength = _pInstanceArgEncoder->encodedLength();
+  if (_pInstanceArgEncoder && _instanceArgStride > 0) {
+    size_t capacity = kMaxInstanceCapacity;
+    if (_instanceArgStride > std::numeric_limits<size_t>::max() / capacity)
+      return;
+    size_t argLength = _instanceArgStride * capacity;
     if (!ensureBudget(argLength))
       return;
     _pInstanceArgBuffer =
@@ -1277,9 +1280,11 @@ void Renderer::updateInstanceArgument(size_t index) {
     return;
   if (index >= kMaxInstanceCapacity)
     return;
+  if (index >= _instances.size())
+    return;
 
   size_t offset = index * _instanceArgStride;
-  if (offset + _instanceArgStride > _pInstanceArgEncoder->encodedLength())
+  if (offset + _instanceArgStride > _instanceArgBufferSize)
     return;
 
   _pInstanceArgElementEncoder->setArgumentBuffer(_pInstanceArgBuffer,


### PR DESCRIPTION
## Summary
- allocate the instance argument buffer using the per-instance stride and maximum capacity
- guard against stride overflow and use the actual buffer length when binding resources
- bail out if updateInstanceArgument is invoked for an out-of-range instance index

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d54ec12a1c832d9b9a8f77a5c5a5b7