### PR TITLE
Add massive LOD drop demo scene

### DIFF
--- a/MetalCpp Path Tracer/scene_lod_massive_drop.xml
+++ b/MetalCpp Path Tracer/scene_lod_massive_drop.xml
@@ -1,0 +1,147 @@
+<Scene width="1280" height="720" maxRayDepth="32">
+    <CameraPath>
+        <!-- Hold inside cluster A so all 64 meshes are resident -->
+        <Keyframe frame="0" position="0,30,120" lookAt="0,20,0" />
+        <Keyframe frame="80" position="0,30,120" lookAt="0,20,0" />
+        <!-- Jump to empty middle ground well beyond FULL_DETAIL_DISTANCE from both clusters -->
+        <Keyframe frame="160" position="600,80,300" lookAt="600,20,0" />
+        <!-- Arrive at cluster B to trigger reloading of all meshes -->
+        <Keyframe frame="240" position="1200,30,120" lookAt="1200,20,0" />
+        <Keyframe frame="320" position="1200,30,120" lookAt="1200,20,0" />
+    </CameraPath>
+
+    <!-- Simple ground -->
+    <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Dense cluster A of 64 high-vertex meshes -->
+    <Mesh file="assets/bunny.obj" position="-87.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-87.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-87.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-87.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-87.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-87.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-87.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-87.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-62.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-62.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-62.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-62.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-62.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-62.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-62.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-62.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-37.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-37.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-37.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-37.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-37.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-37.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-37.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-37.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-12.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-12.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-12.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-12.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-12.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-12.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-12.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-12.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="12.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="12.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="12.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="12.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="12.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="12.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="12.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="12.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="37.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="37.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="37.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="37.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="37.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="37.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="37.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="37.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="62.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="62.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="62.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="62.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="62.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="62.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="62.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="62.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="87.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="87.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="87.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="87.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="87.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="87.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="87.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="87.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Identical cluster B far away so everything unloads in transit -->
+    <Mesh file="assets/bunny.obj" position="1112.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1112.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1112.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1112.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1112.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1112.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1112.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1112.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1137.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1137.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1137.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1137.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1137.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1137.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1137.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1137.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1162.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1162.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1162.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1162.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1162.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1162.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1162.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1162.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1187.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1187.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1187.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1187.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1187.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1187.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1187.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1187.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1212.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1212.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1212.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1212.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1212.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1212.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1212.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1212.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1237.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1237.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1237.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1237.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1237.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1237.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1237.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1237.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1262.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1262.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1262.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1262.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1262.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1262.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1262.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1262.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1287.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1287.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1287.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1287.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1287.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1287.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1287.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1287.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+</Scene>


### PR DESCRIPTION
## Summary
- add a scripted scene that holds 64 bunny meshes near the camera before moving far away
- ensure the camera pauses in empty space so the renderer unloads everything for a dramatic GPU memory drop
- fly on to a second distant cluster so you can watch memory re-allocate

## Testing
- not run (scene definition only)


------
https://chatgpt.com/codex/tasks/task_e_68d592ea3468832d9cc39283fc008dd2