### PR TITLE
Add next event estimation to path tracer

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -39,6 +39,10 @@ struct UniformsData {
   uint64_t blasNodeCount;
   uint32_t maxRayDepth;
   uint32_t debugAS;
+  uint32_t lightCount;
+  float lightTotalWeight;
+  uint32_t padding0 = 0;
+  uint32_t padding1 = 0;
 };
 
 inline uint32_t bitm_random() {
@@ -51,6 +55,34 @@ inline uint32_t bitm_random() {
 inline float randomFloat() {
   return (float)bitm_random() / (float)std::numeric_limits<uint32_t>::max();
 }
+
+namespace {
+
+float luminance(const simd::float3 &c) {
+  return 0.2126f * c.x + 0.7152f * c.y + 0.0722f * c.z;
+}
+
+float primitiveArea(const Primitive &p) {
+  switch (p.type) {
+  case PrimitiveType::Sphere: {
+    float r = p.sphere.radius;
+    return 4.0f * static_cast<float>(M_PI) * r * r;
+  }
+  case PrimitiveType::Triangle: {
+    simd::float3 e1 = p.triangle.v1 - p.triangle.v0;
+    simd::float3 e2 = p.triangle.v2 - p.triangle.v0;
+    return 0.5f * simd::length(simd::cross(e1, e2));
+  }
+  case PrimitiveType::Rectangle: {
+    simd::float3 e1 = p.rectangle.u;
+    simd::float3 e2 = p.rectangle.v;
+    return 4.0f * simd::length(simd::cross(e1, e2));
+  }
+  }
+  return 0.0f;
+}
+
+} // namespace
 
 bool Renderer::isInView(const BoundingSphere &b) {
   simd::float3 toCenter = b.center - Camera::position;
@@ -99,6 +131,10 @@ Renderer::~Renderer() {
     _pTLASBuffer->release();
   if (_pActiveBuffer)
     _pActiveBuffer->release();
+  if (_pLightIndexBuffer)
+    _pLightIndexBuffer->release();
+  if (_pLightCdfBuffer)
+    _pLightCdfBuffer->release();
 
   for (int i = 0; i < 2; i++)
     if (_accumulationTargets[i])
@@ -288,6 +324,75 @@ void Renderer::buildBuffers(const Scene &scene) {
   delete[] primitiveBuffer;
   delete[] materialBuffer;
 
+  if (_pLightIndexBuffer) {
+    _pLightIndexBuffer->release();
+    _pLightIndexBuffer = nullptr;
+  }
+  if (_pLightCdfBuffer) {
+    _pLightCdfBuffer->release();
+    _pLightCdfBuffer = nullptr;
+  }
+
+  std::vector<uint32_t> lightIndices;
+  std::vector<float> lightCdf;
+  float totalWeight = 0.0f;
+
+  if (primitiveCount > 0) {
+    const auto &primitives = scene.getPrimitives();
+    lightIndices.reserve(primitives.size());
+    lightCdf.reserve(primitives.size());
+
+    for (size_t i = 0; i < primitives.size(); ++i) {
+      const Primitive &p = primitives[i];
+      const Material &m = p.material;
+      float emissionStrength = m.emissionPower * luminance(m.emissionColor);
+      if (emissionStrength <= 0.0f)
+        continue;
+
+      float area = primitiveArea(p);
+      if (area <= 0.0f)
+        continue;
+
+      float weight = area * emissionStrength;
+      if (weight <= 0.0f)
+        continue;
+
+      totalWeight += weight;
+      lightIndices.push_back(static_cast<uint32_t>(i));
+      lightCdf.push_back(totalWeight);
+    }
+  }
+
+  _lightCount = lightIndices.size();
+  _lightTotalWeight = totalWeight;
+
+  size_t lightCount = _lightCount > 0 ? _lightCount : 1;
+  _pLightIndexBuffer =
+      _pDevice->newBuffer(lightCount * sizeof(uint32_t),
+                          MTL::ResourceStorageModeManaged);
+  _pLightCdfBuffer =
+      _pDevice->newBuffer(lightCount * sizeof(float),
+                          MTL::ResourceStorageModeManaged);
+
+  if (_lightCount > 0) {
+    memcpy(_pLightIndexBuffer->contents(), lightIndices.data(),
+           _lightCount * sizeof(uint32_t));
+    _pLightIndexBuffer->didModifyRange(
+        NS::Range::Make(0, _lightCount * sizeof(uint32_t)));
+
+    memcpy(_pLightCdfBuffer->contents(), lightCdf.data(),
+           _lightCount * sizeof(float));
+    _pLightCdfBuffer->didModifyRange(
+        NS::Range::Make(0, _lightCount * sizeof(float)));
+  } else {
+    uint32_t dummyIndex = 0;
+    float dummyCdf = 0.0f;
+    memcpy(_pLightIndexBuffer->contents(), &dummyIndex, sizeof(uint32_t));
+    memcpy(_pLightCdfBuffer->contents(), &dummyCdf, sizeof(float));
+    _pLightIndexBuffer->didModifyRange(NS::Range::Make(0, sizeof(uint32_t)));
+    _pLightCdfBuffer->didModifyRange(NS::Range::Make(0, sizeof(float)));
+  }
+
   if (_pActiveBuffer) {
     _pActiveBuffer->release();
     _pActiveBuffer = nullptr;
@@ -452,6 +557,8 @@ void Renderer::updateUniforms() {
   u.blasNodeCount = _blasNodeCount;
   u.maxRayDepth = _pScene->maxRayDepth;
   u.debugAS = InputSystem::debugAS;
+  u.lightCount = static_cast<uint32_t>(_lightCount);
+  u.lightTotalWeight = _lightTotalWeight;
 
   _pUniformsBuffer->didModifyRange(NS::Range::Make(0, sizeof(UniformsData)));
 }
@@ -483,6 +590,8 @@ void Renderer::draw(MTK::View *pView) {
   pEnc->setFragmentBuffer(_pPrimitiveIndexBuffer, 0, 6);
   pEnc->setFragmentBuffer(_pTLASBuffer, 0, 7);
   pEnc->setFragmentBuffer(_pActiveBuffer, 0, 8);
+  pEnc->setFragmentBuffer(_pLightIndexBuffer, 0, 9);
+  pEnc->setFragmentBuffer(_pLightCdfBuffer, 0, 10);
 
   pEnc->setFragmentTexture(_accumulationTargets[0], 0);
   pEnc->setFragmentTexture(_accumulationTargets[1], 1);

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -79,6 +79,8 @@ private:
   MTL::Buffer *_pPrimitiveIndexBuffer = nullptr;
   MTL::Buffer *_pTLASBuffer = nullptr;
   MTL::Buffer *_pActiveBuffer = nullptr;
+  MTL::Buffer *_pLightIndexBuffer = nullptr;
+  MTL::Buffer *_pLightCdfBuffer = nullptr;
   size_t _blasNodeCount = 0;
   size_t _tlasNodeCount = 0;
   size_t _activeNodeCount = 0;
@@ -93,6 +95,8 @@ private:
 
   size_t _residentPrimitiveCount = 0;
   size_t _residentTriangleCount = 0;
+  size_t _lightCount = 0;
+  float _lightTotalWeight = 0.0f;
 
   std::chrono::high_resolution_clock::time_point _cpuStart;
   double _lastCPUTime = 0.0;

--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -16,6 +16,8 @@ float4 fragment fragmentMain(
     device const int* primitiveIndices [[buffer(6)]],
     device const float4* tlasNodes [[buffer(7)]],
     device const uchar* activeMask [[buffer(8)]],
+    device const uint* lightIndices [[buffer(9)]],
+    device const float* lightCdf [[buffer(10)]],
     texture2d<float, access::read_write> lastFrame [[texture(0)]],
     texture2d<float, access::read_write> currentFrame [[texture(1)]])
 
@@ -60,10 +62,14 @@ float4 fragment fragmentMain(
         u.primitiveCount,
         primitiveIndices,
         activeMask,
+        lightIndices,
+        lightCdf,
         seed,
         u.maxRayDepth,
         u.debugAS,
-        u.blasNodeCount
+        u.blasNodeCount,
+        u.lightCount,
+        u.lightTotalWeight
     );
 
 

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -38,6 +38,87 @@ inline float3 randomInUnitSphere(thread uint32_t &seed) {
   }
 }
 
+inline uint selectLightOffset(float xi, device const float *lightCdf,
+                              uint lightCount, float totalWeight) {
+  if (lightCount == 0 || totalWeight <= 0.0f)
+    return lightCount;
+
+  float target = xi * totalWeight;
+  uint low = 0;
+  uint high = lightCount;
+  while (low < high) {
+    uint mid = (low + high) / 2;
+    if (lightCdf[mid] < target)
+      low = mid + 1;
+    else
+      high = mid;
+  }
+  return min(low, lightCount - 1);
+}
+
+inline bool sampleLightPoint(int primitiveType, float4 p0, float4 p1, float4 p2,
+                             thread uint32_t &seed, thread float3 &position,
+                             thread float3 &normal, thread float &area) {
+  if (primitiveType == 0) {
+    float radius = p1.x;
+    if (radius <= 0.0f)
+      return false;
+    float u1 = randomFloat(seed);
+    seed = random(seed);
+    float u2 = randomFloat(seed);
+    seed = random(seed);
+    float z = 2.0 * u1 - 1.0;
+    float phi = 2.0 * M_PI * u2;
+    float r = sqrt(max(0.0f, 1.0f - z * z));
+    float3 dir = float3(r * cos(phi), r * sin(phi), z);
+    position = p0.xyz + radius * dir;
+    normal = dir;
+    area = 4.0f * M_PI * radius * radius;
+    return area > 0.0f;
+  } else if (primitiveType == 1) {
+    float u1 = randomFloat(seed);
+    seed = random(seed);
+    float u2 = randomFloat(seed);
+    seed = random(seed);
+    float su1 = sqrt(u1);
+    float b0 = 1.0 - su1;
+    float b1 = su1 * (1.0 - u2);
+    float b2 = su1 * u2;
+    float3 v0 = p0.xyz;
+    float3 v1 = p1.xyz;
+    float3 v2 = p2.xyz;
+    position = b0 * v0 + b1 * v1 + b2 * v2;
+    float3 e1 = v1 - v0;
+    float3 e2 = v2 - v0;
+    float3 n = cross(e1, e2);
+    float lenN = length(n);
+    if (lenN <= 0.0f)
+      return false;
+    normal = n / lenN;
+    area = 0.5f * lenN;
+    return area > 0.0f;
+  } else if (primitiveType == 2) {
+    float u1 = randomFloat(seed);
+    seed = random(seed);
+    float u2 = randomFloat(seed);
+    seed = random(seed);
+    float su = u1 * 2.0 - 1.0;
+    float sv = u2 * 2.0 - 1.0;
+    float3 center = p0.xyz;
+    float3 e1 = p1.xyz;
+    float3 e2 = p2.xyz;
+    position = center + su * e1 + sv * e2;
+    float3 n = cross(e1, e2);
+    float lenN = length(n);
+    if (lenN <= 0.0f)
+      return false;
+    normal = n / lenN;
+    area = 4.0f * lenN;
+    return area > 0.0f;
+  }
+  return false;
+}
+
 // BVH intersection helper
 inline bool intersectAABB(thread const ray &r, float3 bmin, float3 bmax,
                           float tMin, float tMax) {
@@ -288,8 +369,11 @@ inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
                        device const float4 *materials, uint primitiveCount,
                        device const int *primitiveIndices,
                        device const uchar *activeMask,
+                       device const uint *lightIndices,
+                       device const float *lightCdf,
                        thread uint32_t &seed, uint maxRayDepth,
-                       uint debugAS, uint blasNodeCount) {
+                       uint debugAS, uint blasNodeCount, uint lightCount,
+                       float lightTotalWeight) {
   float footprint = length(cross(rayDx, rayDy));
   float lodAtten = 1.0 / (1.0 + footprint);
   if (debugAS == 1) {
@@ -346,6 +430,78 @@ inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
     }
 
     float3 offsetNormal = bestHit.frontFace ? bestHit.normal : -bestHit.normal;
+
+    if (materialType == 0.0 && lightCount > 0 && lightTotalWeight > 0.0f) {
+      float lightXi = randomFloat(seed);
+      seed = random(seed);
+      uint selectedOffset =
+          selectLightOffset(lightXi, lightCdf, lightCount, lightTotalWeight);
+      if (selectedOffset < lightCount) {
+        uint lightPrimIndex = lightIndices[selectedOffset];
+        if (lightPrimIndex != bestHit.primitiveId) {
+          int base = int(lightPrimIndex) * 3;
+          float4 lp0 = primitives[base + 0];
+          float4 lp1 = primitives[base + 1];
+          float4 lp2 = primitives[base + 2];
+          float3 lightPoint;
+          float3 lightNormal;
+          float area = 0.0f;
+          if (sampleLightPoint(int(lp0.w), lp0, lp1, lp2, seed, lightPoint,
+                               lightNormal, area) && area > 0.0f) {
+            float3 toLight = lightPoint - bestHit.point;
+            float dist2 = dot(toLight, toLight);
+            if (dist2 > 1e-6f) {
+              float dist = sqrt(dist2);
+              float3 wi = toLight / dist;
+              float cosTheta = max(dot(bestHit.normal, wi), 0.0f);
+              float cosLight = max(dot(lightNormal, -wi), 0.0f);
+              if (cosTheta > 0.0f && cosLight > 0.0f) {
+                float currentCdf = lightCdf[selectedOffset];
+                float prevCdf =
+                    (selectedOffset > 0) ? lightCdf[selectedOffset - 1] : 0.0f;
+                float weight = currentCdf - prevCdf;
+                float lightPdf =
+                    (lightTotalWeight > 0.0f && weight > 0.0f)
+                        ? weight / lightTotalWeight
+                        : 0.0f;
+                if (lightPdf > 0.0f) {
+                  float pdfArea = 1.0f / area;
+                  float pdfSolid = pdfArea * dist2 / cosLight;
+                  float totalPdf = lightPdf * pdfSolid;
+                  if (totalPdf > 0.0f) {
+                    ray shadowRay;
+                    shadowRay.origin = bestHit.point + 0.0005f * offsetNormal;
+                    shadowRay.direction = wi;
+                    intersection shadowHit = firstHitTLAS(
+                        shadowRay, tlasNodes, tlasNodeCount, bvhNodes,
+                        primitives, primitiveIndices, activeMask);
+                    bool visible = false;
+                    if (shadowHit.primitiveId == -1) {
+                      visible = true;
+                    } else if (shadowHit.primitiveId == int(lightPrimIndex) &&
+                               shadowHit.t >= dist - 0.001f) {
+                      visible = true;
+                    }
+                    if (visible) {
+                      int lightMatIndex = int(lightPrimIndex) * 2;
+                      if (lightMatIndex + 1 < int(primitiveCount) * 2) {
+                        float4 lightM1 = materials[lightMatIndex + 1];
+                        float3 lightRadiance = lightM1.xyz * lightM1.w;
+                        float3 throughput = absorption.xyz * (albedo / M_PI);
+                        float3 contribution =
+                            throughput * lightRadiance * (cosTheta / totalPdf);
+                        light.xyz += contribution;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
     r.origin = bestHit.point + 0.0001 * offsetNormal;
     scatter(r, bestHit, materialType, seed);
     seed = random(seed);

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -43,6 +43,10 @@ struct UniformsData
     uint64_t blasNodeCount;
     uint maxRayDepth;
     uint debugAS;
+    uint lightCount;
+    float lightTotalWeight;
+    uint padding0;
+    uint padding1;
 };
 
 


### PR DESCRIPTION
## Summary
- gather emissive primitives on the CPU and upload light-sampling data to the GPU
- extend uniforms and resource bindings so shaders can access light information
- implement next event estimation in the path tracer to sample direct lighting from area lights

## Testing
- not run (Metal renderer cannot be executed in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d595d83e88832d8dedf5ce64a4871e