### PR TITLE
Mark scene buffer builders as const

### DIFF
--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -205,7 +205,7 @@ simd::float4 *Scene::createSphereMaterialsBuffer() {
   return buffer;
 }
 
-simd::float4 *Scene::createBVHBuffer() {
+simd::float4 *Scene::createBVHBuffer() const {
   simd::float4 *buffer = new simd::float4[bvhNodes.size() * 2];
   for (size_t i = 0; i < bvhNodes.size(); ++i) {
     const auto &n = bvhNodes[i];
@@ -215,7 +215,7 @@ simd::float4 *Scene::createBVHBuffer() {
   return buffer;
 }
 
-simd::float4 *Scene::createTLASBuffer(size_t &outCount) {
+simd::float4 *Scene::createTLASBuffer(size_t &outCount) const {
   outCount = 0;
   if (tlasNodes.empty())
     return nullptr;
@@ -236,7 +236,7 @@ simd::float4 *Scene::createTLASBuffer(size_t &outCount) {
   return buffer;
 }
 
-int *Scene::createPrimitiveIndexBuffer() {
+int *Scene::createPrimitiveIndexBuffer() const {
   int *buffer = new int[primitiveIndices.size()];
   for (size_t i = 0; i < primitiveIndices.size(); ++i) {
     buffer[i] = static_cast<int>(primitiveIndices[i]);
@@ -245,7 +245,7 @@ int *Scene::createPrimitiveIndexBuffer() {
 }
 
 void Scene::createTriangleBuffers(std::vector<simd::float3> &outVertices,
-                                  std::vector<simd::uint3> &outIndices) {
+                                  std::vector<simd::uint3> &outIndices) const {
   outVertices.clear();
   outIndices.clear();
   uint32_t baseVertex = 0;

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -59,11 +59,11 @@ public:
   simd::float4 *createMaterialsBuffer() const;
   simd::float4 *createSphereBuffer();
   simd::float4 *createSphereMaterialsBuffer();
-  simd::float4 *createBVHBuffer();
-  simd::float4 *createTLASBuffer(size_t &outCount);
-  int *createPrimitiveIndexBuffer();
+  simd::float4 *createBVHBuffer() const;
+  simd::float4 *createTLASBuffer(size_t &outCount) const;
+  int *createPrimitiveIndexBuffer() const;
   void createTriangleBuffers(std::vector<simd::float3> &outVertices,
-                             std::vector<simd::uint3> &outIndices);
+                             std::vector<simd::uint3> &outIndices) const;
 
   std::vector<CameraKeyframe> cameraPath;
 


### PR DESCRIPTION
## Summary
- mark Scene buffer creation helpers as const so they can be called on const references
- update the corresponding implementations to match the new const qualifiers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d591688f74832dbefd89b845ba0a96