### PR TITLE
Define scatter helper for ray bounce

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -21,7 +21,9 @@ template <typename T> inline void swap(thread T &a, thread T &b) {
 
 inline float3 randomUnitVector(thread uint32_t &seed) {
   float z = 2.0 * randomFloat(seed) - 1.0;
+  seed = random(seed);
   float t = 2.0 * M_PI * randomFloat(seed);
+  seed = random(seed);
   float r = sqrt(1.0 - z * z);
   return float3(r * cos(t), r * sin(t), z);
 }
@@ -29,9 +31,13 @@ inline float3 randomUnitVector(thread uint32_t &seed) {
 // Helper: Random point in unit sphere
 inline float3 randomInUnitSphere(thread uint32_t &seed) {
   while (true) {
-    float3 p =
-        2.0 * float3(randomFloat(seed), randomFloat(seed), randomFloat(seed)) -
-        float3(1.0);
+    float x = 2.0 * randomFloat(seed) - 1.0;
+    seed = random(seed);
+    float y = 2.0 * randomFloat(seed) - 1.0;
+    seed = random(seed);
+    float z = 2.0 * randomFloat(seed) - 1.0;
+    seed = random(seed);
+    float3 p = float3(x, y, z);
 
     if (length_squared(p) < 1.0)
       return p;

--- a/MetalCpp Path Tracer/Renderer/Shaders/Scatter.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Scatter.h
@@ -7,6 +7,8 @@
 #include "Random.h"
 #include "Structs.h"
 
+using namespace metal;
+
 struct BSDFSample {
   float3 direction;
   float3 weight; // bsdf * cos(theta) / pdf contribution
@@ -106,6 +108,41 @@ inline float3 evaluateBSDF(thread const float3 &inDir,
   }
   // Delta materials have zero contribution for arbitrary directions
   return float3(0.0);
+}
+
+inline float schlickReflectance(float cosine, float refIdx) {
+  float r0 = (1.0 - refIdx) / (1.0 + refIdx);
+  r0 = r0 * r0;
+  return r0 + (1.0 - r0) * pow((1.0 - cosine), 5.0);
+}
+
+inline void scatter(thread ray &r, thread const intersection &hit,
+                    float materialType, thread uint32_t &seed) {
+  float3 normal = hit.frontFace ? hit.normal : -hit.normal;
+
+  if (materialType == 0.0) {
+    float3 scatterDir = normal + randomUnitVector(seed);
+    seed = random(seed);
+    if (length_squared(scatterDir) < 1e-6)
+      scatterDir = normal;
+    r.direction = normalize(scatterDir);
+  } else if (materialType < 0.0) {
+    r.direction = normalize(reflect(r.direction, normal));
+  } else {
+    float refractionRatio = hit.frontFace ? (1.0 / materialType) : materialType;
+    float cosTheta = fmin(dot(-r.direction, normal), 1.0);
+    float sinTheta = sqrt(fmax(0.0, 1.0 - cosTheta * cosTheta));
+    bool cannotRefract = refractionRatio * sinTheta > 1.0;
+    float reflectProb = schlickReflectance(cosTheta, materialType);
+    bool shouldReflect = cannotRefract || reflectProb > randomFloat(seed);
+    seed = random(seed);
+    float3 dir = shouldReflect ? reflect(r.direction, normal)
+                               : refract(r.direction, normal, refractionRatio);
+    r.direction = normalize(dir);
+  }
+
+  r.min_distance = 0.0001;
+  r.max_distance = INFINITY;
 }
 
 #endif


### PR DESCRIPTION
## Summary
- add a scatter helper in Scatter.h to update ray directions for diffuse, reflective, and dielectric materials
- fix random sampling utilities to advance the RNG seed between samples so that scatter uses varied directions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d57797d8c4832d9fc2d343985f0438