### PR TITLE
Build per-object TLAS BVH and GPU traversal

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -568,10 +568,20 @@ void Renderer::dumpAccelerationStructure(const std::string &path) {
   for (size_t i = 0; i < tlasCount; ++i) {
     simd::float4 bmin = tlasData[2 * i];
     simd::float4 bmax = tlasData[2 * i + 1];
-    int childIndex = reinterpret_cast<const int *>(&bmin)[3];
-    out << "    {\"child\":" << childIndex << ",\"min\":[" << bmin.x << ","
-        << bmin.y << "," << bmin.z << "],\"max\":[" << bmax.x << "," << bmax.y
-        << "," << bmax.z << "]}";
+    int first = reinterpret_cast<const int *>(&bmin)[3];
+    int second = reinterpret_cast<const int *>(&bmax)[3];
+    bool isLeaf = first < 0;
+    out << "    {\"index\":" << i << ",\"leaf\":"
+        << (isLeaf ? "true" : "false") << ",\"min\":[" << bmin.x << ","
+        << bmin.y << "," << bmin.z << "],\"max\":[" << bmax.x << ","
+        << bmax.y << "," << bmax.z << "]";
+    if (isLeaf) {
+      int objectIndex = -(first + 1);
+      out << ",\"object\":" << objectIndex << ",\"blasRoot\":" << second;
+    } else {
+      out << ",\"left\":" << first << ",\"right\":" << second;
+    }
+    out << "}";
     if (i + 1 < tlasCount)
       out << ",\n";
     else

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -197,6 +197,90 @@ inline intersection firstHitBVH(thread const ray &r,
   return in;
 }
 
+inline intersection
+firstHitTLAS(thread const ray &r, device const float4 *tlasNodes,
+             uint tlasNodeCount, device const float4 *bvhNodes,
+             device const float4 *primitives, device const int *primitiveIndices,
+             device const uchar *activeMask) {
+  intersection bestHit;
+  bestHit.t = INFINITY;
+  bestHit.primitiveId = -1;
+  bestHit.nodeIndex = -1;
+  bestHit.isTriangle = 0;
+
+  if (tlasNodeCount == 0)
+    return bestHit;
+
+  constexpr int stackSize = 64;
+  int stack[stackSize];
+  int stackPtr = 0;
+  stack[stackPtr++] = 0;
+
+  while (stackPtr > 0) {
+    int nodeIdx = stack[--stackPtr];
+    float3 bmin = tlasNodes[2 * nodeIdx + 0].xyz;
+    float3 bmax = tlasNodes[2 * nodeIdx + 1].xyz;
+
+    if (!intersectAABB(r, bmin, bmax, 0.0001, bestHit.t))
+      continue;
+
+    int leftChild = as_type<int>(tlasNodes[2 * nodeIdx + 0].w);
+    int rightChild = as_type<int>(tlasNodes[2 * nodeIdx + 1].w);
+
+    if (leftChild < 0) {
+      int blasRoot = rightChild;
+      if (blasRoot >= 0) {
+        intersection hit = firstHitBVH(r, bvhNodes, primitives,
+                                       primitiveIndices, activeMask, blasRoot);
+        if (hit.primitiveId != -1 && hit.t < bestHit.t)
+          bestHit = hit;
+      }
+      continue;
+    }
+
+    bool leftHit = false;
+    bool rightHit = false;
+    float leftKey = INFINITY;
+    float rightKey = INFINITY;
+
+    if (leftChild >= 0) {
+      float3 leftMin = tlasNodes[2 * leftChild + 0].xyz;
+      float3 leftMax = tlasNodes[2 * leftChild + 1].xyz;
+      leftHit = intersectAABB(r, leftMin, leftMax, 0.0001, bestHit.t);
+      leftKey = dot((leftMin + leftMax) * 0.5 - r.origin, r.direction);
+    }
+
+    if (rightChild >= 0) {
+      float3 rightMin = tlasNodes[2 * rightChild + 0].xyz;
+      float3 rightMax = tlasNodes[2 * rightChild + 1].xyz;
+      rightHit = intersectAABB(r, rightMin, rightMax, 0.0001, bestHit.t);
+      rightKey = dot((rightMin + rightMax) * 0.5 - r.origin, r.direction);
+    }
+
+    if (leftHit && rightHit) {
+      if (stackPtr + 2 <= stackSize) {
+        if (leftKey < rightKey) {
+          stack[stackPtr++] = rightChild;
+          stack[stackPtr++] = leftChild;
+        } else {
+          stack[stackPtr++] = leftChild;
+          stack[stackPtr++] = rightChild;
+        }
+      } else if (stackPtr < stackSize) {
+        stack[stackPtr++] = (leftKey < rightKey) ? leftChild : rightChild;
+      }
+    } else if (leftHit) {
+      if (stackPtr < stackSize)
+        stack[stackPtr++] = leftChild;
+    } else if (rightHit) {
+      if (stackPtr < stackSize)
+        stack[stackPtr++] = rightChild;
+    }
+  }
+
+  return bestHit;
+}
+
 inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
                        device const float4 *tlasNodes,
                        uint tlasNodeCount, device const float4 *bvhNodes,
@@ -219,21 +303,9 @@ inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
     }
     return float4(0.0, 0.0, 0.0, 1.0);
   } else if (debugAS == 2) {
-    intersection bestHit;
-    bestHit.t = INFINITY;
-    bestHit.primitiveId = -1;
-    for (uint i = 0; i < tlasNodeCount; ++i) {
-      float3 bmin = tlasNodes[2 * i + 0].xyz;
-      float3 bmax = tlasNodes[2 * i + 1].xyz;
-      int startNode = as_type<int>(tlasNodes[2 * i + 0].w);
-      if (!intersectAABB(r, bmin, bmax, 0.0001, bestHit.t))
-        continue;
-      intersection hit =
-          firstHitBVH(r, bvhNodes, primitives, primitiveIndices, activeMask,
-                     startNode);
-      if (hit.primitiveId != -1 && hit.t < bestHit.t)
-        bestHit = hit;
-    }
+    intersection bestHit = firstHitTLAS(r, tlasNodes, tlasNodeCount, bvhNodes,
+                                        primitives, primitiveIndices,
+                                        activeMask);
     if (bestHit.primitiveId != -1) {
       float t = (blasNodeCount > 1)
                     ? float(bestHit.nodeIndex) / float(blasNodeCount - 1)
@@ -247,24 +319,9 @@ inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
   float4 light = float4(0.0);
 
   for (uint depth = 0; depth < maxRayDepth; ++depth) {
-    intersection bestHit;
-    bestHit.t = INFINITY;
-    bestHit.primitiveId = -1;
-
-    for (uint i = 0; i < tlasNodeCount; ++i) {
-      float3 bmin = tlasNodes[2 * i + 0].xyz;
-      float3 bmax = tlasNodes[2 * i + 1].xyz;
-      int startNode = as_type<int>(tlasNodes[2 * i + 0].w);
-
-      if (!intersectAABB(r, bmin, bmax, 0.0001, bestHit.t))
-        continue;
-
-      intersection hit =
-          firstHitBVH(r, bvhNodes, primitives, primitiveIndices, activeMask,
-                     startNode);
-      if (hit.primitiveId != -1 && hit.t < bestHit.t)
-        bestHit = hit;
-    }
+    intersection bestHit = firstHitTLAS(r, tlasNodes, tlasNodeCount, bvhNodes,
+                                        primitives, primitiveIndices,
+                                        activeMask);
 
     if (bestHit.primitiveId == -1) {
       float3 unitDir = normalize(r.direction);

--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -1,7 +1,10 @@
 #include "Scene.h"
 #include <algorithm>
 #include <cstdio>
+#include <cstring>
 #include <limits>
+#include <numeric>
+#include <vector>
 
 namespace MetalCppPathTracer {
 
@@ -11,13 +14,43 @@ void Scene::clear() {
   primitives.clear();
   bvhNodes.clear();
   primitiveIndices.clear();
+  objects.clear();
+  objectIndices.clear();
+  tlasNodes.clear();
   cameraPath.clear();
   screenSize = {1280.f, 720.f};
   maxRayDepth = 32;
 }
 
-size_t Scene::addPrimitive(const Primitive &p) {
-  primitives.push_back(p);
+size_t Scene::addPrimitive(const Primitive &p) { return addObjectInternal(&p, 1); }
+
+size_t Scene::addObject(const std::vector<Primitive> &prims) {
+  if (prims.empty())
+    return primitives.size();
+  return addObjectInternal(prims.data(), prims.size());
+}
+
+size_t Scene::addObjectInternal(const Primitive *prims, size_t count) {
+  if (count == 0)
+    return primitives.size();
+
+  size_t start = primitives.size();
+  primitives.insert(primitives.end(), prims, prims + count);
+
+  SceneObject object;
+  object.firstPrimitive = start;
+  object.primitiveCount = count;
+  objects.push_back(object);
+
+  for (size_t i = 0; i < count; ++i) {
+    const Primitive &p = primitives[start + i];
+    if (p.type == PrimitiveType::Sphere) {
+      const auto &s = p.sphere;
+      printf("Sphere -> Position: (%.2f, %.2f, %.2f), Radius: %.2f\n",
+             s.center.x, s.center.y, s.center.z, s.radius);
+    }
+  }
+
   return primitives.size() - 1;
 }
 
@@ -56,25 +89,36 @@ const std::vector<size_t> &Scene::getPrimitiveIndices() const {
 }
 
 void Scene::buildBVH() {
-  std::stable_sort(primitives.begin(), primitives.end(),
-                   [](const Primitive &a, const Primitive &b) {
-                     return static_cast<int>(a.type) < static_cast<int>(b.type);
-                   });
-
   primitiveIndices.resize(primitives.size());
-  for (size_t i = 0; i < primitives.size(); ++i)
-    primitiveIndices[i] = i;
+  std::iota(primitiveIndices.begin(), primitiveIndices.end(), 0);
 
   bvhNodes.clear();
-  buildBVHRecursive(0, primitives.size());
+  tlasNodes.clear();
+  objectIndices.clear();
 
-  for (const auto &p : primitives) {
-    if (p.type == PrimitiveType::Sphere) {
-      const auto &s = p.sphere;
-      printf("Sphere -> Position: (%.2f, %.2f, %.2f), Radius: %.2f\n",
-             s.center.x, s.center.y, s.center.z, s.radius);
+  if (primitives.empty() || objects.empty())
+    return;
+
+  bvhNodes.reserve(primitives.size() * 2);
+
+  for (size_t i = 0; i < objects.size(); ++i) {
+    auto &obj = objects[i];
+    if (obj.primitiveCount == 0)
+      continue;
+
+    int root = buildBVHRecursive(obj.firstPrimitive,
+                                 obj.firstPrimitive + obj.primitiveCount);
+    obj.blasRootIndex = root;
+    if (root >= 0) {
+      const BVHNode &rootNode = bvhNodes[root];
+      obj.boundsMin = rootNode.boundsMin;
+      obj.boundsMax = rootNode.boundsMax;
+      objectIndices.push_back(i);
     }
   }
+
+  if (!objectIndices.empty())
+    buildTLASRecursive(0, objectIndices.size());
 }
 
 size_t Scene::getBVHNodeCount() const { return bvhNodes.size(); }
@@ -160,33 +204,21 @@ simd::float4 *Scene::createBVHBuffer() {
 
 simd::float4 *Scene::createTLASBuffer(size_t &outCount) {
   outCount = 0;
-  if (bvhNodes.empty()) {
+  if (tlasNodes.empty())
     return nullptr;
-  }
 
-  const BVHNode &root = bvhNodes[0];
-  if (root.count > 0) {
-    outCount = 1;
-    simd::float4 *buffer = new simd::float4[2];
-    int rootIndex = 0;
-    buffer[0] = simd::make_float4(root.boundsMin, *(float *)&rootIndex);
-    buffer[1] = simd::make_float4(root.boundsMax, 0.0f);
-    return buffer;
-  }
-
-  int leftChild = root.leftFirst;
-  int rightChild = -root.count;
-
-  outCount = 2;
+  outCount = tlasNodes.size();
   simd::float4 *buffer = new simd::float4[outCount * 2];
 
-  const BVHNode &left = bvhNodes[leftChild];
-  buffer[0] = simd::make_float4(left.boundsMin, *(float *)&leftChild);
-  buffer[1] = simd::make_float4(left.boundsMax, 0.0f);
-
-  const BVHNode &right = bvhNodes[rightChild];
-  buffer[2] = simd::make_float4(right.boundsMin, *(float *)&rightChild);
-  buffer[3] = simd::make_float4(right.boundsMax, 0.0f);
+  for (size_t i = 0; i < tlasNodes.size(); ++i) {
+    const TLASNode &node = tlasNodes[i];
+    float leftBits = 0.0f;
+    float rightBits = 0.0f;
+    std::memcpy(&leftBits, &node.leftChild, sizeof(int));
+    std::memcpy(&rightBits, &node.rightChild, sizeof(int));
+    buffer[2 * i] = simd::make_float4(node.boundsMin, leftBits);
+    buffer[2 * i + 1] = simd::make_float4(node.boundsMax, rightBits);
+  }
 
   return buffer;
 }
@@ -324,6 +356,122 @@ int Scene::buildBVHRecursive(size_t start, size_t end) {
   return nodeIndex;
 }
 
+int Scene::buildTLASRecursive(size_t start, size_t end) {
+  TLASNode node;
+  simd::float3 bMin(std::numeric_limits<float>::max());
+  simd::float3 bMax(-std::numeric_limits<float>::max());
+
+  for (size_t i = start; i < end; ++i) {
+    const SceneObject &obj = objects[objectIndices[i]];
+    bMin = simd::min(bMin, obj.boundsMin);
+    bMax = simd::max(bMax, obj.boundsMax);
+  }
+
+  node.boundsMin = bMin;
+  node.boundsMax = bMax;
+  node.leftChild = -1;
+  node.rightChild = -1;
+
+  int nodeIndex = static_cast<int>(tlasNodes.size());
+  tlasNodes.push_back(node);
+
+  size_t count = end - start;
+  if (count == 1) {
+    size_t objectIndex = objectIndices[start];
+    tlasNodes[nodeIndex].leftChild =
+        -static_cast<int>(objectIndex) - 1; // encode object index
+    tlasNodes[nodeIndex].rightChild = objects[objectIndex].blasRootIndex;
+    return nodeIndex;
+  }
+
+  const float parentArea = surfaceArea(bMin, bMax);
+  if (parentArea <= 0.0f) {
+    size_t mid = start + count / 2;
+    int leftChild = buildTLASRecursive(start, mid);
+    int rightChild = buildTLASRecursive(mid, end);
+    tlasNodes[nodeIndex].leftChild = leftChild;
+    tlasNodes[nodeIndex].rightChild = rightChild;
+    return nodeIndex;
+  }
+
+  const size_t range = end - start;
+  float bestCost = std::numeric_limits<float>::max();
+  int bestAxis = -1;
+  size_t bestSplit = start + range / 2;
+
+  for (int axis = 0; axis < 3; ++axis) {
+    std::sort(objectIndices.begin() + start, objectIndices.begin() + end,
+              [&](size_t a, size_t b) {
+                return objectAxisValue(a, axis) < objectAxisValue(b, axis);
+              });
+
+    std::vector<simd::float3> leftMin(range);
+    std::vector<simd::float3> leftMax(range);
+    std::vector<simd::float3> rightMin(range);
+    std::vector<simd::float3> rightMax(range);
+
+    simd::float3 currMin(std::numeric_limits<float>::max());
+    simd::float3 currMax(-std::numeric_limits<float>::max());
+    for (size_t i = start; i < end; ++i) {
+      const SceneObject &obj = objects[objectIndices[i]];
+      currMin = simd::min(currMin, obj.boundsMin);
+      currMax = simd::max(currMax, obj.boundsMax);
+      leftMin[i - start] = currMin;
+      leftMax[i - start] = currMax;
+    }
+
+    currMin = simd::float3(std::numeric_limits<float>::max());
+    currMax =
+        simd::float3(-std::numeric_limits<float>::max());
+    for (size_t i = end; i-- > start;) {
+      const SceneObject &obj = objects[objectIndices[i]];
+      currMin = simd::min(currMin, obj.boundsMin);
+      currMax = simd::max(currMax, obj.boundsMax);
+      rightMin[i - start] = currMin;
+      rightMax[i - start] = currMax;
+    }
+
+    for (size_t i = 1; i < range; ++i) {
+      float saLeft = surfaceArea(leftMin[i - 1], leftMax[i - 1]);
+      float saRight = surfaceArea(rightMin[i], rightMax[i]);
+
+      size_t leftCount = i;
+      size_t rightCount = range - i;
+
+      float cost = 0.125f + (saLeft / parentArea) * leftCount +
+                   (saRight / parentArea) * rightCount;
+
+      if (cost < bestCost) {
+        bestCost = cost;
+        bestAxis = axis;
+        bestSplit = start + i;
+      }
+    }
+  }
+
+  if (bestAxis == -1) {
+    size_t mid = start + range / 2;
+    int leftChild = buildTLASRecursive(start, mid);
+    int rightChild = buildTLASRecursive(mid, end);
+    tlasNodes[nodeIndex].leftChild = leftChild;
+    tlasNodes[nodeIndex].rightChild = rightChild;
+    return nodeIndex;
+  }
+
+  std::sort(objectIndices.begin() + start, objectIndices.begin() + end,
+            [&](size_t a, size_t b) {
+              return objectAxisValue(a, bestAxis) <
+                     objectAxisValue(b, bestAxis);
+            });
+
+  int leftChild = buildTLASRecursive(start, bestSplit);
+  int rightChild = buildTLASRecursive(bestSplit, end);
+  tlasNodes[nodeIndex].leftChild = leftChild;
+  tlasNodes[nodeIndex].rightChild = rightChild;
+
+  return nodeIndex;
+}
+
 float Scene::surfaceArea(const simd::float3 &bmin, const simd::float3 &bmax) {
   simd::float3 d = bmax - bmin;
   return 2.0f * (d.x * d.y + d.y * d.z + d.z * d.x);
@@ -337,6 +485,11 @@ float Scene::primitiveAxisValue(const Primitive &p, int axis) const {
   else
     return (p.triangle.v0[axis] + p.triangle.v1[axis] + p.triangle.v2[axis]) /
            3.0f;
+}
+
+float Scene::objectAxisValue(size_t objectIndex, int axis) const {
+  const SceneObject &obj = objects[objectIndex];
+  return 0.5f * (obj.boundsMin[axis] + obj.boundsMax[axis]);
 }
 
 void Scene::primitiveBounds(const Primitive &p, simd::float3 &pMin,

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -9,6 +9,21 @@
 
 namespace MetalCppPathTracer {
 
+struct SceneObject {
+  size_t firstPrimitive = 0;
+  size_t primitiveCount = 0;
+  simd::float3 boundsMin = simd::make_float3(0.0f, 0.0f, 0.0f);
+  simd::float3 boundsMax = simd::make_float3(0.0f, 0.0f, 0.0f);
+  int blasRootIndex = -1;
+};
+
+struct TLASNode {
+  simd::float3 boundsMin = simd::make_float3(0.0f, 0.0f, 0.0f);
+  simd::float3 boundsMax = simd::make_float3(0.0f, 0.0f, 0.0f);
+  int leftChild = -1;
+  int rightChild = -1;
+};
+
 struct CameraKeyframe {
   uint32_t frame;
   simd::float3 position;
@@ -22,6 +37,7 @@ public:
   void clear();
 
   size_t addPrimitive(const Primitive &p);
+  size_t addObject(const std::vector<Primitive> &prims);
   size_t getPrimitiveCount() const;
   size_t getSphereCount() const;
   size_t getTriangleCount() const;
@@ -53,10 +69,16 @@ private:
   std::vector<Primitive> primitives;
   std::vector<size_t> primitiveIndices;
   std::vector<BVHNode> bvhNodes;
+  std::vector<SceneObject> objects;
+  std::vector<size_t> objectIndices;
+  std::vector<TLASNode> tlasNodes;
 
+  size_t addObjectInternal(const Primitive *prims, size_t count);
   int buildBVHRecursive(size_t start, size_t end);
+  int buildTLASRecursive(size_t start, size_t end);
   float surfaceArea(const simd::float3 &bmin, const simd::float3 &bmax);
   float primitiveAxisValue(const Primitive &p, int axis) const;
+  float objectAxisValue(size_t objectIndex, int axis) const;
   void primitiveBounds(const Primitive &p, simd::float3 &pMin,
                        simd::float3 &pMax) const;
 };

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -142,6 +142,8 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             m.materialType = e->FloatAttribute("materialType", 0);
             m.emissionPower = e->FloatAttribute("emissionPower", 0);
 
+            std::vector<Primitive> meshPrimitives;
+            meshPrimitives.reserve(tris.size());
             for (const auto& tri : tris) {
                 Primitive p{};
                 p.type = PrimitiveType::Triangle;
@@ -149,8 +151,9 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
                 p.triangle.v1 = pos + scale * verts[tri.y];
                 p.triangle.v2 = pos + scale * verts[tri.z];
                 p.material = m;
-                scene->addPrimitive(p);
+                meshPrimitives.push_back(p);
             }
+            scene->addObject(meshPrimitives);
         }
         else if (tag == "CameraPath") {
             for (auto* kf = e->FirstChildElement("Keyframe"); kf; kf = kf->NextSiblingElement("Keyframe")) {


### PR DESCRIPTION
## Summary
- track scene objects when adding primitives so BVH builds produce per-object BLAS roots and TLAS nodes
- build a TLAS SAH BVH over objects and pack it into the GPU buffer while updating the JSON dump formatting
- traverse the TLAS hierarchy on the GPU instead of iterating leaves linearly for rendering and debug views

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d58201f99c832d934c8630d9af19f6