### PR TITLE
Restore renderer to state before per-instance residency refactor

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -15,20 +15,8 @@
 #include <chrono>
 #include <simd/simd.h>
 #include <string>
-#include <unordered_map>
-#include <unordered_set>
-#include <CoreFoundation/CoreFoundation.h>
 
 using namespace MetalCppPathTracer;
-
-static constexpr size_t kMaxInstanceCapacity = 16384;
-static constexpr size_t kTLASNodeFootprintBytes = sizeof(simd::float4) * 2;
-static constexpr int kMaxTLASLeafInstances = 8;
-static constexpr double kBudgetDecreaseFactor = 0.8;
-static constexpr double kBudgetIncreaseFactor = 1.1;
-static constexpr double kBudgetIncreaseThreshold = 0.6;
-static constexpr double kBudgetDecreaseThreshold = 1.2;
-static constexpr size_t kPrimitiveStride = 4;
 
 struct UniformsData {
   int primitiveIndex;
@@ -51,17 +39,6 @@ struct UniformsData {
   uint64_t blasNodeCount;
   uint32_t maxRayDepth;
   uint32_t debugAS;
-  uint32_t residentInstanceCount;
-  uint32_t totalInstanceCount;
-  uint32_t lightCount;
-  uint32_t paddingUniforms[3];
-};
-
-struct InstanceMetadataCPU {
-  uint32_t primitiveCount;
-  uint32_t blasNodeCount;
-  uint32_t rootNodeIndex;
-  uint32_t padding;
 };
 
 inline uint32_t bitm_random() {
@@ -75,56 +52,57 @@ inline float randomFloat() {
   return (float)bitm_random() / (float)std::numeric_limits<uint32_t>::max();
 }
 
+bool Renderer::isInView(const BoundingSphere &b) {
+  simd::float3 toCenter = b.center - Camera::position;
+  float dist = simd::length(toCenter);
+  if (dist < 1e-5f)
+    return true;
+  simd::float3 dir = toCenter / dist;
+  float cosAngle = simd::dot(simd::normalize(Camera::forward), dir);
+  if (cosAngle <= 0.0f)
+    return false;
+  float angle = acosf(cosAngle);
+  float halfFov = (Camera::verticalFov * M_PI / 180.0f) * 0.5f;
+  float radiusAngle = asinf(std::min(b.radius / dist, 1.0f));
+  return angle <= halfFov + radiusAngle;
+}
+
 Renderer::Renderer(MTL::Device *pDevice)
     : _pDevice(pDevice->retain()), _pScene(new Scene()) {
   _pCommandQueue = _pDevice->newCommandQueue();
 
-  _recommendedBudget = std::numeric_limits<size_t>::max();
-  _gpuMemoryBudget = std::numeric_limits<size_t>::max();
-
   Camera::reset();
 
-  buildShaders();
   updateVisibleScene();
+  buildShaders();
   buildTextures();
 
   recalculateViewport();
 }
 
 Renderer::~Renderer() {
-  for (PendingStreamIn &pending : _pendingStreamIns) {
-    for (MTL::Buffer *buffer : pending.stagingBuffers) {
-      if (buffer)
-        buffer->release();
-    }
-    pending.stagingBuffers.clear();
-    if (pending.commandBuffer) {
-      pending.commandBuffer->waitUntilCompleted();
-      pending.commandBuffer->release();
-    }
-  }
-  _pendingStreamIns.clear();
-
-  for (size_t i = 0; i < _instances.size(); ++i)
-    releaseInstanceResources(i);
-
+  if (_pSphereBuffer)
+    _pSphereBuffer->release();
+  if (_pSphereMaterialBuffer)
+    _pSphereMaterialBuffer->release();
   if (_pTriangleVertexBuffer)
     _pTriangleVertexBuffer->release();
   if (_pTriangleIndexBuffer)
     _pTriangleIndexBuffer->release();
-  releaseBuffer(_pUniformsBuffer, _uniformsBufferSize);
-  releaseBuffer(_pTLASBuffer, _tlasBufferSize);
-  releaseBuffer(_pTLASInstanceIndexBuffer, _tlasInstanceIndexBufferSize);
-  releaseBuffer(_pInstanceMetaBuffer, _instanceMetaBufferSize);
-  releaseBuffer(_pInstanceArgBuffer, _instanceArgBufferSize);
-  if (_pInstanceArgElementEncoder)
-    _pInstanceArgElementEncoder->release();
-  if (_pInstanceArgEncoder)
-    _pInstanceArgEncoder->release();
-  releaseBuffer(_pLightBuffer, _lightBufferSize);
+  if (_pUniformsBuffer)
+    _pUniformsBuffer->release();
+  if (_pBVHBuffer)
+    _pBVHBuffer->release();
+  if (_pPrimitiveIndexBuffer)
+    _pPrimitiveIndexBuffer->release();
+  if (_pTLASBuffer)
+    _pTLASBuffer->release();
+  if (_pActiveBuffer)
+    _pActiveBuffer->release();
 
   for (int i = 0; i < 2; i++)
-    releaseTexture(_accumulationTargets[i], _accumulationTargetSizes[i]);
+    if (_accumulationTargets[i])
+      _accumulationTargets[i]->release();
 
   if (_pPSO)
     _pPSO->release();
@@ -165,50 +143,6 @@ void Renderer::buildShaders() {
     assert(false);
   }
 
-  if (_pInstanceArgEncoder) {
-    _pInstanceArgEncoder->release();
-    _pInstanceArgEncoder = nullptr;
-  }
-  if (_pInstanceArgElementEncoder) {
-    _pInstanceArgElementEncoder->release();
-    _pInstanceArgElementEncoder = nullptr;
-  }
-  _instanceArgStride = 0;
-  _pInstanceArgEncoder = pFragFn->newArgumentEncoder(NS::UInteger(3));
-  if (_pInstanceArgEncoder) {
-    // Build an element encoder that matches InstanceResources { id(0)..id(3) }
-    MTL::ArgumentDescriptor* d0 = MTL::ArgumentDescriptor::argumentDescriptor();
-    d0->setIndex(NS::UInteger(0));
-    d0->setDataType(MTL::DataType::DataTypePointer);
-    d0->setAccess(MTL::BindingAccess::ArgumentAccessReadOnly);
-    MTL::ArgumentDescriptor* d1 = MTL::ArgumentDescriptor::argumentDescriptor();
-    d1->setIndex(NS::UInteger(1));
-    d1->setDataType(MTL::DataType::DataTypePointer);
-    d1->setAccess(MTL::BindingAccess::ArgumentAccessReadOnly);
-    MTL::ArgumentDescriptor* d2 = MTL::ArgumentDescriptor::argumentDescriptor();
-    d2->setIndex(NS::UInteger(2));
-    d2->setDataType(MTL::DataType::DataTypePointer);
-    d2->setAccess(MTL::BindingAccess::ArgumentAccessReadOnly);
-    MTL::ArgumentDescriptor* d3 = MTL::ArgumentDescriptor::argumentDescriptor();
-    d3->setIndex(NS::UInteger(3));
-    d3->setDataType(MTL::DataType::DataTypePointer);
-    d3->setAccess(MTL::BindingAccess::ArgumentAccessReadOnly);
-    CFTypeRef descs[] = { (CFTypeRef)d0, (CFTypeRef)d1, (CFTypeRef)d2, (CFTypeRef)d3 };
-    NS::Array* descArray = (NS::Array*)CFArrayCreate(kCFAllocatorDefault, descs, 4, &kCFTypeArrayCallBacks);
-    _pInstanceArgElementEncoder = _pDevice->newArgumentEncoder(descArray);
-    descArray->release();
-    if (_pInstanceArgElementEncoder) {
-      size_t elementLength = _pInstanceArgElementEncoder->encodedLength();
-      size_t elementAlignment = _pInstanceArgElementEncoder->alignment();
-      if (elementAlignment > 0) {
-        size_t remainder = elementLength % elementAlignment;
-        if (remainder != 0)
-          elementLength += elementAlignment - remainder;
-      }
-      _instanceArgStride = elementLength;
-    }
-  }
-
   pVertexFn->release();
   pFragFn->release();
   pDesc->release();
@@ -236,11 +170,29 @@ void Renderer::updateVisibleScene() {
          _pScene->getPrimitiveCount(), _pScene->getSphereCount(),
          _pScene->getTriangleCount(), _pScene->getRectangleCount());
 
-  // Store full primitive list and initialize per-instance data
+  // Store full primitive list and initialize tracking
   _allPrimitives = _pScene->getPrimitives();
-  initializeInstances();
+  size_t primCount = _allPrimitives.size();
+  _activePrimitive.assign(primCount, true);
+  _primitiveBounds.resize(primCount);
+  for (size_t i = 0; i < primCount; ++i) {
+    const Primitive &p = _allPrimitives[i];
+    if (p.type == PrimitiveType::Sphere) {
+      _primitiveBounds[i] = {p.sphere.center, p.sphere.radius};
+    } else if (p.type == PrimitiveType::Triangle) {
+      simd::float3 c = (p.triangle.v0 + p.triangle.v1 + p.triangle.v2) / 3.0f;
+      float r = simd::length(p.triangle.v0 - c);
+      r = std::max(r, (float)simd::length(p.triangle.v1 - c));
+      r = std::max(r, (float)simd::length(p.triangle.v2 - c));
+      _primitiveBounds[i] = {c, r};
+    } else {
+      float r = simd::length(p.rectangle.u) + simd::length(p.rectangle.v);
+      _primitiveBounds[i] = {p.rectangle.center, r};
+    }
+  }
+
+  rebuildAccelerationStructures();
   buildBuffers();
-  preloadInitialResidency();
 }
 
 void Renderer::recalculateViewport() {
@@ -280,256 +232,116 @@ void Renderer::recalculateViewport() {
 }
 
 void Renderer::buildBuffers() {
+  const size_t primitiveCount = _pScene->getPrimitiveCount();
   const size_t uniformsDataSize = sizeof(UniformsData);
 
   // Uniforms
-  releaseBuffer(_pUniformsBuffer, _uniformsBufferSize);
+  if (_pUniformsBuffer)
+    _pUniformsBuffer->release();
   if (!ensureBudget(uniformsDataSize))
     return;
   _pUniformsBuffer =
       _pDevice->newBuffer(uniformsDataSize, MTL::ResourceStorageModeManaged);
-  if (!_pUniformsBuffer)
-    return;
-  _uniformsBufferSize = uniformsDataSize;
-  trackAllocation(_uniformsBufferSize);
   _pUniformsBuffer->didModifyRange(NS::Range::Make(0, uniformsDataSize));
 
-  releaseBuffer(_pInstanceMetaBuffer, _instanceMetaBufferSize);
-  size_t instanceCount = _instances.size();
-  size_t metaCount = instanceCount > 0 ? instanceCount : 1;
-  size_t metaSize = metaCount * sizeof(InstanceMetadataCPU);
-  if (!ensureBudget(metaSize))
-    return;
-  _pInstanceMetaBuffer =
-      _pDevice->newBuffer(metaSize, MTL::ResourceStorageModeManaged);
-  if (!_pInstanceMetaBuffer)
-    return;
-  _instanceMetaBufferSize = metaSize;
-  trackAllocation(_instanceMetaBufferSize);
-  std::memset(_pInstanceMetaBuffer->contents(), 0, metaSize);
-  _pInstanceMetaBuffer->didModifyRange(NS::Range::Make(0, metaSize));
-
-  releaseBuffer(_pInstanceArgBuffer, _instanceArgBufferSize);
-  if (_pInstanceArgEncoder && _instanceArgStride > 0) {
-    size_t capacity = kMaxInstanceCapacity;
-    if (_instanceArgStride > std::numeric_limits<size_t>::max() / capacity)
-      return;
-    size_t argLength = _instanceArgStride * capacity;
-    if (!ensureBudget(argLength))
-      return;
-    _pInstanceArgBuffer =
-        _pDevice->newBuffer(argLength, MTL::ResourceStorageModeShared);
-    if (!_pInstanceArgBuffer)
-      return;
-    _instanceArgBufferSize = argLength;
-    trackAllocation(_instanceArgBufferSize);
-    std::memset(_pInstanceArgBuffer->contents(), 0, argLength);
-    _pInstanceArgEncoder->setArgumentBuffer(_pInstanceArgBuffer, 0);
+  // Destroy previous
+  if (_pSphereBuffer) {
+    _pSphereBuffer->release();
+    _pSphereBuffer = nullptr;
+  }
+  if (_pSphereMaterialBuffer) {
+    _pSphereMaterialBuffer->release();
+    _pSphereMaterialBuffer = nullptr;
   }
 
-  rebuildTLAS();
-}
+  // ✅ Unified buffer
+  simd::float4 *primitiveBuffer = nullptr;
+  simd::float4 *materialBuffer = nullptr;
+  if (primitiveCount > 0) {
+    primitiveBuffer =
+        _pScene->createTransformsBuffer(); // 3 float4s per primitive
+    materialBuffer =
+        _pScene->createMaterialsBuffer(); // 2 float4s per primitive
+  }
 
-void Renderer::preloadInitialResidency() {
-  if (_instances.empty()) {
-    _minInstanceFootprint = 0;
-    _recentVisibleFootprint = 0;
+  const size_t primitiveSize = primitiveCount * 3 * sizeof(simd::float4);
+  const size_t materialSize = primitiveCount * 2 * sizeof(simd::float4);
+
+  size_t primitiveAlloc =
+      primitiveSize > 0 ? primitiveSize : sizeof(simd::float4);
+  size_t materialAlloc = materialSize > 0 ? materialSize : sizeof(simd::float4);
+  if (!ensureBudget(primitiveAlloc + materialAlloc)) {
+    delete[] primitiveBuffer;
+    delete[] materialBuffer;
     return;
   }
+  _pSphereBuffer =
+      _pDevice->newBuffer(primitiveAlloc, MTL::ResourceStorageModeManaged);
+  _pSphereMaterialBuffer =
+      _pDevice->newBuffer(materialAlloc, MTL::ResourceStorageModeManaged);
 
-  struct Candidate {
-    size_t index;
-    float distance;
-    size_t footprint;
-  };
-
-  std::vector<Candidate> candidates;
-  candidates.reserve(_instances.size());
-
-  float closestDistance = std::numeric_limits<float>::max();
-  size_t fallbackIndex = std::numeric_limits<size_t>::max();
-  size_t totalRequired = 0;
-  size_t minFootprint = std::numeric_limits<size_t>::max();
-
-  for (size_t i = 0; i < _instances.size(); ++i) {
-    const InstanceRecord &inst = _instances[i];
-    if (inst.cpuPrimitiveCount == 0)
-      continue;
-
-    size_t footprint = instanceFootprintBytes(inst) + kTLASNodeFootprintBytes;
-    if (footprint == 0)
-      continue;
-
-    float dist = simd::length(inst.bounds.center - Camera::position) -
-                 inst.bounds.radius;
-    dist = std::max(dist, 0.0f);
-    candidates.push_back({i, dist, footprint});
-    totalRequired += footprint;
-    minFootprint = std::min(minFootprint, footprint);
-    if (dist < closestDistance) {
-      closestDistance = dist;
-      fallbackIndex = i;
-    }
+  if (primitiveCount > 0) {
+    memcpy(_pSphereBuffer->contents(), primitiveBuffer, primitiveSize);
+    memcpy(_pSphereMaterialBuffer->contents(), materialBuffer, materialSize);
+    _pSphereBuffer->didModifyRange(NS::Range::Make(0, primitiveSize));
+    _pSphereMaterialBuffer->didModifyRange(NS::Range::Make(0, materialSize));
   }
 
-  if (candidates.empty()) {
-    _minInstanceFootprint = 0;
-    _recentVisibleFootprint = 0;
+  delete[] primitiveBuffer;
+  delete[] materialBuffer;
+
+  // Active mask buffer (1 byte per primitive)
+  if (_pActiveBuffer) {
+    _pActiveBuffer->release();
+    _pActiveBuffer = nullptr;
+  }
+  size_t activeSize = primitiveCount * sizeof(uint8_t);
+  size_t activeAlloc = activeSize > 0 ? activeSize : sizeof(uint8_t);
+  if (!ensureBudget(activeAlloc))
     return;
+  _pActiveBuffer =
+      _pDevice->newBuffer(activeAlloc, MTL::ResourceStorageModeManaged);
+  if (primitiveCount > 0) {
+    std::vector<uint8_t> activeBytes(primitiveCount);
+    for (size_t i = 0; i < primitiveCount; ++i)
+      activeBytes[i] = _activePrimitive[i] ? 1 : 0;
+    memcpy(_pActiveBuffer->contents(), activeBytes.data(), activeSize);
+    _pActiveBuffer->didModifyRange(NS::Range::Make(0, activeSize));
   }
 
-  std::sort(candidates.begin(), candidates.end(),
-            [](const Candidate &a, const Candidate &b) {
-              if (a.distance == b.distance)
-                return a.index < b.index;
-              return a.distance < b.distance;
-            });
-
-  bool hasBudget = _gpuMemoryBudget != std::numeric_limits<size_t>::max();
-  if (!_manualBudget && hasBudget && totalRequired > 0 &&
-      totalRequired > _gpuMemoryBudget) {
-    size_t previousBudget = _gpuMemoryBudget;
-    _gpuMemoryBudget = totalRequired;
-    _recommendedBudget = std::max(_recommendedBudget, _gpuMemoryBudget);
-    double prevMB =
-        static_cast<double>(previousBudget) / (1024.0 * 1024.0);
-    double newMB =
-        static_cast<double>(_gpuMemoryBudget) / (1024.0 * 1024.0);
-    printf("Expanded GPU memory budget from %.2f MB to %.2f MB for initial "
-           "residency (%zu instances).\n",
-           prevMB, newMB, candidates.size());
-    hasBudget = _gpuMemoryBudget != std::numeric_limits<size_t>::max();
-  }
-
-  size_t budgetLimit = hasBudget ? _gpuMemoryBudget
-                                 : std::numeric_limits<size_t>::max();
-  size_t preloadedBytes = 0;
-  size_t streamedCount = 0;
-
-  for (const Candidate &candidate : candidates) {
-    if (hasBudget &&
-        (candidate.footprint > budgetLimit ||
-         preloadedBytes + candidate.footprint > budgetLimit))
-      continue;
-
-    if (streamInInstance(candidate.index)) {
-      preloadedBytes += candidate.footprint;
-      streamedCount++;
-    }
-  }
-
-  if (streamedCount == 0 && fallbackIndex != std::numeric_limits<size_t>::max()) {
-    size_t footprint =
-        instanceFootprintBytes(_instances[fallbackIndex]) +
-        kTLASNodeFootprintBytes;
-    if (footprint > 0 && streamInInstance(fallbackIndex)) {
-      preloadedBytes += footprint;
-      streamedCount = 1;
-      minFootprint = std::min(minFootprint, footprint);
-    }
-  }
-
-  if (minFootprint == std::numeric_limits<size_t>::max())
-    _minInstanceFootprint = 0;
-  else
-    _minInstanceFootprint = minFootprint;
-
-  _recentVisibleFootprint = totalRequired;
-
-  if (streamedCount > 0) {
-    double mb = static_cast<double>(preloadedBytes) / (1024.0 * 1024.0);
-    printf("Preloaded %zu/%zu instances (%.2f MB) before first frame.\n",
-           streamedCount, candidates.size(), mb);
-  }
-
-  if (_residentInstanceCount > 0) {
-    _blasNodeCount = _currentBlasNodeCount;
-    refreshActiveNodeCount();
-  }
+  // Dummy triangle buffer bindings
+  simd::float3 dummyVertex = {0, 0, 0};
+  simd::uint3 dummyIndex = {0, 0, 0};
+  if (!ensureBudget(sizeof(simd::float3)))
+    return;
+  _pTriangleVertexBuffer = _pDevice->newBuffer(
+      &dummyVertex, sizeof(simd::float3), MTL::ResourceStorageModeManaged);
+  if (!ensureBudget(sizeof(simd::uint3)))
+    return;
+  _pTriangleIndexBuffer = _pDevice->newBuffer(&dummyIndex, sizeof(simd::uint3),
+                                              MTL::ResourceStorageModeManaged);
 }
 
 void Renderer::buildTextures() {
-  for (uint i = 0; i < 2; i++)
-    releaseTexture(_accumulationTargets[i], _accumulationTargetSizes[i]);
-
   MTL::TextureDescriptor *textureDescriptor =
       MTL::TextureDescriptor::alloc()->init();
 
   textureDescriptor->setPixelFormat(MTL::PixelFormat::PixelFormatRGBA32Float);
   textureDescriptor->setTextureType(MTL::TextureType::TextureType2D);
+  textureDescriptor->setWidth(Camera::screenSize.x);
+  textureDescriptor->setHeight(Camera::screenSize.y);
   textureDescriptor->setStorageMode(MTL::StorageMode::StorageModePrivate);
   textureDescriptor->setUsage(MTL::TextureUsageShaderRead |
                               MTL::TextureUsageShaderWrite);
-
-  auto attemptAllocation = [&](NS::UInteger width,
-                               NS::UInteger height) -> bool {
-    if (width == 0 || height == 0)
-      return false;
-
-    textureDescriptor->setWidth(width);
-    textureDescriptor->setHeight(height);
-
-    size_t texSize = static_cast<size_t>(width) *
-                     static_cast<size_t>(height) * 4ull * sizeof(float);
-    MTL::Texture *newTargets[2] = {nullptr, nullptr};
-    size_t newSizes[2] = {0, 0};
-    bool success = true;
-
-    for (uint i = 0; i < 2; ++i) {
-      if (!ensureBudget(texSize)) {
-        success = false;
-        break;
-      }
-
-      newTargets[i] = _pDevice->newTexture(textureDescriptor);
-      if (!newTargets[i]) {
-        success = false;
-        break;
-      }
-
-      newSizes[i] = texSize;
-      trackAllocation(texSize);
+  size_t texSize = static_cast<size_t>(Camera::screenSize.x * Camera::screenSize.y *
+                                       4 * sizeof(float));
+  for (uint i = 0; i < 2; i++) {
+    if (!ensureBudget(texSize)) {
+      textureDescriptor->release();
+      return;
     }
-
-    if (!success) {
-      for (uint i = 0; i < 2; ++i) {
-        if (newTargets[i]) {
-          trackDeallocation(newSizes[i]);
-          newTargets[i]->release();
-        }
-      }
-      return false;
-    }
-
-    for (uint i = 0; i < 2; ++i) {
-      _accumulationTargets[i] = newTargets[i];
-      _accumulationTargetSizes[i] = newSizes[i];
-    }
-
-    return true;
-  };
-
-  NS::UInteger targetWidth =
-      std::max<NS::UInteger>(1, static_cast<NS::UInteger>(Camera::screenSize.x));
-  NS::UInteger targetHeight =
-      std::max<NS::UInteger>(1, static_cast<NS::UInteger>(Camera::screenSize.y));
-
-  bool allocated = attemptAllocation(targetWidth, targetHeight);
-
-  if (!allocated) {
-    printf("Warning: Failed to allocate %.0fx%.0f accumulation targets; falling "
-           "back to 1x1 buffer.\n",
-           Camera::screenSize.x, Camera::screenSize.y);
-    allocated = attemptAllocation(1, 1);
+    _accumulationTargets[i] = _pDevice->newTexture(textureDescriptor);
   }
-
-  if (!allocated) {
-    printf("Error: Unable to allocate accumulation textures; accumulation will "
-           "be disabled.\n");
-  } else {
-    _pendingAccumulationReset = true;
-  }
-
   textureDescriptor->release();
 }
 
@@ -580,19 +392,12 @@ bool Renderer::updateCamera() {
   return changed;
 }
 
-void Renderer::updateUniforms(bool cameraChanged) {
-  if (!_pUniformsBuffer)
-    return;
-
-  if (_lightTableDirty)
-    rebuildLightTable();
-
+void Renderer::updateUniforms() {
   UniformsData &u = *((UniformsData *)_pUniformsBuffer->contents());
 
-  if (cameraChanged || _pendingAccumulationReset) {
+  if (updateCamera()) {
     u.frameCount = 0;
     u.randomSeed = {randomFloat(), randomFloat(), randomFloat()};
-    _pendingAccumulationReset = false;
   } else {
     u.frameCount++;
   }
@@ -601,21 +406,16 @@ void Renderer::updateUniforms(bool cameraChanged) {
   u.triangleCount = _pScene->getTriangleCount();
   u.totalPrimitiveCount = _allPrimitives.size();
   u.tlasNodeCount = _tlasNodeCount;
-  u.blasNodeCount = _currentBlasNodeCount;
+  u.blasNodeCount = _blasNodeCount;
   u.maxRayDepth = _pScene->maxRayDepth;
   u.debugAS = InputSystem::debugAS;
-  u.residentInstanceCount = static_cast<uint32_t>(_residentInstanceCount);
-  u.totalInstanceCount = static_cast<uint32_t>(_instances.size());
-  u.lightCount = static_cast<uint32_t>(_lightTable.size());
 
   _pUniformsBuffer->didModifyRange(NS::Range::Make(0, sizeof(UniformsData)));
 }
 
 void Renderer::draw(MTK::View *pView) {
-  processPendingStreamIns();
-  bool cameraChanged = updateCamera();
   updateLODByDistance();
-  updateUniforms(cameraChanged);
+  updateUniforms();
   beginFrameMetrics();
   std::swap(_accumulationTargets[0], _accumulationTargets[1]);
 
@@ -630,12 +430,16 @@ void Renderer::draw(MTK::View *pView) {
 
   pEnc->setRenderPipelineState(_pPSO);
 
-  pEnc->setFragmentBuffer(_pUniformsBuffer, 0, 0);
-  pEnc->setFragmentBuffer(_pTLASBuffer, 0, 1);
-  pEnc->setFragmentBuffer(_pInstanceMetaBuffer, 0, 2);
-  pEnc->setFragmentBuffer(_pInstanceArgBuffer, 0, 3);
-  pEnc->setFragmentBuffer(_pTLASInstanceIndexBuffer, 0, 4);
-  pEnc->setFragmentBuffer(_pLightBuffer, 0, 5);
+  // Always bind something for each slot
+  pEnc->setFragmentBuffer(_pBVHBuffer, 0, 0); // New!
+  pEnc->setFragmentBuffer(_pSphereBuffer, 0, 1);
+  pEnc->setFragmentBuffer(_pSphereMaterialBuffer, 0, 2);
+  pEnc->setFragmentBuffer(_pUniformsBuffer, 0, 3);
+  pEnc->setFragmentBuffer(_pTriangleVertexBuffer, 0, 4);
+  pEnc->setFragmentBuffer(_pTriangleIndexBuffer, 0, 5);
+  pEnc->setFragmentBuffer(_pPrimitiveIndexBuffer, 0, 6);
+  pEnc->setFragmentBuffer(_pTLASBuffer, 0, 7);
+  pEnc->setFragmentBuffer(_pActiveBuffer, 0, 8);
 
   pEnc->setFragmentTexture(_accumulationTargets[0], 0);
   pEnc->setFragmentTexture(_accumulationTargets[1], 1);
@@ -655,1301 +459,40 @@ void Renderer::draw(MTK::View *pView) {
 }
 
 void Renderer::updateLODByDistance() {
+  // Keep primitives active until the camera is reasonably far away.
+  // Using a larger threshold prevents the entire scene from being culled
+  // when starting far from the origin.
   const float FULL_DETAIL_DISTANCE = 250.0f;
-  const float EVICT_DISTANCE = FULL_DETAIL_DISTANCE * 1.5f;
-
-  if (_instances.empty()) {
-    _minInstanceFootprint = 0;
-    return;
-  }
-
-  struct Candidate {
-    size_t index;
-    float distance;
-    bool withinDistance;
-  };
-
-  std::vector<Candidate> candidates;
-  candidates.reserve(_instances.size());
-
-  for (size_t i = 0; i < _instances.size(); ++i) {
-    const auto &bounds = _instances[i].bounds;
-    float dist = simd::length(bounds.center - Camera::position) - bounds.radius;
+  size_t activeCount = 0;
+  for (size_t g = 0; g < _allPrimitives.size(); ++g) {
+    float dist =
+        simd::length(_primitiveBounds[g].center - Camera::position) -
+        _primitiveBounds[g].radius;
     dist = std::max(dist, 0.0f);
-    bool within = dist < FULL_DETAIL_DISTANCE;
-    if (!within && _instances[i].state == ResidencyState::Resident) {
-      // Allow previously resident instances to linger while the camera remains
-      // nearby, but release them once they move far enough away. This
-      // hysteresis avoids thrashing at the distance threshold yet enables large
-      // memory drops after the viewer travels to a different region.
-      if (dist <= EVICT_DISTANCE)
-        within = true;
-    }
-    candidates.push_back({i, dist, within});
+    bool shouldBeActive = dist < FULL_DETAIL_DISTANCE;
+    if (_activePrimitive[g] != shouldBeActive)
+      setPrimitiveActive(g, shouldBeActive);
+    if (_activePrimitive[g])
+      activeCount++;
   }
 
-  std::sort(candidates.begin(), candidates.end(),
-            [](const Candidate &a, const Candidate &b) {
-              if (a.distance == b.distance)
-                return a.index < b.index;
-              return a.distance < b.distance;
-            });
-
-  std::vector<bool> keep(_instances.size(), false);
-  bool hasBudget = _gpuMemoryBudget != std::numeric_limits<size_t>::max();
-  size_t closestIndex =
-      candidates.empty() ? std::numeric_limits<size_t>::max()
-                           : candidates.front().index;
-  size_t minFootprint = std::numeric_limits<size_t>::max();
-  size_t usedBudget = 0;
-  size_t requiredBudget = 0;
-  size_t visibleCount = 0;
-
-  for (const Candidate &candidate : candidates) {
-    size_t footprint =
-        instanceFootprintBytes(_instances[candidate.index]) +
-        kTLASNodeFootprintBytes;
-    if (footprint > 0)
-      minFootprint = std::min(minFootprint, footprint);
-    if (!candidate.withinDistance)
-      continue;
-
-    if (hasBudget && footprint > _gpuMemoryBudget) {
-      if (_manualBudget)
-        continue;
-      size_t previousBudget = _gpuMemoryBudget;
-      _gpuMemoryBudget = footprint;
-      _recommendedBudget =
-          std::max(_recommendedBudget, _gpuMemoryBudget);
-      double prevMB = static_cast<double>(previousBudget) /
-                      (1024.0 * 1024.0);
-      double newMB = static_cast<double>(_gpuMemoryBudget) /
-                     (1024.0 * 1024.0);
-      printf("Expanded GPU memory budget from %.2f MB to %.2f MB to fit instance %zu.\n",
-             prevMB, newMB, candidate.index);
-      hasBudget =
-          _gpuMemoryBudget != std::numeric_limits<size_t>::max();
-    }
-
-    if (hasBudget && footprint > _gpuMemoryBudget)
-      continue;
-
-    requiredBudget += footprint;
-    visibleCount++;
-    if (_instances[candidate.index].state == ResidencyState::Resident) {
-      keep[candidate.index] = true;
-      usedBudget += footprint;
-    }
+  if (activeCount == 0 && !_activePrimitive.empty()) {
+    // Ensure at least one primitive remains visible to avoid a blank scene
+    setPrimitiveActive(0, true);
+    activeCount = 1;
   }
 
-  _recentVisibleFootprint = requiredBudget;
-
-  if (minFootprint == std::numeric_limits<size_t>::max())
-    _minInstanceFootprint = 0;
-  else
-    _minInstanceFootprint = minFootprint;
-
-  if (hasBudget && usedBudget > _gpuMemoryBudget) {
-    for (auto it = candidates.rbegin();
-         it != candidates.rend() && usedBudget > _gpuMemoryBudget; ++it) {
-      size_t index = it->index;
-      if (!keep[index])
-        continue;
-      size_t footprint =
-          instanceFootprintBytes(_instances[index]) + kTLASNodeFootprintBytes;
-      if (footprint == 0)
-        continue;
-      keep[index] = false;
-      if (usedBudget >= footprint)
-        usedBudget -= footprint;
-    }
+  size_t newActiveNodes = _tlasNodeCount + activeCount;
+  if (newActiveNodes != _activeNodeCount) {
+    _activeNodeCount = newActiveNodes;
+    printf("Active nodes: %zu\n", _activeNodeCount);
   }
-
-  if (!_manualBudget && hasBudget && requiredBudget > 0 &&
-      requiredBudget > _gpuMemoryBudget) {
-    size_t previousBudget = _gpuMemoryBudget;
-    _gpuMemoryBudget = requiredBudget;
-    _recommendedBudget = std::max(_recommendedBudget, _gpuMemoryBudget);
-    double prevMB = static_cast<double>(previousBudget) / (1024.0 * 1024.0);
-    double newMB = static_cast<double>(_gpuMemoryBudget) / (1024.0 * 1024.0);
-    printf("Expanded GPU memory budget from %.2f MB to %.2f MB to keep %zu instances resident.\n",
-           prevMB, newMB, visibleCount);
-    hasBudget = _gpuMemoryBudget != std::numeric_limits<size_t>::max();
-  }
-
-  for (const Candidate &candidate : candidates) {
-    if (!candidate.withinDistance)
-      continue;
-    if (keep[candidate.index])
-      continue;
-
-    size_t footprint =
-        instanceFootprintBytes(_instances[candidate.index]) +
-        kTLASNodeFootprintBytes;
-    if (footprint == 0)
-      continue;
-
-    if (hasBudget && footprint > _gpuMemoryBudget) {
-      if (_manualBudget)
-        continue;
-      size_t previousBudget = _gpuMemoryBudget;
-      _gpuMemoryBudget = footprint;
-      _recommendedBudget =
-          std::max(_recommendedBudget, _gpuMemoryBudget);
-      double prevMB = static_cast<double>(previousBudget) /
-                      (1024.0 * 1024.0);
-      double newMB = static_cast<double>(_gpuMemoryBudget) /
-                     (1024.0 * 1024.0);
-      printf("Expanded GPU memory budget from %.2f MB to %.2f MB to fit instance %zu.\n",
-             prevMB, newMB, candidate.index);
-      hasBudget =
-          _gpuMemoryBudget != std::numeric_limits<size_t>::max();
-    }
-
-    if (hasBudget) {
-      if (footprint > _gpuMemoryBudget)
-        continue;
-      if (usedBudget + footprint > _gpuMemoryBudget)
-        continue;
-    }
-
-    keep[candidate.index] = true;
-    usedBudget += footprint;
-  }
-
-  if (!candidates.empty() &&
-      std::none_of(keep.begin(), keep.end(), [](bool value) { return value; })) {
-    keep[closestIndex] = true;
-  }
-
-  bool residencyChanged = false;
-
-  for (size_t i = 0; i < _instances.size(); ++i) {
-    if (!keep[i] && _instances[i].state == ResidencyState::Resident) {
-      streamOutInstance(i);
-      residencyChanged = true;
-    }
-  }
-
-  for (size_t i = 0; i < _instances.size(); ++i) {
-    if (keep[i]) {
-      if (streamInInstance(i))
-        residencyChanged = true;
-    }
-  }
-
-  if (_residentInstanceCount == 0 && !_instances.empty()) {
-    size_t fallbackIndex = closestIndex == std::numeric_limits<size_t>::max()
-                               ? 0
-                               : closestIndex;
-    if (streamInInstance(fallbackIndex))
-      residencyChanged = true;
-  }
-
-  if (residencyChanged) {
-    _blasNodeCount = _currentBlasNodeCount;
-    refreshActiveNodeCount();
-  }
-}
-
-void Renderer::initializeInstances() {
-  for (size_t i = 0; i < _instances.size(); ++i)
-    releaseInstanceResources(i);
-  _instances.clear();
-  _instancesPendingRelease.clear();
-  _residentInstanceCount = 0;
-  _currentBlasNodeCount = 0;
-  _tlasNodeCount = 0;
-  _activeNodeCount = 0;
-  _blasNodeCount = 0;
-  _cpuBlasNodeCount = 0;
-  _totalNodeCount = 0;
-  _minInstanceFootprint = 0;
-  _recentVisibleFootprint = 0;
-  _lastOffloadedNodeCount = 0;
-  _lastOffloadedInstanceCount = 0;
-  markLightTableDirty();
-
-  size_t primitiveCount = _allPrimitives.size();
-  if (primitiveCount > kMaxInstanceCapacity) {
-    printf(
-        "Warning: Scene has %zu primitives but only %zu instances are supported; "
-        "excess primitives will be ignored.\n",
-        primitiveCount, kMaxInstanceCapacity);
-    primitiveCount = kMaxInstanceCapacity;
-  }
-
-  _instances.reserve(primitiveCount);
-
-  auto finalizeInstance = [](InstanceRecord &inst) {
-    if (inst.cpuPrimitiveCount == 0)
-      return;
-
-    inst.bounds.center = (inst.aabbMin + inst.aabbMax) * 0.5f;
-    inst.bounds.radius =
-        simd::length(inst.aabbMax - inst.bounds.center);
-
-    struct BuildPrim {
-      int index;
-      simd::float3 min;
-      simd::float3 max;
-      simd::float3 centroid;
-    };
-
-    struct BlasNodeCPU {
-      simd::float3 min;
-      simd::float3 max;
-      int leftFirst = 0;
-      int second = 0;
-    };
-
-    std::vector<BuildPrim> refs;
-    refs.reserve(inst.cpuPrimitiveCount);
-    for (uint32_t i = 0; i < inst.cpuPrimitiveCount; ++i) {
-      BuildPrim ref;
-      ref.index = inst.primitiveIndices[i];
-      ref.min = inst.primitiveBoundsMin[i];
-      ref.max = inst.primitiveBoundsMax[i];
-      ref.centroid = (ref.min + ref.max) * 0.5f;
-      refs.push_back(ref);
-    }
-
-    std::vector<BlasNodeCPU> nodes;
-    nodes.reserve(inst.cpuPrimitiveCount * 2);
-    std::vector<int> ordered;
-    ordered.reserve(inst.cpuPrimitiveCount);
-
-    auto buildNode = [&](auto &&self, size_t begin, size_t end) -> int {
-      size_t count = end - begin;
-      if (count == 0)
-        return -1;
-
-      simd::float3 bmin = refs[begin].min;
-      simd::float3 bmax = refs[begin].max;
-      simd::float3 cmin = refs[begin].centroid;
-      simd::float3 cmax = refs[begin].centroid;
-      for (size_t i = begin + 1; i < end; ++i) {
-        bmin = simd::min(bmin, refs[i].min);
-        bmax = simd::max(bmax, refs[i].max);
-        cmin = simd::min(cmin, refs[i].centroid);
-        cmax = simd::max(cmax, refs[i].centroid);
-      }
-
-      int nodeIndex = static_cast<int>(nodes.size());
-      nodes.push_back({});
-      nodes[nodeIndex].min = bmin;
-      nodes[nodeIndex].max = bmax;
-
-      constexpr size_t kLeafSize = 4;
-      if (count <= kLeafSize) {
-        int start = static_cast<int>(ordered.size());
-        for (size_t i = begin; i < end; ++i)
-          ordered.push_back(refs[i].index);
-        nodes[nodeIndex].leftFirst = start;
-        nodes[nodeIndex].second = static_cast<int>(count);
-      } else {
-        simd::float3 extent = cmax - cmin;
-        int axis = 0;
-        if (extent.y > extent.x && extent.y >= extent.z)
-          axis = 1;
-        else if (extent.z > extent.x && extent.z > extent.y)
-          axis = 2;
-
-        float split = (cmin[axis] + cmax[axis]) * 0.5f;
-        auto midIter = std::partition(refs.begin() + begin, refs.begin() + end,
-                                      [axis, split](const BuildPrim &ref) {
-                                        return ref.centroid[axis] < split;
-                                      });
-        size_t mid = static_cast<size_t>(midIter - refs.begin());
-        if (mid == begin || mid == end)
-          mid = begin + count / 2;
-
-        int left = self(self, begin, mid);
-        int right = self(self, mid, end);
-        nodes[nodeIndex].leftFirst = left;
-        nodes[nodeIndex].second = -right;
-      }
-
-      return nodeIndex;
-    };
-
-    if (!refs.empty())
-      buildNode(buildNode, 0, refs.size());
-
-    inst.cpuBlasNodeCount = static_cast<uint32_t>(nodes.size());
-    inst.blasNodes.resize(nodes.size() * 2);
-    for (size_t i = 0; i < nodes.size(); ++i) {
-      float leftBits = 0.0f;
-      float secondBits = 0.0f;
-      std::memcpy(&leftBits, &nodes[i].leftFirst, sizeof(float));
-      std::memcpy(&secondBits, &nodes[i].second, sizeof(float));
-      inst.blasNodes[2 * i] = simd::make_float4(nodes[i].min, leftBits);
-      inst.blasNodes[2 * i + 1] = simd::make_float4(nodes[i].max, secondBits);
-    }
-
-    inst.primitiveIndices = std::move(ordered);
-
-    inst.state = ResidencyState::NotResident;
-    inst.gpu = InstanceGPU{};
-  };
-
-  auto appendPrimitive = [&](InstanceRecord &inst, const Primitive &p) {
-    simd::float3 pMin(0.0f);
-    simd::float3 pMax(0.0f);
-
-    switch (p.type) {
-    case PrimitiveType::Sphere: {
-      const float radius = p.sphere.radius;
-      const float radiusSq = radius * radius;
-      simd::float3 center = p.sphere.center;
-      simd::float3 radiusVec = simd::make_float3(radius, radius, radius);
-      pMin = center - radiusVec;
-      pMax = center + radiusVec;
-      inst.primitiveData.push_back(
-          simd::make_float4(center, static_cast<float>(p.type)));
-      inst.primitiveData.push_back(
-          simd::make_float4(radius, radiusSq, 0.0f, 0.0f));
-      inst.primitiveData.push_back(simd::make_float4(simd::float3(0.0f), 0.0f));
-      inst.primitiveData.push_back(simd::make_float4(simd::float3(0.0f), 0.0f));
-      break;
-    }
-    case PrimitiveType::Triangle: {
-      const auto &tri = p.triangle;
-      pMin = simd::min(tri.v0, simd::min(tri.v1, tri.v2));
-      pMax = simd::max(tri.v0, simd::max(tri.v1, tri.v2));
-      simd::float3 edge1 = tri.v1 - tri.v0;
-      simd::float3 edge2 = tri.v2 - tri.v0;
-      simd::float3 normal = simd::cross(edge1, edge2);
-      float lenSq = simd::dot(normal, normal);
-      if (lenSq > 1e-12f)
-        normal *= 1.0f / std::sqrt(lenSq);
-      else
-        normal = simd::make_float3(0.0f, 0.0f, 0.0f);
-      inst.primitiveData.push_back(
-          simd::make_float4(tri.v0, static_cast<float>(p.type)));
-      inst.primitiveData.push_back(simd::make_float4(edge1, 0.0f));
-      inst.primitiveData.push_back(simd::make_float4(edge2, 0.0f));
-      inst.primitiveData.push_back(simd::make_float4(normal, 0.0f));
-      break;
-    }
-    case PrimitiveType::Rectangle: {
-      const auto &rect = p.rectangle;
-      simd::float3 corners[4] = {rect.center + rect.u + rect.v,
-                                 rect.center + rect.u - rect.v,
-                                 rect.center - rect.u + rect.v,
-                                 rect.center - rect.u - rect.v};
-      pMin = corners[0];
-      pMax = corners[0];
-      for (int k = 1; k < 4; ++k) {
-        pMin = simd::min(pMin, corners[k]);
-        pMax = simd::max(pMax, corners[k]);
-      }
-      simd::float3 normal = simd::cross(rect.u, rect.v);
-      float lenSq = simd::dot(normal, normal);
-      if (lenSq > 1e-12f)
-        normal *= 1.0f / std::sqrt(lenSq);
-      else
-        normal = simd::make_float3(0.0f, 0.0f, 0.0f);
-      float invDotU = 0.0f;
-      float invDotV = 0.0f;
-      float dotU = simd::dot(rect.u, rect.u);
-      float dotV = simd::dot(rect.v, rect.v);
-      if (dotU > 1e-12f)
-        invDotU = 1.0f / dotU;
-      if (dotV > 1e-12f)
-        invDotV = 1.0f / dotV;
-      inst.primitiveData.push_back(
-          simd::make_float4(rect.center, static_cast<float>(p.type)));
-      inst.primitiveData.push_back(simd::make_float4(rect.u, invDotU));
-      inst.primitiveData.push_back(simd::make_float4(rect.v, invDotV));
-      inst.primitiveData.push_back(simd::make_float4(normal, 0.0f));
-      break;
-    }
-    }
-
-    if (inst.cpuPrimitiveCount == 0) {
-      inst.aabbMin = pMin;
-      inst.aabbMax = pMax;
-    } else {
-      inst.aabbMin = simd::min(inst.aabbMin, pMin);
-      inst.aabbMax = simd::max(inst.aabbMax, pMax);
-    }
-
-    inst.primitiveBoundsMin.push_back(pMin);
-    inst.primitiveBoundsMax.push_back(pMax);
-    inst.materialData.push_back(
-        simd::make_float4(p.material.albedo, p.material.materialType));
-    inst.materialData.push_back(
-        simd::make_float4(p.material.emissionColor,
-                           p.material.emissionPower));
-    inst.primitiveIndices.push_back(static_cast<int>(inst.cpuPrimitiveCount));
-    inst.cpuPrimitiveCount++;
-  };
-
-  std::unordered_map<uint32_t, std::vector<size_t>> meshPrimitiveMap;
-  meshPrimitiveMap.reserve(primitiveCount);
-
-  size_t fallbackTriangleCount = 0;
-  size_t nonTriangleCount = 0;
-
-  for (size_t i = 0; i < primitiveCount; ++i) {
-    const Primitive &p = _allPrimitives[i];
-    if (p.type == PrimitiveType::Triangle) {
-      if (p.meshId != kInvalidMeshId) {
-        auto &indices = meshPrimitiveMap[p.meshId];
-        indices.push_back(i);
-      } else {
-        fallbackTriangleCount++;
-      }
-    } else {
-      nonTriangleCount++;
-    }
-  }
-
-  size_t potentialInstanceCount = meshPrimitiveMap.size() + fallbackTriangleCount +
-                                  nonTriangleCount;
-  if (potentialInstanceCount > kMaxInstanceCapacity) {
-    printf(
-        "Warning: Scene has %zu potential instances but only %zu are supported; "
-        "excess instances will be ignored.\n",
-        potentialInstanceCount, kMaxInstanceCapacity);
-  }
-
-  _instances.reserve(std::min(potentialInstanceCount, kMaxInstanceCapacity));
-
-  auto buildInstanceFromIndices = [&](const std::vector<size_t> &indices,
-                                      uint32_t meshId) {
-    if (indices.empty() || _instances.size() >= kMaxInstanceCapacity)
-      return;
-    InstanceRecord inst;
-    inst.meshId = meshId;
-    inst.primitiveIndex = indices.front();
-    for (size_t idx : indices) {
-      appendPrimitive(inst, _allPrimitives[idx]);
-    }
-    finalizeInstance(inst);
-    _instances.push_back(std::move(inst));
-  };
-
-  std::unordered_set<uint32_t> processedMeshes;
-  processedMeshes.reserve(meshPrimitiveMap.size());
-
-  for (size_t i = 0; i < primitiveCount; ++i) {
-    const Primitive &p = _allPrimitives[i];
-    if (_instances.size() >= kMaxInstanceCapacity)
-      break;
-
-    if (p.type == PrimitiveType::Triangle) {
-      if (p.meshId != kInvalidMeshId) {
-        if (processedMeshes.insert(p.meshId).second) {
-          auto it = meshPrimitiveMap.find(p.meshId);
-          if (it != meshPrimitiveMap.end())
-            buildInstanceFromIndices(it->second, p.meshId);
-        }
-      } else {
-        InstanceRecord inst;
-        inst.meshId = kInvalidMeshId;
-        inst.primitiveIndex = i;
-        appendPrimitive(inst, p);
-        finalizeInstance(inst);
-        _instances.push_back(std::move(inst));
-      }
-    } else {
-      InstanceRecord inst;
-      inst.meshId = kInvalidMeshId;
-      inst.primitiveIndex = i;
-      appendPrimitive(inst, p);
-      finalizeInstance(inst);
-      _instances.push_back(std::move(inst));
-    }
-  }
-
-  size_t totalBlas = 0;
-  for (const auto &inst : _instances)
-    totalBlas += inst.cpuBlasNodeCount;
-  _cpuBlasNodeCount = totalBlas;
-  _totalNodeCount = _tlasNodeCount + _cpuBlasNodeCount;
-  _pendingAccumulationReset = true;
-}
-
-size_t Renderer::instanceFootprintBytes(const InstanceRecord &inst) const {
-  size_t bytes = inst.primitiveData.size() * sizeof(simd::float4);
-  bytes += inst.materialData.size() * sizeof(simd::float4);
-  bytes += inst.primitiveIndices.size() * sizeof(int);
-  bytes += inst.blasNodes.size() * sizeof(simd::float4);
-  return bytes;
-}
-
-bool Renderer::streamInInstance(size_t index) {
-  if (index >= _instances.size())
-    return false;
-
-  InstanceRecord &inst = _instances[index];
-  if (inst.state == ResidencyState::Resident)
-    return false;
-  if (inst.state == ResidencyState::StreamingIn)
-    return false;
-
-  if (inst.state == ResidencyState::StreamingOut) {
-    auto it = std::find(_instancesPendingRelease.begin(),
-                        _instancesPendingRelease.end(), index);
-    if (it != _instancesPendingRelease.end())
-      _instancesPendingRelease.erase(it);
-    inst.state = ResidencyState::Resident;
-    inst.gpu.primitiveCount = inst.cpuPrimitiveCount;
-    inst.gpu.blasNodeCount = inst.cpuBlasNodeCount;
-    inst.gpu.rootNodeIndex = 0;
-    _residentInstanceCount++;
-    _currentBlasNodeCount += inst.gpu.blasNodeCount;
-    updateInstanceArgument(index);
-    updateInstanceMetadata(index);
-    _pendingAccumulationReset = true;
-    markLightTableDirty();
-    return true;
-  }
-
-  size_t gpuFootprint = instanceFootprintBytes(inst);
-  if (gpuFootprint > 0) {
-    if (_gpuMemoryBudget != std::numeric_limits<size_t>::max() &&
-        gpuFootprint > _gpuMemoryBudget) {
-      if (_manualBudget) {
-        inst.state = ResidencyState::NotResident;
-        return false;
-      }
-      size_t previousBudget = _gpuMemoryBudget;
-      _gpuMemoryBudget = gpuFootprint;
-      _recommendedBudget =
-          std::max(_recommendedBudget, _gpuMemoryBudget);
-      double prevMB = static_cast<double>(previousBudget) /
-                      (1024.0 * 1024.0);
-      double newMB = static_cast<double>(_gpuMemoryBudget) /
-                     (1024.0 * 1024.0);
-      printf("Expanded GPU memory budget from %.2f MB to %.2f MB to fit instance %zu.\n",
-             prevMB, newMB, index);
-    }
-    if (!ensureBudget(gpuFootprint)) {
-      inst.state = ResidencyState::NotResident;
-      return false;
-    }
-  }
-
-  inst.state = ResidencyState::StreamingIn;
-
-  std::vector<MTL::Buffer *> stagingBuffers;
-  stagingBuffers.reserve(4);
-
-  auto cleanupStaging = [&]() {
-    for (MTL::Buffer *buffer : stagingBuffers)
-      buffer->release();
-    stagingBuffers.clear();
-  };
-
-  MTL::CommandBuffer *cmd = _pCommandQueue->commandBuffer();
-  if (!cmd) {
-    inst.state = ResidencyState::NotResident;
-    return false;
-  }
-
-  MTL::BlitCommandEncoder *blit = cmd->blitCommandEncoder();
-  if (!blit) {
-    inst.state = ResidencyState::NotResident;
-    return false;
-  }
-
-  auto enqueueCopy = [&](const void *src, size_t size, MTL::Buffer **dst,
-                         size_t &dstSize) {
-    if (*dst) {
-      trackDeallocation(dstSize);
-      (*dst)->release();
-      *dst = nullptr;
-      dstSize = 0;
-    }
-    if (size == 0)
-      return true;
-    if (!ensureBudget(size))
-      return false;
-    MTL::Buffer *staging =
-        _pDevice->newBuffer(size, MTL::ResourceStorageModeShared);
-    if (!staging)
-      return false;
-    std::memcpy(staging->contents(), src, size);
-    MTL::Buffer *gpu =
-        _pDevice->newBuffer(size, MTL::ResourceStorageModePrivate);
-    if (!gpu) {
-      staging->release();
-      return false;
-    }
-    blit->copyFromBuffer(staging, 0, gpu, 0, size);
-    stagingBuffers.push_back(staging);
-    *dst = gpu;
-    dstSize = size;
-    trackAllocation(size);
-    return true;
-  };
-
-  bool success = enqueueCopy(inst.primitiveData.data(),
-                             inst.primitiveData.size() * sizeof(simd::float4),
-                             &inst.gpu.primitives, inst.gpu.primitiveBytes);
-  success = success &&
-            enqueueCopy(inst.materialData.data(),
-                        inst.materialData.size() * sizeof(simd::float4),
-                        &inst.gpu.materials, inst.gpu.materialBytes);
-  success = success && enqueueCopy(inst.primitiveIndices.data(),
-                                   inst.primitiveIndices.size() * sizeof(int),
-                                   &inst.gpu.primitiveIndices,
-                                   inst.gpu.primitiveIndicesBytes);
-  success = success &&
-            enqueueCopy(inst.blasNodes.data(),
-                        inst.blasNodes.size() * sizeof(simd::float4),
-                        &inst.gpu.blasNodes, inst.gpu.blasNodesBytes);
-
-  blit->endEncoding();
-
-  if (!success) {
-    cleanupStaging();
-    releaseInstanceResources(index);
-    inst.state = ResidencyState::NotResident;
-    return false;
-  }
-
-  PendingStreamIn pending;
-  pending.instanceIndex = index;
-  pending.commandBuffer = cmd;
-  cmd->retain();
-  pending.stagingBuffers = std::move(stagingBuffers);
-
-  cmd->commit();
-
-  _pendingStreamIns.push_back(std::move(pending));
-  return true;
-}
-
-void Renderer::streamOutInstance(size_t index) {
-  if (index >= _instances.size())
-    return;
-
-  InstanceRecord &inst = _instances[index];
-  if (inst.state != ResidencyState::Resident)
-    return;
-
-  inst.state = ResidencyState::StreamingOut;
-  if (_residentInstanceCount > 0)
-    _residentInstanceCount--;
-  if (_currentBlasNodeCount >= inst.gpu.blasNodeCount)
-    _currentBlasNodeCount -= inst.gpu.blasNodeCount;
-  updateInstanceArgument(index);
-  updateInstanceMetadata(index);
-  if (std::find(_instancesPendingRelease.begin(), _instancesPendingRelease.end(),
-                index) == _instancesPendingRelease.end())
-    _instancesPendingRelease.push_back(index);
-  _pendingAccumulationReset = true;
-  markLightTableDirty();
-}
-
-void Renderer::releaseInstanceResources(size_t index) {
-  if (index >= _instances.size())
-    return;
-
-  InstanceRecord &inst = _instances[index];
-  if (inst.gpu.blasNodes) {
-    trackDeallocation(inst.gpu.blasNodesBytes);
-    inst.gpu.blasNodesBytes = 0;
-    inst.gpu.blasNodes->release();
-    inst.gpu.blasNodes = nullptr;
-  }
-  if (inst.gpu.primitives) {
-    trackDeallocation(inst.gpu.primitiveBytes);
-    inst.gpu.primitiveBytes = 0;
-    inst.gpu.primitives->release();
-    inst.gpu.primitives = nullptr;
-  }
-  if (inst.gpu.materials) {
-    trackDeallocation(inst.gpu.materialBytes);
-    inst.gpu.materialBytes = 0;
-    inst.gpu.materials->release();
-    inst.gpu.materials = nullptr;
-  }
-  if (inst.gpu.primitiveIndices) {
-    trackDeallocation(inst.gpu.primitiveIndicesBytes);
-    inst.gpu.primitiveIndicesBytes = 0;
-    inst.gpu.primitiveIndices->release();
-    inst.gpu.primitiveIndices = nullptr;
-  }
-  inst.gpu.primitiveCount = 0;
-  inst.gpu.blasNodeCount = 0;
-  inst.gpu.rootNodeIndex = 0;
-  inst.state = ResidencyState::NotResident;
-  markLightTableDirty();
-}
-
-void Renderer::updateInstanceArgument(size_t index) {
-  if (!_pInstanceArgEncoder || !_pInstanceArgElementEncoder ||
-      !_pInstanceArgBuffer || _instanceArgStride == 0)
-    return;
-  if (index >= kMaxInstanceCapacity)
-    return;
-  if (index >= _instances.size())
-    return;
-
-  size_t offset = index * _instanceArgStride;
-  if (offset + _instanceArgStride > _instanceArgBufferSize)
-    return;
-
-  _pInstanceArgElementEncoder->setArgumentBuffer(_pInstanceArgBuffer,
-                                                 NS::UInteger(offset));
-  const InstanceRecord &inst = _instances[index];
-  if (inst.state == ResidencyState::Resident) {
-    _pInstanceArgElementEncoder->setBuffer(inst.gpu.blasNodes, 0,
-                                           NS::UInteger(0));
-    _pInstanceArgElementEncoder->setBuffer(inst.gpu.primitives, 0,
-                                           NS::UInteger(1));
-    _pInstanceArgElementEncoder->setBuffer(inst.gpu.materials, 0,
-                                           NS::UInteger(2));
-    _pInstanceArgElementEncoder->setBuffer(inst.gpu.primitiveIndices, 0,
-                                           NS::UInteger(3));
-  } else {
-    _pInstanceArgElementEncoder->setBuffer(nullptr, 0, NS::UInteger(0));
-    _pInstanceArgElementEncoder->setBuffer(nullptr, 0, NS::UInteger(1));
-    _pInstanceArgElementEncoder->setBuffer(nullptr, 0, NS::UInteger(2));
-    _pInstanceArgElementEncoder->setBuffer(nullptr, 0, NS::UInteger(3));
-  }
-}
-
-void Renderer::updateInstanceMetadata(size_t index) {
-  if (!_pInstanceMetaBuffer)
-    return;
-  if (index >= _instances.size())
-    return;
-
-  InstanceMetadataCPU *meta =
-      reinterpret_cast<InstanceMetadataCPU *>(_pInstanceMetaBuffer->contents());
-  InstanceMetadataCPU data{};
-  const InstanceRecord &inst = _instances[index];
-  if (inst.state == ResidencyState::Resident) {
-    data.primitiveCount = inst.gpu.primitiveCount;
-    data.blasNodeCount = inst.gpu.blasNodeCount;
-    data.rootNodeIndex = inst.gpu.rootNodeIndex;
-  }
-  meta[index] = data;
-  _pInstanceMetaBuffer->didModifyRange(
-      NS::Range::Make(index * sizeof(InstanceMetadataCPU),
-                      sizeof(InstanceMetadataCPU)));
-}
-
-void Renderer::markLightTableDirty() {
-  _lightTableDirty = true;
-  _pendingAccumulationReset = true;
-}
-
-static float encodeUInt32(uint32_t value) {
-  float bits = 0.0f;
-  std::memcpy(&bits, &value, sizeof(uint32_t));
-  return bits;
-}
-
-void Renderer::rebuildLightTable() {
-  if (!_lightTableDirty)
-    return;
-
-  if (_pLightBuffer) {
-    _pLightBuffer->release();
-    _pLightBuffer = nullptr;
-  }
-
-  _lightTable.clear();
-  std::vector<float> weights;
-  weights.reserve(_instances.size());
-
-  constexpr float kPi = 3.14159265358979323846f;
-
-  auto primitiveArea = [&](const InstanceRecord &inst,
-                           size_t primIndex) -> float {
-    size_t base = primIndex * kPrimitiveStride;
-    if (base + 3 >= inst.primitiveData.size())
-      return 0.0f;
-    const simd::float4 &p0 = inst.primitiveData[base + 0];
-    const simd::float4 &p1 = inst.primitiveData[base + 1];
-    const simd::float4 &p2 = inst.primitiveData[base + 2];
-    int type = static_cast<int>(p0.w);
-    switch (type) {
-    case 0: {
-      float radius = p1.x;
-      return 4.0f * kPi * radius * radius;
-    }
-    case 1: {
-      simd::float3 edge1 = p1.xyz;
-      simd::float3 edge2 = p2.xyz;
-      simd::float3 crossProd = simd::cross(edge1, edge2);
-      float len = simd::length(crossProd);
-      return 0.5f * len;
-    }
-    case 2: {
-      simd::float3 u = p1.xyz;
-      simd::float3 v = p2.xyz;
-      simd::float3 crossProd = simd::cross(u, v);
-      float len = simd::length(crossProd);
-      return 4.0f * len;
-    }
-    default:
-      break;
-    }
-    return 0.0f;
-  };
-
-  double totalWeight = 0.0;
-
-  for (size_t instIndex = 0; instIndex < _instances.size(); ++instIndex) {
-    const InstanceRecord &inst = _instances[instIndex];
-    if (inst.state != ResidencyState::Resident)
-      continue;
-    if (inst.cpuPrimitiveCount == 0)
-      continue;
-
-    for (uint32_t prim = 0; prim < inst.cpuPrimitiveCount; ++prim) {
-      size_t matBase = static_cast<size_t>(prim) * 2;
-      if (matBase + 1 >= inst.materialData.size())
-        continue;
-      const simd::float4 &m1 = inst.materialData[matBase + 1];
-      simd::float3 emissionColor = {m1.x, m1.y, m1.z};
-      float emissionPower = m1.w;
-      if (emissionPower <= 0.0f)
-        continue;
-
-      simd::float3 radiance = emissionColor * emissionPower;
-      float luminance = 0.2126f * radiance.x + 0.7152f * radiance.y +
-                        0.0722f * radiance.z;
-      if (luminance <= 0.0f)
-        continue;
-
-      float area = primitiveArea(inst, prim);
-      if (area <= 0.0f)
-        continue;
-
-      GPULightData light{};
-      light.meta = simd::make_float4(encodeUInt32(static_cast<uint32_t>(instIndex)),
-                                     encodeUInt32(static_cast<uint32_t>(prim)),
-                                     area, 0.0f);
-      light.emission = simd::make_float4(emissionColor, emissionPower);
-      light.cdf = simd::make_float4(0.0f, 0.0f, 0.0f, 0.0f);
-
-      _lightTable.push_back(light);
-      float weight = luminance * area;
-      weights.push_back(weight);
-      totalWeight += static_cast<double>(weight);
-    }
-  }
-
-  if (_lightTable.empty() || totalWeight <= 0.0) {
-    _lightTable.clear();
-    _lightTableDirty = false;
-
-    // Ensure the shader always has a valid buffer bound even when no emissive
-    // primitives are present. Metal validation requires that all buffer slots
-    // used by the shader are populated, so create a small dummy buffer in this
-    // case instead of leaving it null.
-    GPULightData emptyLight{};
-    size_t bufferSize = sizeof(GPULightData);
-    if (!_pLightBuffer || _pLightBuffer->length() < bufferSize) {
-      releaseBuffer(_pLightBuffer, _lightBufferSize);
-      if (!ensureBudget(bufferSize))
-        return;
-      _pLightBuffer =
-          _pDevice->newBuffer(bufferSize, MTL::ResourceStorageModeManaged);
-      if (_pLightBuffer) {
-        _lightBufferSize = bufferSize;
-        trackAllocation(_lightBufferSize);
-      }
-    }
-
-    if (_pLightBuffer) {
-      std::memcpy(_pLightBuffer->contents(), &emptyLight, bufferSize);
-      _pLightBuffer->didModifyRange(NS::Range::Make(0, bufferSize));
-    }
-
-    return;
-  }
-
-  float cumulative = 0.0f;
-  for (size_t i = 0; i < _lightTable.size(); ++i) {
-    float weight = weights[i];
-    float pdf = weight > 0.0f ? static_cast<float>(weight / totalWeight) : 0.0f;
-    cumulative += pdf;
-    _lightTable[i].meta.w = pdf;
-    _lightTable[i].cdf.x = cumulative;
-  }
-  _lightTable.back().cdf.x = 1.0f;
-
-  size_t bufferSize = _lightTable.size() * sizeof(GPULightData);
-  if (!ensureBudget(bufferSize)) {
-    _lightTable.clear();
-    _lightTableDirty = false;
-    return;
-  }
-
-  releaseBuffer(_pLightBuffer, _lightBufferSize);
-  _pLightBuffer =
-      _pDevice->newBuffer(bufferSize, MTL::ResourceStorageModeManaged);
-  if (_pLightBuffer) {
-    _lightBufferSize = bufferSize;
-    trackAllocation(_lightBufferSize);
-    std::memcpy(_pLightBuffer->contents(), _lightTable.data(), bufferSize);
-    _pLightBuffer->didModifyRange(NS::Range::Make(0, bufferSize));
-  }
-
-  _lightTableDirty = false;
-}
-
-std::pair<size_t, size_t> Renderer::calculateOffloadedResidency() const {
-  size_t offloadedNodes = 0;
-  size_t offloadedInstances = 0;
-  for (const auto &inst : _instances) {
-    if (inst.state != ResidencyState::Resident) {
-      offloadedNodes += inst.cpuBlasNodeCount;
-      offloadedInstances++;
-    }
-  }
-  return {offloadedNodes, offloadedInstances};
-}
-
-void Renderer::refreshActiveNodeCount() {
-  size_t previousActive = _activeNodeCount;
-  size_t previousOffloadedNodes = _lastOffloadedNodeCount;
-  size_t previousOffloadedInstances = _lastOffloadedInstanceCount;
-  _activeNodeCount = _tlasNodeCount + _currentBlasNodeCount;
-  size_t total = _tlasNodeCount + _cpuBlasNodeCount;
-  if (_totalNodeCount != total)
-    _totalNodeCount = total;
-  auto [offloadedNodes, offloadedInstances] = calculateOffloadedResidency();
-  _lastOffloadedNodeCount = offloadedNodes;
-  _lastOffloadedInstanceCount = offloadedInstances;
-  if (_activeNodeCount != previousActive ||
-      offloadedNodes != previousOffloadedNodes ||
-      offloadedInstances != previousOffloadedInstances) {
-    printf("Active nodes: %zu (offloaded: %zu across %zu instances)\n",
-           _activeNodeCount, offloadedNodes, offloadedInstances);
-  }
-}
-
-void Renderer::rebuildTLAS() {
-  struct TLASNodeCPU {
-    simd::float3 min;
-    simd::float3 max;
-    int leftFirst = 0;
-    int second = 0;
-  };
-
-  struct BuildRef {
-    size_t instanceIndex;
-    simd::float3 min;
-    simd::float3 max;
-    simd::float3 centroid;
-  };
-
-  std::vector<TLASNodeCPU> nodes;
-  std::vector<int> instanceIndices;
-
-  if (!_instances.empty()) {
-    std::vector<BuildRef> refs;
-    refs.reserve(_instances.size());
-    for (size_t index = 0; index < _instances.size(); ++index) {
-      const InstanceRecord &inst = _instances[index];
-      if (inst.cpuPrimitiveCount == 0)
-        continue;
-      BuildRef ref;
-      ref.instanceIndex = index;
-      ref.min = inst.aabbMin;
-      ref.max = inst.aabbMax;
-      ref.centroid = (inst.aabbMin + inst.aabbMax) * 0.5f;
-      refs.push_back(ref);
-    }
-
-    nodes.reserve(refs.size() * 2);
-    instanceIndices.reserve(refs.size());
-
-    auto buildNode = [&](auto &&self, size_t begin, size_t end) -> int {
-      size_t count = end - begin;
-      if (count == 0)
-        return -1;
-
-      simd::float3 bmin = refs[begin].min;
-      simd::float3 bmax = refs[begin].max;
-      simd::float3 cmin = refs[begin].centroid;
-      simd::float3 cmax = refs[begin].centroid;
-      for (size_t i = begin + 1; i < end; ++i) {
-        bmin = simd::min(bmin, refs[i].min);
-        bmax = simd::max(bmax, refs[i].max);
-        cmin = simd::min(cmin, refs[i].centroid);
-        cmax = simd::max(cmax, refs[i].centroid);
-      }
-
-      int nodeIndex = static_cast<int>(nodes.size());
-      nodes.push_back({});
-      nodes[nodeIndex].min = bmin;
-      nodes[nodeIndex].max = bmax;
-
-      if (count <= static_cast<size_t>(kMaxTLASLeafInstances)) {
-        int start = static_cast<int>(instanceIndices.size());
-        for (size_t i = begin; i < end; ++i) {
-          instanceIndices.push_back(static_cast<int>(refs[i].instanceIndex));
-        }
-        nodes[nodeIndex].leftFirst = start;
-        nodes[nodeIndex].second = static_cast<int>(count);
-      } else {
-        simd::float3 extent = cmax - cmin;
-        int axis = 0;
-        if (extent.y > extent.x && extent.y >= extent.z)
-          axis = 1;
-        else if (extent.z > extent.x && extent.z > extent.y)
-          axis = 2;
-
-        size_t mid = begin + count / 2;
-        auto comparator = [axis](const BuildRef &a, const BuildRef &b) {
-          return a.centroid[axis] < b.centroid[axis];
-        };
-        std::nth_element(refs.begin() + begin, refs.begin() + mid,
-                         refs.begin() + end, comparator);
-
-        int leftChild = self(self, begin, mid);
-        int rightChild = self(self, mid, end);
-        nodes[nodeIndex].leftFirst = leftChild;
-        nodes[nodeIndex].second = -rightChild;
-      }
-
-      return nodeIndex;
-    };
-
-    if (!refs.empty())
-      buildNode(buildNode, 0, refs.size());
-  }
-
-  std::vector<simd::float4> tlasData;
-  tlasData.reserve(nodes.size() * 2);
-  for (size_t i = 0; i < nodes.size(); ++i) {
-    float leftBits = 0.0f;
-    float secondBits = 0.0f;
-    std::memcpy(&leftBits, &nodes[i].leftFirst, sizeof(int));
-    std::memcpy(&secondBits, &nodes[i].second, sizeof(int));
-    tlasData.push_back(simd::make_float4(nodes[i].min, leftBits));
-    tlasData.push_back(simd::make_float4(nodes[i].max, secondBits));
-  }
-
-  _tlasNodeCount = nodes.size();
-  _totalNodeCount = _tlasNodeCount + _cpuBlasNodeCount;
-
-  size_t nodeByteCount =
-      !tlasData.empty() ? tlasData.size() * sizeof(simd::float4)
-                        : sizeof(simd::float4) * 2;
-  size_t indexByteCount =
-      !instanceIndices.empty() ? instanceIndices.size() * sizeof(int)
-                               : sizeof(int);
-
-  releaseBuffer(_pTLASBuffer, _tlasBufferSize);
-  releaseBuffer(_pTLASInstanceIndexBuffer, _tlasInstanceIndexBufferSize);
-
-  if (!ensureBudget(nodeByteCount + indexByteCount)) {
-    size_t previousActive = _activeNodeCount;
-    _tlasNodeCount = 0;
-    _activeNodeCount = 0;
-    _totalNodeCount = _cpuBlasNodeCount;
-    if (_activeNodeCount != previousActive) {
-      size_t offloaded = _totalNodeCount;
-      printf("Active nodes: %zu (offloaded: %zu)\n", _activeNodeCount,
-             offloaded);
-    }
-    return;
-  }
-
-  _pTLASBuffer =
-      _pDevice->newBuffer(nodeByteCount, MTL::ResourceStorageModeManaged);
-  if (_pTLASBuffer) {
-    _tlasBufferSize = nodeByteCount;
-    trackAllocation(_tlasBufferSize);
-    simd::float4 *nodeDst =
-        reinterpret_cast<simd::float4 *>(_pTLASBuffer->contents());
-    if (!tlasData.empty())
-      std::memcpy(nodeDst, tlasData.data(),
-                  tlasData.size() * sizeof(simd::float4));
-    else
-      std::memset(nodeDst, 0, nodeByteCount);
-    _pTLASBuffer->didModifyRange(NS::Range::Make(0, nodeByteCount));
-  }
-
-  _pTLASInstanceIndexBuffer =
-      _pDevice->newBuffer(indexByteCount, MTL::ResourceStorageModeManaged);
-  if (_pTLASInstanceIndexBuffer) {
-    _tlasInstanceIndexBufferSize = indexByteCount;
-    trackAllocation(_tlasInstanceIndexBufferSize);
-    int *indexDst =
-        reinterpret_cast<int *>(_pTLASInstanceIndexBuffer->contents());
-    if (!instanceIndices.empty())
-      std::memcpy(indexDst, instanceIndices.data(),
-                  instanceIndices.size() * sizeof(int));
-    else
-      std::memset(indexDst, 0, indexByteCount);
-    _pTLASInstanceIndexBuffer->didModifyRange(
-        NS::Range::Make(0, indexByteCount));
-  }
-
-  refreshActiveNodeCount();
-}
-
-void Renderer::processPendingReleases() {
-  for (size_t index : _instancesPendingRelease)
-    releaseInstanceResources(index);
-  _instancesPendingRelease.clear();
-}
-
-void Renderer::processPendingStreamIns() {
-  if (_pendingStreamIns.empty())
-    return;
-
-  bool residencyChanged = false;
-
-  for (size_t i = 0; i < _pendingStreamIns.size();) {
-    PendingStreamIn &pending = _pendingStreamIns[i];
-    if (!pending.commandBuffer) {
-      _pendingStreamIns.erase(_pendingStreamIns.begin() + i);
-      continue;
-    }
-
-    MTL::CommandBufferStatus status = pending.commandBuffer->status();
-    if (status == MTL::CommandBufferStatus::CommandBufferStatusCompleted ||
-        status == MTL::CommandBufferStatus::CommandBufferStatusError) {
-      for (MTL::Buffer *buffer : pending.stagingBuffers) {
-        if (buffer)
-          buffer->release();
-      }
-      pending.stagingBuffers.clear();
-
-      InstanceRecord &inst = _instances[pending.instanceIndex];
-
-      if (status == MTL::CommandBufferStatus::CommandBufferStatusCompleted) {
-        inst.gpu.primitiveCount = inst.cpuPrimitiveCount;
-        inst.gpu.blasNodeCount = inst.cpuBlasNodeCount;
-        inst.gpu.rootNodeIndex = 0;
-        inst.state = ResidencyState::Resident;
-        _residentInstanceCount++;
-        _currentBlasNodeCount += inst.gpu.blasNodeCount;
-        updateInstanceArgument(pending.instanceIndex);
-        updateInstanceMetadata(pending.instanceIndex);
-        _pendingAccumulationReset = true;
-        markLightTableDirty();
-        residencyChanged = true;
-      } else {
-        releaseInstanceResources(pending.instanceIndex);
-      }
-
-      pending.commandBuffer->release();
-      _pendingStreamIns.erase(_pendingStreamIns.begin() + i);
-    } else {
-      ++i;
-    }
-  }
-
-  if (residencyChanged) {
-    _blasNodeCount = _currentBlasNodeCount;
-    refreshActiveNodeCount();
-  }
-}
-
-bool Renderer::createPrivateBuffer(const void *data, size_t size,
-                                   MTL::Buffer **outBuffer,
-                                   size_t &sizeTracker) {
-  if (*outBuffer) {
-    trackDeallocation(sizeTracker);
-    (*outBuffer)->release();
-    *outBuffer = nullptr;
-    sizeTracker = 0;
-  }
-  if (size == 0)
-    return true;
-  if (!ensureBudget(size))
-    return false;
-
-  MTL::Buffer *staging =
-      _pDevice->newBuffer(size, MTL::ResourceStorageModeShared);
-  if (!staging)
-    return false;
-  if (data)
-    std::memcpy(staging->contents(), data, size);
-  else
-    std::memset(staging->contents(), 0, size);
-  MTL::Buffer *gpu =
-      _pDevice->newBuffer(size, MTL::ResourceStorageModePrivate);
-  if (!gpu) {
-    staging->release();
-    return false;
-  }
-  MTL::CommandBuffer *cmd = _pCommandQueue->commandBuffer();
-  if (!cmd) {
-    staging->release();
-    gpu->release();
-    return false;
-  }
-  MTL::BlitCommandEncoder *blit = cmd->blitCommandEncoder();
-  if (!blit) {
-    staging->release();
-    gpu->release();
-    return false;
-  }
-  blit->copyFromBuffer(staging, 0, gpu, 0, size);
-  blit->endEncoding();
-  cmd->commit();
-  cmd->waitUntilCompleted();
-
-  staging->release();
-  *outBuffer = gpu;
-  sizeTracker = size;
-  trackAllocation(size);
-  return true;
-}
-
-bool Renderer::createPrivateBuffer(const std::vector<simd::float4> &data,
-                                   MTL::Buffer **outBuffer,
-                                   size_t &sizeTracker) {
-  const void *ptr = data.empty() ? nullptr : data.data();
-  return createPrivateBuffer(ptr, data.size() * sizeof(simd::float4),
-                             outBuffer, sizeTracker);
-}
-
-bool Renderer::createPrivateBuffer(const std::vector<int> &data,
-                                   MTL::Buffer **outBuffer,
-                                   size_t &sizeTracker) {
-  const void *ptr = data.empty() ? nullptr : data.data();
-  return createPrivateBuffer(ptr, data.size() * sizeof(int), outBuffer,
-                             sizeTracker);
-}
-
-void Renderer::trackAllocation(size_t bytes) { _trackedAllocatedBytes += bytes; }
-
-void Renderer::trackDeallocation(size_t bytes) {
-  if (bytes >= _trackedAllocatedBytes)
-    _trackedAllocatedBytes = 0;
-  else
-    _trackedAllocatedBytes -= bytes;
-}
-
-void Renderer::releaseBuffer(MTL::Buffer *&buffer, size_t &sizeTracker) {
-  if (!buffer)
-    return;
-  trackDeallocation(sizeTracker);
-  buffer->release();
-  buffer = nullptr;
-  sizeTracker = 0;
-}
-
-void Renderer::releaseTexture(MTL::Texture *&texture, size_t &sizeTracker) {
-  if (!texture)
-    return;
-  trackDeallocation(sizeTracker);
-  texture->release();
-  texture = nullptr;
-  sizeTracker = 0;
 }
 
 void Renderer::drawableSizeWillChange(MTK::View *pView, CGSize size) {
   for (uint i = 0; i < 2; i++)
-    releaseTexture(_accumulationTargets[i], _accumulationTargetSizes[i]);
+    if (_accumulationTargets[i])
+      _accumulationTargets[i]->release();
 
   Camera::screenSize = {(float)size.width, (float)size.height};
 
@@ -1958,6 +501,91 @@ void Renderer::drawableSizeWillChange(MTK::View *pView, CGSize size) {
 }
 
 bool Renderer::hasKeyframes() const { return !_pScene->cameraPath.empty(); }
+
+void Renderer::setPrimitiveActive(size_t index, bool active) {
+  if (index >= _activePrimitive.size())
+    return;
+  if (_activePrimitive[index] == active)
+    return;
+  _activePrimitive[index] = active;
+  if (_pActiveBuffer) {
+    uint8_t *mask = static_cast<uint8_t *>(_pActiveBuffer->contents());
+    mask[index] = active ? 1 : 0;
+    _pActiveBuffer->didModifyRange(NS::Range::Make(index, 1));
+  }
+}
+
+void Renderer::rebuildAccelerationStructures() {
+  _pScene->buildBVH();
+
+  size_t newBlasCount = _pScene->getBVHNodeCount();
+  _blasNodeCount = newBlasCount;
+
+  simd::float4 *bvhData = _pScene->createBVHBuffer();
+  if (_pBVHBuffer)
+    _pBVHBuffer->release();
+  size_t bvhSize = sizeof(simd::float4) * newBlasCount * 2;
+  if (!ensureBudget(bvhSize)) {
+    delete[] bvhData;
+    return;
+  }
+  _pBVHBuffer =
+      _pDevice->newBuffer(bvhData, bvhSize, MTL::ResourceStorageModeManaged);
+  _pBVHBuffer->didModifyRange(NS::Range::Make(0, _pBVHBuffer->length()));
+  delete[] bvhData;
+
+  size_t tlasCount = 0;
+  simd::float4 *tlasData = _pScene->createTLASBuffer(tlasCount);
+  _tlasNodeCount = tlasCount;
+  _totalNodeCount = _tlasNodeCount + _allPrimitives.size();
+  size_t oldActiveCount = _activeNodeCount;
+  size_t activePrim = 0;
+  for (bool a : _activePrimitive)
+    if (a)
+      activePrim++;
+  _activeNodeCount = _tlasNodeCount + activePrim;
+  if (_activeNodeCount != oldActiveCount) {
+    printf("Active nodes: %zu\n", _activeNodeCount);
+  }
+  if (_pTLASBuffer)
+    _pTLASBuffer->release();
+  if (tlasData && tlasCount > 0) {
+    size_t tlasSize = sizeof(simd::float4) * tlasCount * 2;
+    if (!ensureBudget(tlasSize)) {
+      delete[] tlasData;
+      return;
+    }
+    _pTLASBuffer =
+        _pDevice->newBuffer(tlasData, tlasSize, MTL::ResourceStorageModeManaged);
+    _pTLASBuffer->didModifyRange(NS::Range::Make(0, _pTLASBuffer->length()));
+  } else {
+    if (!ensureBudget(1)) {
+      delete[] tlasData;
+      return;
+    }
+    _pTLASBuffer = _pDevice->newBuffer(1, MTL::ResourceStorageModeManaged);
+  }
+  delete[] tlasData;
+
+  size_t indexCount = _pScene->getPrimitiveCount();
+  size_t indexSize = indexCount * sizeof(int);
+  if (_pPrimitiveIndexBuffer)
+    _pPrimitiveIndexBuffer->release();
+  if (indexCount > 0) {
+    if (!ensureBudget(indexSize))
+      return;
+    int *rawIndices = _pScene->createPrimitiveIndexBuffer();
+    _pPrimitiveIndexBuffer = _pDevice->newBuffer(
+        rawIndices, indexSize, MTL::ResourceStorageModeManaged);
+    _pPrimitiveIndexBuffer->didModifyRange(NS::Range::Make(0, indexSize));
+    delete[] rawIndices;
+  } else {
+    if (!ensureBudget(sizeof(int)))
+      return;
+    _pPrimitiveIndexBuffer =
+        _pDevice->newBuffer(sizeof(int), MTL::ResourceStorageModeManaged);
+  }
+}
 
 void Renderer::dumpAccelerationStructure(const std::string &path) {
   std::filesystem::create_directories(
@@ -1968,50 +596,46 @@ void Renderer::dumpAccelerationStructure(const std::string &path) {
 
   out << "{\n";
 
+  size_t tlasCount = 0;
+  simd::float4 *tlasData = _pScene->createTLASBuffer(tlasCount);
   out << "  \"tlas\": [\n";
-  bool wroteAny = false;
-  for (size_t i = 0; i < _instances.size(); ++i) {
-    const auto &inst = _instances[i];
-    if (inst.state != ResidencyState::Resident)
-      continue;
-    if (wroteAny)
+  for (size_t i = 0; i < tlasCount; ++i) {
+    simd::float4 bmin = tlasData[2 * i];
+    simd::float4 bmax = tlasData[2 * i + 1];
+    int childIndex = reinterpret_cast<const int *>(&bmin)[3];
+    out << "    {\"child\":" << childIndex << ",\"min\":[" << bmin.x << ","
+        << bmin.y << "," << bmin.z << "],\"max\":[" << bmax.x << "," << bmax.y
+        << "," << bmax.z << "]}";
+    if (i + 1 < tlasCount)
       out << ",\n";
-    out << "    {\"instance\":" << i << ",\"min\":[" << inst.aabbMin.x << ","
-        << inst.aabbMin.y << "," << inst.aabbMin.z << "],\"max\":["
-        << inst.aabbMax.x << "," << inst.aabbMax.y << "," << inst.aabbMax.z
-        << "]}";
-    wroteAny = true;
+    else
+      out << "\n";
   }
-  if (wroteAny)
-    out << "\n";
+  out << "  ],\n";
+  delete[] tlasData;
+
+  const auto &nodes = _pScene->getBVHNodes();
+  out << "  \"blas\": [\n";
+  for (size_t i = 0; i < nodes.size(); ++i) {
+    const auto &n = nodes[i];
+    out << "    {\"index\":" << i << ",\"min\":[" << n.boundsMin.x << ","
+        << n.boundsMin.y << "," << n.boundsMin.z << "],\"max\":["
+        << n.boundsMax.x << "," << n.boundsMax.y << "," << n.boundsMax.z
+        << "],\"leftFirst\":" << n.leftFirst << ",\"count\":" << n.count << "}";
+    if (i + 1 < nodes.size())
+      out << ",\n";
+    else
+      out << "\n";
+  }
   out << "  ],\n";
 
-  out << "  \"instances\": [\n";
-  for (size_t i = 0; i < _instances.size(); ++i) {
-    const auto &inst = _instances[i];
-    const char *stateStr = "notResident";
-    switch (inst.state) {
-    case ResidencyState::NotResident:
-      stateStr = "notResident";
-      break;
-    case ResidencyState::StreamingIn:
-      stateStr = "streamingIn";
-      break;
-    case ResidencyState::Resident:
-      stateStr = "resident";
-      break;
-    case ResidencyState::StreamingOut:
-      stateStr = "streamingOut";
-      break;
-    }
-    out << "    {\"index\":" << i << ",\"state\":\"" << stateStr
-        << "\",\"cpuPrimitiveCount\":" << inst.cpuPrimitiveCount
-        << ",\"bounds\":[" << inst.bounds.center.x << ","
-        << inst.bounds.center.y << "," << inst.bounds.center.z << ","
-        << inst.bounds.radius << "],\"resident\":"
-        << (inst.state == ResidencyState::Resident ? "true" : "false")
+  out << "  \"primitives\": [\n";
+  size_t primCount = std::min(_allPrimitives.size(), _activePrimitive.size());
+  for (size_t i = 0; i < primCount; ++i) {
+    out << "    {\"index\":" << i
+        << ",\"active\":" << (_activePrimitive[i] ? "true" : "false")
         << "}";
-    if (i + 1 < _instances.size())
+    if (i + 1 < primCount)
       out << ",\n";
     else
       out << "\n";
@@ -2022,95 +646,27 @@ void Renderer::dumpAccelerationStructure(const std::string &path) {
 }
 
 double Renderer::currentGPUMemoryMB() const {
-  return static_cast<double>(_trackedAllocatedBytes) / (1024.0 * 1024.0);
+  return static_cast<double>(_pDevice->currentAllocatedSize()) /
+         (1024.0 * 1024.0);
 }
 
-bool Renderer::popCompletedFrameMetrics(FrameMetrics &outMetrics) {
-  std::lock_guard<std::mutex> lock(_metricsMutex);
-  if (!_hasPendingMetrics)
+void Renderer::setGPUMemoryBudgetMB(double mb) {
+  if (mb <= 0.0)
+    _gpuMemoryBudget = std::numeric_limits<size_t>::max();
+  else
+    _gpuMemoryBudget = static_cast<size_t>(mb * 1024.0 * 1024.0);
+}
+
+bool Renderer::ensureBudget(size_t bytes) const {
+  if (_gpuMemoryBudget == std::numeric_limits<size_t>::max())
+    return true;
+  size_t current = _pDevice->currentAllocatedSize();
+  if (current + bytes > _gpuMemoryBudget) {
+    printf("GPU memory budget exceeded: requested %zu bytes (current %zu, budget %zu)\n",
+           bytes, current, _gpuMemoryBudget);
     return false;
-  outMetrics = _pendingFrameMetrics;
-  _hasPendingMetrics = false;
+  }
   return true;
-}
-
-bool Renderer::ensureBudget(size_t bytes) {
-  if (_gpuMemoryBudget == std::numeric_limits<size_t>::max())
-    return true;
-
-  size_t current = _trackedAllocatedBytes;
-  if (current + bytes <= _gpuMemoryBudget)
-    return true;
-
-  if (!_instancesPendingRelease.empty()) {
-    size_t pendingBytes = 0;
-    for (size_t index : _instancesPendingRelease) {
-      if (index >= _instances.size())
-        continue;
-      const InstanceRecord &inst = _instances[index];
-      pendingBytes += inst.gpu.blasNodesBytes;
-      pendingBytes += inst.gpu.primitiveBytes;
-      pendingBytes += inst.gpu.materialBytes;
-      pendingBytes += inst.gpu.primitiveIndicesBytes;
-    }
-
-    if (pendingBytes > 0) {
-      size_t effectiveCurrent = current > pendingBytes ? current - pendingBytes : 0;
-      if (effectiveCurrent + bytes <= _gpuMemoryBudget)
-        return true;
-    }
-  }
-
-  printf("GPU memory budget exceeded: requested %zu bytes (current %zu, budget %zu)\n",
-         bytes, current, _gpuMemoryBudget);
-  return false;
-}
-
-void Renderer::adjustBudgetForPerformance() {
-  if (_manualBudget)
-    return;
-  if (_gpuMemoryBudget == std::numeric_limits<size_t>::max())
-    return;
-  if (_minInstanceFootprint == 0 && _recentVisibleFootprint == 0)
-    return;
-  if (_lastGPUTime <= 0.0)
-    return;
-
-  size_t minBudget = std::max(_minInstanceFootprint, size_t(16 * 1024 * 1024));
-  if (_recentVisibleFootprint > 0)
-    minBudget = std::max(minBudget, _recentVisibleFootprint);
-  size_t maxBudget = _recommendedBudget != std::numeric_limits<size_t>::max()
-                         ? std::max(_recommendedBudget, minBudget)
-                         : std::max(_gpuMemoryBudget, minBudget);
-
-  size_t newBudget = _gpuMemoryBudget;
-
-  if (_lastGPUTime > _targetFrameTime * kBudgetDecreaseThreshold &&
-      _gpuMemoryBudget > minBudget) {
-    size_t scaled = static_cast<size_t>(
-        static_cast<double>(_gpuMemoryBudget) * kBudgetDecreaseFactor);
-    if (scaled < minBudget)
-      scaled = minBudget;
-    if (scaled < newBudget)
-      newBudget = scaled;
-  } else if (_lastGPUTime < _targetFrameTime * kBudgetIncreaseThreshold &&
-             _gpuMemoryBudget < maxBudget) {
-    size_t scaled = static_cast<size_t>(
-        static_cast<double>(_gpuMemoryBudget) * kBudgetIncreaseFactor);
-    if (scaled < _gpuMemoryBudget + _minInstanceFootprint)
-      scaled = _gpuMemoryBudget + _minInstanceFootprint;
-    if (scaled > maxBudget)
-      scaled = maxBudget;
-    if (scaled > newBudget)
-      newBudget = scaled;
-  }
-
-  if (newBudget != _gpuMemoryBudget) {
-    _gpuMemoryBudget = newBudget;
-    double mb = static_cast<double>(_gpuMemoryBudget) / (1024.0 * 1024.0);
-    printf("Dynamic GPU budget adjusted to %.2f MB (GPU %.2f ms)\n", mb,
-           _lastGPUTime * 1000.0);
-  }
 }
 
 void Renderer::beginFrameMetrics() {
@@ -2127,27 +683,13 @@ void Renderer::completeFrameMetrics(MTL::CommandBuffer *pCmd) {
   } else {
     _lastRaysPerSecond = 0.0;
   }
-  processPendingReleases();
-  adjustBudgetForPerformance();
-  auto [offloadedNodes, offloadedInstances] = calculateOffloadedResidency();
-  double gpuMemoryMB = currentGPUMemoryMB();
-
-  {
-    std::lock_guard<std::mutex> lock(_metricsMutex);
-    _pendingFrameMetrics.cpuTime = _lastCPUTime;
-    _pendingFrameMetrics.gpuTime = _lastGPUTime;
-    _pendingFrameMetrics.raysPerSecond = _lastRaysPerSecond;
-    _pendingFrameMetrics.activeNodes = _activeNodeCount;
-    _pendingFrameMetrics.offloadedNodes = offloadedNodes;
-    _pendingFrameMetrics.offloadedInstances = offloadedInstances;
-    _pendingFrameMetrics.gpuMemoryMB = gpuMemoryMB;
-    _hasPendingMetrics = true;
-  }
-
+  size_t offloaded = _totalNodeCount > _activeNodeCount ?
+                         _totalNodeCount - _activeNodeCount :
+                         0;
   printf(
-      "Nodes active: %zu offloaded: %zu (instances: %zu) CPU: %.3f ms GPU: %.3f ms Rays/s: %.2f\n",
-      _activeNodeCount, offloadedNodes, offloadedInstances,
-      _lastCPUTime * 1000.0, _lastGPUTime * 1000.0, _lastRaysPerSecond);
+      "Nodes active: %zu offloaded: %zu CPU: %.3f ms GPU: %.3f ms Rays/s: %.2f\n",
+      _activeNodeCount, offloaded, _lastCPUTime * 1000.0,
+      _lastGPUTime * 1000.0, _lastRaysPerSecond);
 }
 
 double Renderer::lastCPUTime() const { return _lastCPUTime; }
@@ -2155,11 +697,3 @@ double Renderer::lastGPUTime() const { return _lastGPUTime; }
 double Renderer::lastRaysPerSecond() const { return _lastRaysPerSecond; }
 size_t Renderer::activeNodeCount() const { return _activeNodeCount; }
 size_t Renderer::totalNodeCount() const { return _totalNodeCount; }
-size_t Renderer::offloadedNodeCount() const {
-  return calculateOffloadedResidency().first;
-}
-
-size_t Renderer::offloadedInstanceCount() const {
-  return calculateOffloadedResidency().second;
-}
-

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -6,9 +6,7 @@
 #include <cstdint>
 #include <chrono>
 #include <limits>
-#include <mutex>
 #include <simd/simd.h>
-#include <utility>
 #include <vector>
 
 #include "Scene.h"
@@ -28,7 +26,7 @@ public:
   void recalculateViewport();
   bool updateCamera();
 
-  void updateUniforms(bool cameraChanged);
+  void updateUniforms();
   void draw(MTK::View *pView);
   void drawableSizeWillChange(MTK::View *pView, CGSize size);
 
@@ -39,21 +37,12 @@ public:
   // Dump acceleration structure to a JSON file for debugging.
   void dumpAccelerationStructure(const std::string &path);
 
-  struct FrameMetrics {
-    double cpuTime = 0.0;
-    double gpuTime = 0.0;
-    double raysPerSecond = 0.0;
-    size_t activeNodes = 0;
-    size_t offloadedNodes = 0;
-    size_t offloadedInstances = 0;
-    double gpuMemoryMB = 0.0;
-  };
-
   // Return the amount of GPU memory currently allocated by the device in MB.
   double currentGPUMemoryMB() const;
 
-  // Retrieve the most recently completed frame metrics, if available.
-  bool popCompletedFrameMetrics(FrameMetrics &outMetrics);
+  // Set a maximum GPU memory budget in megabytes. A value of 0 disables the
+  // budget and allows unlimited allocations.
+  void setGPUMemoryBudgetMB(double mb);
 
   // Expose last recorded performance metrics.
   double lastCPUTime() const;
@@ -61,8 +50,14 @@ public:
   double lastRaysPerSecond() const;
   size_t activeNodeCount() const;
   size_t totalNodeCount() const;
-  size_t offloadedNodeCount() const;
-  size_t offloadedInstanceCount() const;
+
+  std::vector<std::pair<simd::float3, float>> _allSpheres;
+
+  struct Chunk {
+    std::vector<std::pair<simd::float4, simd::float4>>
+        spheres; // (transform, material)
+    simd::int3 chunkCoords;
+  };
 
 private:
   MTL::Device *_pDevice = nullptr;
@@ -73,35 +68,25 @@ private:
   Scene *_pScene = nullptr;
 
   // Buffers
+  MTL::Buffer *_pSphereBuffer = nullptr;
+  MTL::Buffer *_pSphereMaterialBuffer = nullptr;
   MTL::Buffer *_pTriangleVertexBuffer = nullptr;
   MTL::Buffer *_pTriangleIndexBuffer = nullptr;
   MTL::Buffer *_pUniformsBuffer = nullptr;
+  MTL::Buffer *_pBVHBuffer = nullptr;
+  MTL::Buffer *_pPrimitiveIndexBuffer = nullptr;
   MTL::Buffer *_pTLASBuffer = nullptr;
-  MTL::Buffer *_pTLASInstanceIndexBuffer = nullptr;
-  MTL::Buffer *_pInstanceMetaBuffer = nullptr;
-  MTL::Buffer *_pInstanceArgBuffer = nullptr;
-  MTL::ArgumentEncoder *_pInstanceArgEncoder = nullptr;
-  MTL::ArgumentEncoder *_pInstanceArgElementEncoder = nullptr;
-  size_t _instanceArgStride = 0;
+  MTL::Buffer *_pActiveBuffer = nullptr;
   size_t _blasNodeCount = 0;
   size_t _tlasNodeCount = 0;
   size_t _activeNodeCount = 0;
   size_t _totalNodeCount = 0;
-  size_t _cpuBlasNodeCount = 0;
-  size_t _residentInstanceCount = 0;
-  size_t _currentBlasNodeCount = 0;
-  size_t _recommendedBudget = std::numeric_limits<size_t>::max();
-  size_t _minInstanceFootprint = 0;
-  size_t _recentVisibleFootprint = 0;
-  bool _manualBudget = false;
-  double _targetFrameTime = 1.0 / 30.0;
   // Accumulation framebuffers
   MTL::Texture *_accumulationTargets[2] = {nullptr, nullptr};
 
   // GPU memory budgeting
   size_t _gpuMemoryBudget = std::numeric_limits<size_t>::max();
-  bool ensureBudget(size_t bytes);
-  void adjustBudgetForPerformance();
+  bool ensureBudget(size_t bytes) const;
 
   struct BoundingSphere {
     simd::float3 center;
@@ -109,107 +94,11 @@ private:
   };
 
   std::vector<Primitive> _allPrimitives;
+  std::vector<bool> _activePrimitive;
+  std::vector<BoundingSphere> _primitiveBounds;
 
-  enum class ResidencyState {
-    NotResident,
-    StreamingIn,
-    Resident,
-    StreamingOut,
-  };
-
-  struct PendingStreamIn {
-    size_t instanceIndex = 0;
-    MTL::CommandBuffer *commandBuffer = nullptr;
-    std::vector<MTL::Buffer *> stagingBuffers;
-  };
-
-  struct InstanceGPU {
-    MTL::Buffer *blasNodes = nullptr;
-    MTL::Buffer *primitives = nullptr;
-    MTL::Buffer *materials = nullptr;
-    MTL::Buffer *primitiveIndices = nullptr;
-    size_t blasNodesBytes = 0;
-    size_t primitiveBytes = 0;
-    size_t materialBytes = 0;
-    size_t primitiveIndicesBytes = 0;
-    uint32_t primitiveCount = 0;
-    uint32_t blasNodeCount = 0;
-    uint32_t rootNodeIndex = 0;
-  };
-
-  struct GPULightData {
-    simd::float4 meta;
-    simd::float4 emission;
-    simd::float4 cdf;
-  };
-
-  struct InstanceRecord {
-    size_t primitiveIndex = 0;
-    uint32_t meshId = kInvalidMeshId;
-    BoundingSphere bounds;
-    simd::float3 aabbMin;
-    simd::float3 aabbMax;
-    std::vector<simd::float4> primitiveData;
-    std::vector<simd::float4> materialData;
-    std::vector<int> primitiveIndices;
-    std::vector<simd::float4> blasNodes;
-    std::vector<simd::float3> primitiveBoundsMin;
-    std::vector<simd::float3> primitiveBoundsMax;
-    uint32_t cpuPrimitiveCount = 0;
-    uint32_t cpuBlasNodeCount = 0;
-    ResidencyState state = ResidencyState::NotResident;
-    InstanceGPU gpu;
-  };
-
-  std::vector<InstanceRecord> _instances;
-  std::vector<size_t> _instancesPendingRelease;
-  std::vector<PendingStreamIn> _pendingStreamIns;
-  std::vector<GPULightData> _lightTable;
-
-  size_t _trackedAllocatedBytes = 0;
-  size_t _uniformsBufferSize = 0;
-  size_t _tlasBufferSize = 0;
-  size_t _tlasInstanceIndexBufferSize = 0;
-  size_t _instanceMetaBufferSize = 0;
-  size_t _instanceArgBufferSize = 0;
-  size_t _lightBufferSize = 0;
-  size_t _accumulationTargetSizes[2] = {0, 0};
-
-  bool streamInInstance(size_t index);
-  void streamOutInstance(size_t index);
-  void releaseInstanceResources(size_t index);
-  void updateInstanceArgument(size_t index);
-  void updateInstanceMetadata(size_t index);
-  void rebuildLightTable();
-  void markLightTableDirty();
-  void rebuildTLAS();
-  void refreshActiveNodeCount();
-  std::pair<size_t, size_t> calculateOffloadedResidency() const;
-  void initializeInstances();
-  void preloadInitialResidency();
-  void processPendingReleases();
-  void processPendingStreamIns();
-  size_t instanceFootprintBytes(const InstanceRecord &inst) const;
-  bool createPrivateBuffer(const void *data, size_t size,
-                           MTL::Buffer **outBuffer,
-                           size_t &sizeTracker);
-  bool createPrivateBuffer(const std::vector<simd::float4> &data,
-                           MTL::Buffer **outBuffer,
-                           size_t &sizeTracker);
-  bool createPrivateBuffer(const std::vector<int> &data,
-                           MTL::Buffer **outBuffer,
-                           size_t &sizeTracker);
-
-  void trackAllocation(size_t bytes);
-  void trackDeallocation(size_t bytes);
-  void releaseBuffer(MTL::Buffer *&buffer, size_t &sizeTracker);
-  void releaseTexture(MTL::Texture *&texture, size_t &sizeTracker);
-
-  bool _pendingAccumulationReset = false;
-  bool _lightTableDirty = true;
-
-  MTL::Buffer *_pLightBuffer = nullptr;
-
+  bool isInView(const BoundingSphere &b);
+  void rebuildAccelerationStructures();
   void updateLODByDistance();
 
   // Performance metrics
@@ -220,11 +109,6 @@ private:
   double _lastGPUTime = 0.0;
   double _lastRaysPerSecond = 0.0;
   size_t _lastRayCount = 0;
-  size_t _lastOffloadedNodeCount = 0;
-  size_t _lastOffloadedInstanceCount = 0;
-  FrameMetrics _pendingFrameMetrics;
-  bool _hasPendingMetrics = false;
-  mutable std::mutex _metricsMutex;
 
   size_t _animationFrame = 0;
 };

--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -7,12 +7,15 @@ using metal::raytracing::ray;
 
 float4 fragment fragmentMain(
     v2f in [[stage_in]],
-    device const UniformsData* uniforms [[buffer(0)]],
-    device const float4* tlasNodes [[buffer(1)]],
-    constant InstanceMetadata* instanceMetadata [[buffer(2)]],
-    device InstanceArgumentBuffer& instanceArgs [[buffer(3)]],
-    device const int* tlasInstanceIndices [[buffer(4)]],
-    device const Light* lights [[buffer(5)]],
+    device const float4* bvhNodes [[buffer(0)]],          // <--- ADD THIS LINE
+    device const float4* primitives [[buffer(1)]],
+    device const float4* materials [[buffer(2)]],
+    device const UniformsData* uniforms [[buffer(3)]],
+    device const float3* vertexBuffer [[buffer(4)]],
+    device const uint3* indexBuffer [[buffer(5)]],
+    device const int* primitiveIndices [[buffer(6)]],
+    device const float4* tlasNodes [[buffer(7)]],
+    device const uchar* activeMask [[buffer(8)]],
     texture2d<float, access::read_write> lastFrame [[texture(0)]],
     texture2d<float, access::read_write> currentFrame [[texture(1)]])
 
@@ -25,12 +28,7 @@ float4 fragment fragmentMain(
         lastFrame.write(0, coord);
     }
 
-    uint seed = uint(random(in.uv, u.randomSeed.xyz) * 4294967295.0);
-
-    ulong frameIndex = u.frameCount;
-    uint frameHash = uint((frameIndex & 0xfffffffful) ^ (frameIndex >> 32));
-    seed ^= frameHash * 747796405u + 2891336453u;
-    seed = random(seed);
+    uint32_t seed = random(in.uv, u.randomSeed.xyz) * ((uint32_t)-1);
 
     float xOff = (randomFloat(seed) - 0.5) / u.screenSize.x;
     seed = random(seed);
@@ -55,12 +53,13 @@ float4 fragment fragmentMain(
         rayDx,
         rayDy,
         tlasNodes,
-        tlasInstanceIndices,
         u.tlasNodeCount,
-        instanceArgs,
-        instanceMetadata,
-        lights,
-        u.lightCount,
+        bvhNodes,
+        primitives,       // <- Each primitive is 3 float4s
+        materials,
+        u.primitiveCount,
+        primitiveIndices,
+        activeMask,
         seed,
         u.maxRayDepth,
         u.debugAS,

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -5,7 +5,6 @@
 #include <metal_stdlib>
 
 #define M_PI 3.14159265358979323846
-#define PRIMITIVE_STRIDE 4
 
 #include "Intersect.h"
 #include "Random.h"
@@ -62,18 +61,13 @@ inline intersection firstHitBVH(thread const ray &r,
                                 device const float4 *bvhNodes,
                                 device const float4 *primitives,
                                 device const int *primitiveIndices,
-                                uint primitiveCount,
-                                int startNode,
-                                int instanceId,
-                                float tMax = INFINITY) {
+                                device const uchar *activeMask,
+                                int startNode) {
   intersection in;
-  in.t = tMax;
+  in.t = INFINITY;
   in.primitiveId = -1;
   in.isTriangle = 0;
   in.nodeIndex = -1;
-  in.instanceId = instanceId;
-
-  bool foundHit = false;
 
   constexpr int stackSize = 64;
   int stack[stackSize];
@@ -88,21 +82,19 @@ inline intersection firstHitBVH(thread const ray &r,
     int leftFirst = as_type<int>(bvhNodes[2 * nodeIdx + 0].w);
     int second = as_type<int>(bvhNodes[2 * nodeIdx + 1].w);
 
-    float currentMax = foundHit ? in.t : tMax;
-    if (!intersectAABB(r, bmin, bmax, 0.0001, currentMax))
+    if (!intersectAABB(r, bmin, bmax, 0.0001, in.t))
       continue;
 
     if (second > 0) {
       int count = second;
       for (int i = 0; i < count; ++i) {
         int primIdx = primitiveIndices[leftFirst + i];
-        if (primIdx >= int(primitiveCount))
+        if (!activeMask[primIdx])
           continue;
-        int base = primIdx * PRIMITIVE_STRIDE;
+        int base = primIdx * 3;
         float4 p0 = primitives[base + 0];
         float4 p1 = primitives[base + 1];
         float4 p2 = primitives[base + 2];
-        float4 p3 = primitives[base + 3];
 
         int primitiveType = int(p0.w);
         float tHit = INFINITY;
@@ -113,11 +105,10 @@ inline intersection firstHitBVH(thread const ray &r,
         if (primitiveType == 0) {
           float3 center = p0.xyz;
           float radius = p1.x;
-          float radiusSq = p1.y > 0.0 ? p1.y : radius * radius;
           float3 oc = r.origin - center;
           float a = dot(r.direction, r.direction);
           float b = dot(oc, r.direction);
-          float c = dot(oc, oc) - radiusSq;
+          float c = dot(oc, oc) - radius * radius;
           float discriminant = b * b - a * c;
 
           if (discriminant > 0.0) {
@@ -132,9 +123,11 @@ inline intersection firstHitBVH(thread const ray &r,
           }
         } else if (primitiveType == 1) {
           float3 v0 = p0.xyz;
-          float3 edge1 = p1.xyz;
-          float3 edge2 = p2.xyz;
-          float3 storedNormal = p3.xyz;
+          float3 v1 = p1.xyz;
+          float3 v2 = p2.xyz;
+
+          float3 edge1 = v1 - v0;
+          float3 edge2 = v2 - v0;
           float3 h = cross(r.direction, edge2);
           float a = dot(edge1, h);
           if (abs(a) > 1e-5) {
@@ -149,11 +142,7 @@ inline intersection firstHitBVH(thread const ray &r,
                 if (tt > 0.0001 && tt < in.t) {
                   tHit = tt;
                   hit = r.origin + tHit * r.direction;
-                  float normalLenSq = dot(storedNormal, storedNormal);
-                  if (normalLenSq > 1e-12)
-                    n = storedNormal;
-                  else
-                    n = normalize(cross(edge1, edge2));
+                  n = normalize(cross(edge1, edge2));
                   hitThis = true;
                   in.isTriangle = 1;
                 }
@@ -164,20 +153,15 @@ inline intersection firstHitBVH(thread const ray &r,
           float3 center = p0.xyz;
           float3 e1 = p1.xyz;
           float3 e2 = p2.xyz;
-          float invDotU = p1.w;
-          float invDotV = p2.w;
-          float3 normal = p3.xyz;
-          float normalLenSq = dot(normal, normal);
-          if (normalLenSq < 1e-12)
-            normal = normalize(cross(e1, e2));
+          float3 normal = normalize(cross(e1, e2));
           float denom = dot(normal, r.direction);
           if (fabs(denom) > 1e-5) {
             float tt = dot(center - r.origin, normal) / denom;
             if (tt > 0.0001 && tt < in.t) {
               float3 hitPoint = r.origin + tt * r.direction;
               float3 rel = hitPoint - center;
-              float u = invDotU > 0.0 ? dot(rel, e1) * invDotU : 0.0;
-              float v = invDotV > 0.0 ? dot(rel, e2) * invDotV : 0.0;
+              float u = dot(rel, e1) / dot(e1, e1);
+              float v = dot(rel, e2) / dot(e2, e2);
               if (fabs(u) <= 1.0 && fabs(v) <= 1.0) {
                 tHit = tt;
                 hit = hitPoint;
@@ -188,14 +172,13 @@ inline intersection firstHitBVH(thread const ray &r,
           }
         }
 
-        if (hitThis && tHit < in.t && tHit < tMax) {
+        if (hitThis && tHit < in.t) {
           in.t = tHit;
           in.primitiveId = primIdx;
           in.normal = n;
           in.point = hit;
           in.isTriangle = primitiveType;
           in.nodeIndex = nodeIdx;
-          foundHit = true;
         }
       }
     } else {
@@ -203,10 +186,6 @@ inline intersection firstHitBVH(thread const ray &r,
       stack[stackPtr++] = leftFirst;
       stack[stackPtr++] = rightChild;
     }
-  }
-
-  if (!foundHit) {
-    in.t = INFINITY;
   }
 
   if (in.primitiveId != -1) {
@@ -218,176 +197,24 @@ inline intersection firstHitBVH(thread const ray &r,
   return in;
 }
 
-inline bool isOccluded(thread const ray &shadowRay, float maxDistance,
-                       device const float4 *tlasNodes,
-                       device const int *tlasInstanceIndices,
-                       uint tlasNodeCount,
-                       device InstanceArgumentBuffer &instanceArgs,
-                       constant InstanceMetadata *instanceMetadata,
-                       uint targetInstance,
-                       int targetPrimitive) {
-  if (tlasNodeCount == 0)
-    return false;
-
-  constexpr int stackSize = 128;
-  int stack[stackSize];
-  int stackPtr = 0;
-  stack[stackPtr++] = 0;
-
-  while (stackPtr > 0) {
-    int nodeIdx = stack[--stackPtr];
-    float3 bmin = tlasNodes[2 * nodeIdx + 0].xyz;
-    float3 bmax = tlasNodes[2 * nodeIdx + 1].xyz;
-    int leftFirst = as_type<int>(tlasNodes[2 * nodeIdx + 0].w);
-    int second = as_type<int>(tlasNodes[2 * nodeIdx + 1].w);
-
-    if (!intersectAABB(shadowRay, bmin, bmax, 0.0001, maxDistance))
-      continue;
-
-    if (second > 0) {
-      for (int i = 0; i < second; ++i) {
-        int instanceId = tlasInstanceIndices[leftFirst + i];
-        if (instanceId < 0 || instanceId >= MAX_INSTANCE_COUNT)
-          continue;
-        const constant InstanceMetadata &meta = instanceMetadata[instanceId];
-        if (meta.primitiveCount == 0)
-          continue;
-        const device InstanceResources &resources =
-            instanceArgs.instances[instanceId];
-
-        intersection hit = firstHitBVH(shadowRay, resources.blasNodes,
-                                       resources.primitives,
-                                       resources.primitiveIndices,
-                                       meta.primitiveCount,
-                                       int(meta.rootNodeIndex), instanceId,
-                                       maxDistance);
-        if (hit.primitiveId != -1) {
-          if (instanceId == int(targetInstance) &&
-              targetPrimitive >= 0 &&
-              hit.primitiveId == targetPrimitive) {
-            // Ignore the sampled light itself when it is exactly at the
-            // maximum distance.
-            if (hit.t >= maxDistance * 0.999f)
-              continue;
-          }
-          return true;
-        }
-      }
-    } else {
-      int rightChild = -second;
-      stack[stackPtr++] = leftFirst;
-      stack[stackPtr++] = rightChild;
-    }
-  }
-
-  return false;
-}
-
-inline bool sampleLightPrimitive(int primitiveType,
-                                 device const float4 *primitives,
-                                 int baseIndex,
-                                 thread uint32_t &seed,
-                                 thread float3 &position,
-                                 thread float3 &normal) {
-  float4 p0 = primitives[baseIndex + 0];
-  float4 p1 = primitives[baseIndex + 1];
-  float4 p2 = primitives[baseIndex + 2];
-  float4 p3 = primitives[baseIndex + 3];
-
-  if (primitiveType == 0) {
-    float3 center = p0.xyz;
-    float radius = p1.x;
-    float u1 = randomFloat(seed);
-    seed = random(seed);
-    float u2 = randomFloat(seed);
-    seed = random(seed);
-    float z = 1.0 - 2.0 * u1;
-    float r = sqrt(fmax(0.0, 1.0 - z * z));
-    float phi = 2.0 * M_PI * u2;
-    float x = r * cos(phi);
-    float y = r * sin(phi);
-    normal = normalize(float3(x, y, z));
-    position = center + radius * normal;
-    return true;
-  } else if (primitiveType == 1) {
-    float3 v0 = p0.xyz;
-    float3 edge1 = p1.xyz;
-    float3 edge2 = p2.xyz;
-    float u1 = randomFloat(seed);
-    seed = random(seed);
-    float u2 = randomFloat(seed);
-    seed = random(seed);
-    float su1 = sqrt(u1);
-    float b1 = su1 * (1.0 - u2);
-    float b2 = su1 * u2;
-    position = v0 + b1 * edge1 + b2 * edge2;
-    normal = p3.xyz;
-    float lenSq = dot(normal, normal);
-    if (lenSq < 1e-12)
-      normal = normalize(cross(edge1, edge2));
-    else
-      normal = normalize(normal);
-    return true;
-  } else if (primitiveType == 2) {
-    float3 center = p0.xyz;
-    float3 u = p1.xyz;
-    float3 v = p2.xyz;
-    float u1 = randomFloat(seed);
-    seed = random(seed);
-    float u2 = randomFloat(seed);
-    seed = random(seed);
-    float sx = 2.0 * u1 - 1.0;
-    float sy = 2.0 * u2 - 1.0;
-    position = center + sx * u + sy * v;
-    normal = p3.xyz;
-    float lenSq = dot(normal, normal);
-    if (lenSq < 1e-12)
-      normal = normalize(cross(u, v));
-    else
-      normal = normalize(normal);
-    return true;
-  }
-
-  return false;
-}
-
 inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
                        device const float4 *tlasNodes,
-                       device const int *tlasInstanceIndices,
-                       uint tlasNodeCount,
-                       device InstanceArgumentBuffer &instanceArgs,
-                       constant InstanceMetadata *instanceMetadata,
-                       device const Light *lights,
-                       uint lightCount,
+                       uint tlasNodeCount, device const float4 *bvhNodes,
+                       device const float4 *primitives,
+                       device const float4 *materials, uint primitiveCount,
+                       device const int *primitiveIndices,
+                       device const uchar *activeMask,
                        thread uint32_t &seed, uint maxRayDepth,
                        uint debugAS, uint blasNodeCount) {
   float footprint = length(cross(rayDx, rayDy));
   float lodAtten = 1.0 / (1.0 + footprint);
   if (debugAS == 1) {
-    if (tlasNodeCount == 0)
-      return float4(0.0, 0.0, 0.0, 1.0);
-    constexpr int stackSize = 128;
-    int stack[stackSize];
-    int stackPtr = 0;
-    if (stackPtr < stackSize)
-      stack[stackPtr++] = 0;
-    while (stackPtr > 0) {
-      int nodeIdx = stack[--stackPtr];
-      float3 bmin = tlasNodes[2 * nodeIdx + 0].xyz;
-      float3 bmax = tlasNodes[2 * nodeIdx + 1].xyz;
-      int leftFirst = as_type<int>(tlasNodes[2 * nodeIdx + 0].w);
-      int second = as_type<int>(tlasNodes[2 * nodeIdx + 1].w);
-      if (!intersectAABB(r, bmin, bmax, 0.0001, INFINITY))
-        continue;
-      if (second > 0) {
-        float t = (tlasNodeCount > 1) ? float(nodeIdx) / float(tlasNodeCount - 1)
-                                      : 0.0;
+    for (uint i = 0; i < tlasNodeCount; ++i) {
+      float3 bmin = tlasNodes[2 * i + 0].xyz;
+      float3 bmax = tlasNodes[2 * i + 1].xyz;
+      if (intersectAABB(r, bmin, bmax, 0.0001, INFINITY)) {
+        float t = (tlasNodeCount > 1) ? float(i) / float(tlasNodeCount - 1) : 0.0;
         return float4(t, 1.0 - t, 0.0, 1.0);
-      }
-      int rightChild = -second;
-      if (stackPtr + 2 <= stackSize) {
-        stack[stackPtr++] = leftFirst;
-        stack[stackPtr++] = rightChild;
       }
     }
     return float4(0.0, 0.0, 0.0, 1.0);
@@ -395,48 +222,17 @@ inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
     intersection bestHit;
     bestHit.t = INFINITY;
     bestHit.primitiveId = -1;
-    bestHit.nodeIndex = -1;
-    bestHit.instanceId = -1;
-    if (tlasNodeCount == 0)
-      return float4(0.0, 0.0, 0.0, 1.0);
-    constexpr int stackSize = 128;
-    int stack[stackSize];
-    int stackPtr = 0;
-    if (stackPtr < stackSize)
-      stack[stackPtr++] = 0;
-    while (stackPtr > 0) {
-      int nodeIdx = stack[--stackPtr];
-      float3 bmin = tlasNodes[2 * nodeIdx + 0].xyz;
-      float3 bmax = tlasNodes[2 * nodeIdx + 1].xyz;
-      int leftFirst = as_type<int>(tlasNodes[2 * nodeIdx + 0].w);
-      int second = as_type<int>(tlasNodes[2 * nodeIdx + 1].w);
+    for (uint i = 0; i < tlasNodeCount; ++i) {
+      float3 bmin = tlasNodes[2 * i + 0].xyz;
+      float3 bmax = tlasNodes[2 * i + 1].xyz;
+      int startNode = as_type<int>(tlasNodes[2 * i + 0].w);
       if (!intersectAABB(r, bmin, bmax, 0.0001, bestHit.t))
         continue;
-      if (second > 0) {
-        for (int i = 0; i < second; ++i) {
-          int instanceId = tlasInstanceIndices[leftFirst + i];
-          if (instanceId < 0 || instanceId >= MAX_INSTANCE_COUNT)
-            continue;
-          const constant InstanceMetadata &meta = instanceMetadata[instanceId];
-          if (meta.primitiveCount == 0)
-            continue;
-          const device InstanceResources &resources =
-              instanceArgs.instances[instanceId];
-          intersection hit = firstHitBVH(r, resources.blasNodes,
-                                         resources.primitives,
-                                         resources.primitiveIndices,
-                                         meta.primitiveCount,
-                                         int(meta.rootNodeIndex), instanceId);
-          if (hit.primitiveId != -1 && hit.t < bestHit.t)
-            bestHit = hit;
-        }
-      } else {
-        int rightChild = -second;
-        if (stackPtr + 2 <= stackSize) {
-          stack[stackPtr++] = leftFirst;
-          stack[stackPtr++] = rightChild;
-        }
-      }
+      intersection hit =
+          firstHitBVH(r, bvhNodes, primitives, primitiveIndices, activeMask,
+                     startNode);
+      if (hit.primitiveId != -1 && hit.t < bestHit.t)
+        bestHit = hit;
     }
     if (bestHit.primitiveId != -1) {
       float t = (blasNodeCount > 1)
@@ -447,201 +243,68 @@ inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
     return float4(0.0, 0.0, 0.0, 1.0);
   }
 
-  float3 throughput = float3(1.0);
-  float3 radiance = float3(0.0);
+  float4 absorption = float4(1.0);
+  float4 light = float4(0.0);
 
   for (uint depth = 0; depth < maxRayDepth; ++depth) {
     intersection bestHit;
     bestHit.t = INFINITY;
     bestHit.primitiveId = -1;
-    bestHit.nodeIndex = -1;
-    bestHit.instanceId = -1;
 
-    if (tlasNodeCount > 0) {
-      constexpr int stackSize = 128;
-      int stack[stackSize];
-      int stackPtr = 0;
-      if (stackPtr < stackSize)
-        stack[stackPtr++] = 0;
+    for (uint i = 0; i < tlasNodeCount; ++i) {
+      float3 bmin = tlasNodes[2 * i + 0].xyz;
+      float3 bmax = tlasNodes[2 * i + 1].xyz;
+      int startNode = as_type<int>(tlasNodes[2 * i + 0].w);
 
-      while (stackPtr > 0) {
-        int nodeIdx = stack[--stackPtr];
-        float3 bmin = tlasNodes[2 * nodeIdx + 0].xyz;
-        float3 bmax = tlasNodes[2 * nodeIdx + 1].xyz;
-        int leftFirst = as_type<int>(tlasNodes[2 * nodeIdx + 0].w);
-        int second = as_type<int>(tlasNodes[2 * nodeIdx + 1].w);
-        if (!intersectAABB(r, bmin, bmax, 0.0001, bestHit.t))
-          continue;
-        if (second > 0) {
-          for (int i = 0; i < second; ++i) {
-            int instanceId = tlasInstanceIndices[leftFirst + i];
-            if (instanceId < 0 || instanceId >= MAX_INSTANCE_COUNT)
-              continue;
-            const constant InstanceMetadata &meta =
-                instanceMetadata[instanceId];
-            if (meta.primitiveCount == 0)
-              continue;
-            const device InstanceResources &resources =
-                instanceArgs.instances[instanceId];
+      if (!intersectAABB(r, bmin, bmax, 0.0001, bestHit.t))
+        continue;
 
-            intersection hit = firstHitBVH(r, resources.blasNodes,
-                                           resources.primitives,
-                                           resources.primitiveIndices,
-                                           meta.primitiveCount,
-                                           int(meta.rootNodeIndex),
-                                           instanceId);
-            if (hit.primitiveId != -1 && hit.t < bestHit.t)
-              bestHit = hit;
-          }
-        } else {
-          int rightChild = -second;
-          if (stackPtr + 2 <= stackSize) {
-            stack[stackPtr++] = leftFirst;
-            stack[stackPtr++] = rightChild;
-          }
-        }
-      }
+      intersection hit =
+          firstHitBVH(r, bvhNodes, primitives, primitiveIndices, activeMask,
+                     startNode);
+      if (hit.primitiveId != -1 && hit.t < bestHit.t)
+        bestHit = hit;
     }
 
     if (bestHit.primitiveId == -1) {
       float3 unitDir = normalize(r.direction);
       float t = 0.5 * (unitDir.y + 1.0);
       float3 skyColor = mix(float3(1.0), float3(0.6, 0.7, 1.0), t);
-      radiance += throughput * skyColor;
+      light += absorption * float4(skyColor, 1.0);
       break;
     }
     int matIndex = bestHit.primitiveId * 2;
-    const constant InstanceMetadata &hitMeta =
-        instanceMetadata[bestHit.instanceId];
-    if (matIndex + 1 >= int(hitMeta.primitiveCount) * 2)
+    if (matIndex + 1 >= int(primitiveCount) * 2)
       break;
-    const device InstanceResources &hitResources =
-        instanceArgs.instances[bestHit.instanceId];
-    float4 m0 = hitResources.materials[matIndex + 0];
-    float4 m1 = hitResources.materials[matIndex + 1];
+    float4 m0 = materials[matIndex + 0];
+    float4 m1 = materials[matIndex + 1];
 
     float3 albedo = m0.xyz * lodAtten;
     float materialType = m0.w;
     float3 emissionColor = m1.xyz;
     float emissionPower = m1.w;
 
-    bool isEmitter = (emissionPower > 0.0 || materialType == 2);
-    if (isEmitter) {
-      radiance += throughput * (emissionColor * emissionPower);
-    }
-
-    if (lightCount > 0 && lights != nullptr && materialType == 0.0 &&
-        !isEmitter) {
-      float selectXi = randomFloat(seed);
-      seed = random(seed);
-
-      uint chosen = 0;
-      if (lightCount > 1) {
-        uint left = 0;
-        uint right = lightCount;
-        while (left < right) {
-          uint mid = (left + right) / 2;
-          float cdf = lights[mid].cdf.x;
-          if (selectXi < cdf)
-            right = mid;
-          else
-            left = mid + 1;
-        }
-        chosen = min(left, lightCount - 1);
-      }
-
-      const device Light &lightEntry = lights[chosen];
-      float lightPdf = lightEntry.meta.w;
-      float area = lightEntry.meta.z;
-      if (lightPdf > 0.0 && area > 0.0) {
-        uint lightInstance = as_type<uint>(lightEntry.meta.x);
-        uint lightPrimitive = as_type<uint>(lightEntry.meta.y);
-        if (lightInstance < MAX_INSTANCE_COUNT) {
-          const constant InstanceMetadata &lightMeta =
-              instanceMetadata[lightInstance];
-          if (lightPrimitive < lightMeta.primitiveCount) {
-            const device InstanceResources &lightResources =
-                instanceArgs.instances[lightInstance];
-            if (lightResources.primitives != nullptr &&
-                lightResources.materials != nullptr) {
-              int baseIndex = int(lightPrimitive) * PRIMITIVE_STRIDE;
-              int maxIndex = int(lightMeta.primitiveCount) * PRIMITIVE_STRIDE;
-              if (baseIndex + 3 < maxIndex) {
-                float3 lightPos;
-                float3 lightNormal;
-                bool sampled = sampleLightPrimitive(
-                    int(lightResources.primitives[baseIndex].w),
-                    lightResources.primitives, baseIndex, seed, lightPos,
-                    lightNormal);
-                if (sampled) {
-                  float3 toLight = lightPos - bestHit.point;
-                  float distSq = dot(toLight, toLight);
-                  float dist = sqrt(distSq);
-                  if (dist > 1e-4) {
-                    float3 wi = toLight / dist;
-                    float cosSurface = fmax(0.0, dot(bestHit.normal, wi));
-                    float cosLight = fmax(0.0, dot(lightNormal, -wi));
-                    if (cosSurface > 0.0 && cosLight > 0.0) {
-                      float shadowMax = dist - 0.001;
-                      bool blocked = false;
-                      if (shadowMax > 0.0) {
-                        ray shadowRay{bestHit.point + bestHit.normal * 0.0005f,
-                                      wi};
-                        shadowRay.min_distance = 0.0001f;
-                        shadowRay.max_distance = shadowMax;
-                        blocked = isOccluded(
-                            shadowRay, shadowMax, tlasNodes, tlasInstanceIndices,
-                            tlasNodeCount, instanceArgs, instanceMetadata,
-                            lightInstance, int(lightPrimitive));
-                      }
-                      if (!blocked) {
-                        float3 emission = lightEntry.emission.xyz *
-                                          lightEntry.emission.w;
-                        float pdfArea = lightPdf / area;
-                        if (pdfArea > 0.0) {
-                          float3 bsdfVal = evaluateBSDF(-r.direction, wi,
-                                                        bestHit.normal,
-                                                        materialType, albedo);
-                          float geometry = cosLight / max(distSq, 1e-6f);
-                          float3 direct = emission * bsdfVal * cosSurface *
-                                          geometry / pdfArea;
-                          radiance += throughput * direct;
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+    if (emissionPower > 0.0 || materialType == 2) {
+      light += absorption * float4(emissionColor, 1.0) * emissionPower;
     }
 
     float3 offsetNormal = bestHit.frontFace ? bestHit.normal : -bestHit.normal;
     r.origin = bestHit.point + 0.0001 * offsetNormal;
-    BSDFSample sample = sampleBSDF(r.direction, bestHit.normal,
-                                   bestHit.frontFace, materialType, albedo,
-                                   seed);
-    if (sample.pdf <= 0.0 || all(sample.weight <= float3(0.0)))
-      break;
-
-    throughput *= sample.weight;
-    r.direction = sample.direction;
-    r.min_distance = 0.0001;
-    r.max_distance = INFINITY;
+    scatter(r, bestHit, materialType, seed);
+    seed = random(seed);
+    absorption *= float4(albedo, 1.0);
 
     if (depth >= 5) {
-      float p = max(throughput.x, max(throughput.y, throughput.z));
+      float p = max(absorption.x, max(absorption.y, absorption.z));
       float randVal = randomFloat(seed);
       seed = random(seed);
       if (randVal >= p)
         break;
-      throughput /= p;
+      absorption /= p;
     }
   }
 
-  return float4(clamp(radiance, 0.0, 1.0), 1.0);
+  return clamp(light, 0.0, 1.0);
 }
 
 #endif

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -18,38 +18,6 @@ struct intersection
     int primitiveId = -1;
     int isTriangle = 0;
     int nodeIndex = -1; // BLAS leaf node index
-    int instanceId = -1;
-};
-
-
-struct InstanceMetadata
-{
-    uint primitiveCount;
-    uint blasNodeCount;
-    uint rootNodeIndex;
-    uint padding;
-};
-
-#define MAX_INSTANCE_COUNT 16384
-
-struct InstanceResources
-{
-    device const float4* blasNodes [[id(0)]];
-    device const float4* primitives [[id(1)]];
-    device const float4* materials [[id(2)]];
-    device const int* primitiveIndices [[id(3)]];
-};
-
-struct InstanceArgumentBuffer
-{
-    metal::array<InstanceResources, MAX_INSTANCE_COUNT> instances;
-};
-
-struct Light
-{
-    float4 meta;     // instanceId bits, primitiveIndex bits, area, light selection PDF
-    float4 emission; // emissionColor, emissionPower
-    float4 cdf;      // cumulative probability, padding
 };
 
 
@@ -75,10 +43,6 @@ struct UniformsData
     uint64_t blasNodeCount;
     uint maxRayDepth;
     uint debugAS;
-    uint residentInstanceCount;
-    uint totalInstanceCount;
-    uint lightCount;
-    uint paddingUniforms[3];
 };
 
 


### PR DESCRIPTION
## Summary
- restore the renderer implementation to the version prior to commit a31ad06, removing the per-instance residency streaming changes
- revert shader structures and uniforms to their earlier definitions to match the restored renderer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5764e2504832d940a8ccae52434e6