### PR TITLE
Add hysteresis and cooldown to distance-based LOD

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -58,6 +58,13 @@ inline float randomFloat() {
 
 namespace {
 
+// Distance thresholds that implement a small hysteresis band for LOD toggles
+// along with the minimum number of frames primitives must wait before they can
+// flip state again.
+constexpr float LOD_ENTER_DISTANCE = 225.0f;
+constexpr float LOD_EXIT_DISTANCE = 275.0f;
+constexpr uint32_t LOD_STATE_COOLDOWN_FRAMES = 5;
+
 float luminance(const simd::float3 &c) {
   return 0.2126f * c.x + 0.7152f * c.y + 0.0722f * c.z;
 }
@@ -206,11 +213,16 @@ void Renderer::updateVisibleScene() {
          _pScene->getPrimitiveCount(), _pScene->getSphereCount(),
          _pScene->getTriangleCount(), _pScene->getRectangleCount());
 
+  printf("LOD activation threshold: %.1f, deactivation threshold: %.1f (cooldown "
+         "%u frames)\n",
+         LOD_ENTER_DISTANCE, LOD_EXIT_DISTANCE, LOD_STATE_COOLDOWN_FRAMES);
+
   // Store full primitive list and initialize tracking
   _allPrimitives = _pScene->getPrimitives();
   _allSceneObjects = _pScene->getObjects();
   size_t primCount = _allPrimitives.size();
   _activePrimitive.assign(primCount, true);
+  _primitiveCooldown.assign(primCount, 0);
   _primitiveBounds.resize(primCount);
   for (size_t i = 0; i < primCount; ++i) {
     const Primitive &p = _allPrimitives[i];
@@ -607,10 +619,15 @@ void Renderer::draw(MTK::View *pView) {
 }
 
 void Renderer::updateLODByDistance() {
-  // Keep primitives active until the camera is reasonably far away.
-  // Using a larger threshold prevents the entire scene from being culled
-  // when starting far from the origin.
-  const float FULL_DETAIL_DISTANCE = 250.0f;
+  // Use hysteresis so primitives do not flicker when hovering near the
+  // activation boundary. Inactive primitives only become active once the
+  // camera is closer than LOD_ENTER_DISTANCE, while active primitives stay
+  // active until the camera has moved beyond LOD_EXIT_DISTANCE.
+
+  for (uint32_t &cooldown : _primitiveCooldown)
+    if (cooldown > 0)
+      --cooldown;
+
   size_t activeCount = 0;
   bool changed = false;
   for (size_t g = 0; g < _allPrimitives.size(); ++g) {
@@ -618,8 +635,13 @@ void Renderer::updateLODByDistance() {
         simd::length(_primitiveBounds[g].center - Camera::position) -
         _primitiveBounds[g].radius;
     dist = std::max(dist, 0.0f);
-    bool shouldBeActive = dist < FULL_DETAIL_DISTANCE;
-    if (setPrimitiveActive(g, shouldBeActive))
+    bool currentlyActive = g < _activePrimitive.size() && _activePrimitive[g];
+    bool shouldBeActive = currentlyActive ? dist <= LOD_EXIT_DISTANCE
+                                          : dist < LOD_ENTER_DISTANCE;
+    bool canToggle =
+        g >= _primitiveCooldown.size() || _primitiveCooldown[g] == 0;
+    if (canToggle && shouldBeActive != currentlyActive &&
+        setPrimitiveActive(g, shouldBeActive))
       changed = true;
     if (_activePrimitive[g])
       activeCount++;
@@ -655,6 +677,8 @@ bool Renderer::setPrimitiveActive(size_t index, bool active) {
   if (_activePrimitive[index] == active)
     return false;
   _activePrimitive[index] = active;
+  if (index < _primitiveCooldown.size())
+    _primitiveCooldown[index] = LOD_STATE_COOLDOWN_FRAMES;
   return true;
 }
 

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -90,6 +90,7 @@ private:
 
   std::vector<Primitive> _allPrimitives;
   std::vector<bool> _activePrimitive;
+  std::vector<uint32_t> _primitiveCooldown;
   std::vector<BoundingSphere> _primitiveBounds;
   std::vector<SceneObject> _allSceneObjects;
 

--- a/MetalCpp Path Tracer/scene_lod_massive_drop.xml
+++ b/MetalCpp Path Tracer/scene_lod_massive_drop.xml
@@ -3,7 +3,7 @@
         <!-- Hold inside cluster A so all 64 meshes are resident -->
         <Keyframe frame="0" position="0,30,120" lookAt="0,20,0" />
         <Keyframe frame="80" position="0,30,120" lookAt="0,20,0" />
-        <!-- Jump to empty middle ground well beyond FULL_DETAIL_DISTANCE from both clusters -->
+        <!-- Jump to empty middle ground well beyond LOD_EXIT_DISTANCE from both clusters -->
         <Keyframe frame="160" position="600,80,300" lookAt="600,20,0" />
         <!-- Arrive at cluster B to trigger reloading of all meshes -->
         <Keyframe frame="240" position="1200,30,120" lookAt="1200,20,0" />


### PR DESCRIPTION
## Summary
- introduce separate enter/exit distance thresholds and a brief cooldown to stabilize LOD toggling
- log the new thresholds when loading a scene and track per-primitive cooldown state
- update scene documentation comments to reference the new hysteresis thresholds

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d5a8475358832d918139dabee88286