### PR TITLE
Fix scatter utilities declarations

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -19,15 +19,6 @@ template <typename T> inline void swap(thread T &a, thread T &b) {
   b = tmp;
 }
 
-inline float3 randomUnitVector(thread uint32_t &seed) {
-  float z = 2.0 * randomFloat(seed) - 1.0;
-  seed = random(seed);
-  float t = 2.0 * M_PI * randomFloat(seed);
-  seed = random(seed);
-  float r = sqrt(1.0 - z * z);
-  return float3(r * cos(t), r * sin(t), z);
-}
-
 // Helper: Random point in unit sphere
 inline float3 randomInUnitSphere(thread uint32_t &seed) {
   while (true) {

--- a/MetalCpp Path Tracer/Renderer/Shaders/Random.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Random.h
@@ -25,8 +25,19 @@ inline float3 randomFloat3(uint32_t seed)
 
     const float z = randomFloat(seed)*2-1;
     seed = random(seed);
-    
+
     return {x, y, z};
+}
+
+inline float3 randomUnitVector(thread uint32_t &seed)
+{
+    constexpr float twoPi = 6.28318530717958647692;
+    float z = randomFloat(seed) * 2.0 - 1.0;
+    seed = random(seed);
+    float t = twoPi * randomFloat(seed);
+    seed = random(seed);
+    float r = sqrt(fmax(0.0, 1.0 - z * z));
+    return float3(r * cos(t), r * sin(t), z);
 }
 
 inline float random(float2 uv, float3 random)


### PR DESCRIPTION
## Summary
- provide a shared implementation of randomUnitVector in Random.h for scatter code
- remove the redundant randomUnitVector definition from PathTracing.h so Scatter.h compiles

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d578cae4d4832d92f05296845b6948