### PR TITLE
Remove verbose viewport logging

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -270,10 +270,6 @@ void Renderer::recalculateViewport() {
 
   _pUniformsBuffer->didModifyRange(NS::Range::Make(0, sizeof(UniformsData)));
 
-  printf("viewportU: (%f, %f, %f)\n", viewportU.x, viewportU.y, viewportU.z);
-  printf("viewportV: (%f, %f, %f)\n", viewportV.x, viewportV.y, viewportV.z);
-  printf("firstPixel: (%f, %f, %f)\n", firstPixelPosition.x,
-         firstPixelPosition.y, firstPixelPosition.z);
 }
 
 void Renderer::buildBuffers(const Scene &scene) {


### PR DESCRIPTION
## Summary
- remove the viewport debug printf statements from `Renderer::recalculateViewport`

## Testing
- not run (xcodebuild is unavailable in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68d599da9fd4832d85caeec384e087bc