### PR TITLE
Mark Scene buffer builders const

### DIFF
--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -138,7 +138,7 @@ size_t Scene::getBVHNodeCount() const { return bvhNodes.size(); }
 
 const std::vector<BVHNode> &Scene::getBVHNodes() const { return bvhNodes; }
 
-simd::float4 *Scene::createTransformsBuffer() {
+simd::float4 *Scene::createTransformsBuffer() const {
   simd::float4 *buffer = new simd::float4[primitives.size() * 3];
   for (size_t i = 0; i < primitives.size(); ++i) {
     const auto &p = primitives[i];
@@ -163,7 +163,7 @@ simd::float4 *Scene::createTransformsBuffer() {
   return buffer;
 }
 
-simd::float4 *Scene::createMaterialsBuffer() {
+simd::float4 *Scene::createMaterialsBuffer() const {
   simd::float4 *buffer = new simd::float4[2 * primitives.size()];
   for (size_t i = 0; i < primitives.size(); ++i) {
     const auto &m = primitives[i].material;

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -55,8 +55,8 @@ public:
   simd::float2 screenSize;
   uint32_t maxRayDepth;
 
-  simd::float4 *createTransformsBuffer();
-  simd::float4 *createMaterialsBuffer();
+  simd::float4 *createTransformsBuffer() const;
+  simd::float4 *createMaterialsBuffer() const;
   simd::float4 *createSphereBuffer();
   simd::float4 *createSphereMaterialsBuffer();
   simd::float4 *createBVHBuffer();


### PR DESCRIPTION
## Summary
- mark Scene buffer creation helpers as const so they can be invoked on const Scene references

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d590d388c8832dba1d295d1b7d016d