### PR TITLE
Add energy-based residency heuristic selectable via scene

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -64,6 +64,8 @@ namespace {
 constexpr float LOD_ENTER_DISTANCE = 225.0f;
 constexpr float LOD_EXIT_DISTANCE = 275.0f;
 constexpr uint32_t LOD_STATE_COOLDOWN_FRAMES = 5;
+constexpr float ENERGY_TARGET_FRACTION = 0.9f;
+constexpr size_t ENERGY_MIN_ACTIVE_PRIMITIVES = 16;
 
 float luminance(const simd::float3 &c) {
   return 0.2126f * c.x + 0.7152f * c.y + 0.0722f * c.z;
@@ -87,6 +89,14 @@ float primitiveArea(const Primitive &p) {
   }
   }
   return 0.0f;
+}
+
+float primitiveImportance(const Primitive &p) {
+  float area = std::max(primitiveArea(p), 1e-4f);
+  const Material &m = p.material;
+  float emissive = m.emissionPower * luminance(m.emissionColor);
+  float reflective = luminance(m.albedo);
+  return area * (emissive + reflective);
 }
 
 } // namespace
@@ -217,6 +227,12 @@ void Renderer::updateVisibleScene() {
          "%u frames)\n",
          LOD_ENTER_DISTANCE, LOD_EXIT_DISTANCE, LOD_STATE_COOLDOWN_FRAMES);
 
+  const char *strategyName =
+      _pScene->getResidencyStrategy() == ResidencyStrategy::EnergyImportance
+          ? "Energy importance"
+          : "Distance-based LOD";
+  printf("Active primitive residency strategy: %s\n", strategyName);
+
   // Store full primitive list and initialize tracking
   _allPrimitives = _pScene->getPrimitives();
   _allSceneObjects = _pScene->getObjects();
@@ -224,6 +240,9 @@ void Renderer::updateVisibleScene() {
   _activePrimitive.assign(primCount, true);
   _primitiveCooldown.assign(primCount, 0);
   _primitiveBounds.resize(primCount);
+  _primitiveImportance.assign(primCount, 0.0f);
+  _energySortedIndices.resize(primCount);
+  _totalPrimitiveImportance = 0.0f;
   for (size_t i = 0; i < primCount; ++i) {
     const Primitive &p = _allPrimitives[i];
     if (p.type == PrimitiveType::Sphere) {
@@ -238,7 +257,15 @@ void Renderer::updateVisibleScene() {
       float r = simd::length(p.rectangle.u) + simd::length(p.rectangle.v);
       _primitiveBounds[i] = {p.rectangle.center, r};
     }
+    _primitiveImportance[i] = primitiveImportance(p);
+    _energySortedIndices[i] = i;
+    _totalPrimitiveImportance += std::max(_primitiveImportance[i], 0.0f);
   }
+
+  std::sort(_energySortedIndices.begin(), _energySortedIndices.end(),
+            [this](size_t a, size_t b) {
+              return _primitiveImportance[a] > _primitiveImportance[b];
+            });
 
   _pScene->buildBVH();
 
@@ -572,7 +599,7 @@ void Renderer::updateUniforms() {
 }
 
 void Renderer::draw(MTK::View *pView) {
-  updateLODByDistance();
+  updateResidency();
   updateUniforms();
   beginFrameMetrics();
   std::swap(_accumulationTargets[0], _accumulationTargets[1]);
@@ -618,6 +645,21 @@ void Renderer::draw(MTK::View *pView) {
   pPool->release();
 }
 
+void Renderer::updateResidency() {
+  if (!_pScene)
+    return;
+
+  switch (_pScene->getResidencyStrategy()) {
+  case ResidencyStrategy::EnergyImportance:
+    updateEnergyImportance();
+    break;
+  case ResidencyStrategy::DistanceLOD:
+  default:
+    updateLODByDistance();
+    break;
+  }
+}
+
 void Renderer::updateLODByDistance() {
   // Use hysteresis so primitives do not flicker when hovering near the
   // activation boundary. Inactive primitives only become active once the
@@ -652,6 +694,58 @@ void Renderer::updateLODByDistance() {
     if (setPrimitiveActive(0, true))
       changed = true;
     activeCount = 1;
+  }
+
+  if (changed)
+    rebuildResidentResources();
+}
+
+void Renderer::updateEnergyImportance() {
+  if (_activePrimitive.empty())
+    return;
+
+  const size_t primCount = _activePrimitive.size();
+  std::vector<bool> desiredState(primCount, false);
+  size_t minActive = std::min(primCount, ENERGY_MIN_ACTIVE_PRIMITIVES);
+
+  if (_totalPrimitiveImportance <= 0.0f) {
+    for (size_t i = 0; i < minActive && i < _energySortedIndices.size(); ++i)
+      desiredState[_energySortedIndices[i]] = true;
+  } else {
+    float cumulative = 0.0f;
+    float targetImportance = _totalPrimitiveImportance * ENERGY_TARGET_FRACTION;
+    size_t enabled = 0;
+    for (size_t rank = 0; rank < _energySortedIndices.size(); ++rank) {
+      size_t index = _energySortedIndices[rank];
+      if (enabled >= minActive && cumulative >= targetImportance)
+        break;
+      desiredState[index] = true;
+      cumulative += std::max(_primitiveImportance[index], 0.0f);
+      ++enabled;
+    }
+
+    for (size_t i = 0; i < minActive && i < _energySortedIndices.size(); ++i)
+      desiredState[_energySortedIndices[i]] = true;
+  }
+
+  bool changed = false;
+  for (size_t i = 0; i < primCount; ++i) {
+    bool shouldBeActive = desiredState[i];
+    if (shouldBeActive != _activePrimitive[i])
+      if (setPrimitiveActive(i, shouldBeActive))
+        changed = true;
+  }
+
+  size_t activeCount = 0;
+  for (bool active : _activePrimitive)
+    if (active)
+      ++activeCount;
+
+  if (activeCount == 0 && !_activePrimitive.empty()) {
+    size_t fallback = !_energySortedIndices.empty() ? _energySortedIndices.front()
+                                                    : size_t(0);
+    if (setPrimitiveActive(fallback, true))
+      changed = true;
   }
 
   if (changed)

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -58,7 +58,9 @@ private:
     float radius;
   };
   bool isInView(const BoundingSphere &b);
+  void updateResidency();
   void updateLODByDistance();
+  void updateEnergyImportance();
   void beginFrameMetrics();
   void completeFrameMetrics(MTL::CommandBuffer *pCmd);
 
@@ -93,6 +95,9 @@ private:
   std::vector<uint32_t> _primitiveCooldown;
   std::vector<BoundingSphere> _primitiveBounds;
   std::vector<SceneObject> _allSceneObjects;
+  std::vector<float> _primitiveImportance;
+  std::vector<size_t> _energySortedIndices;
+  float _totalPrimitiveImportance = 0.0f;
 
   size_t _residentPrimitiveCount = 0;
   size_t _residentTriangleCount = 0;

--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -20,6 +20,7 @@ void Scene::clear() {
   cameraPath.clear();
   screenSize = {1280.f, 720.f};
   maxRayDepth = 32;
+  residencyStrategy = ResidencyStrategy::DistanceLOD;
 }
 
 size_t Scene::addPrimitive(const Primitive &p) {
@@ -100,6 +101,14 @@ const std::vector<size_t> &Scene::getPrimitiveIndices() const {
 }
 
 const std::vector<SceneObject> &Scene::getObjects() const { return objects; }
+
+ResidencyStrategy Scene::getResidencyStrategy() const {
+  return residencyStrategy;
+}
+
+void Scene::setResidencyStrategy(ResidencyStrategy strategy) {
+  residencyStrategy = strategy;
+}
 
 void Scene::buildBVH() {
   primitiveIndices.resize(primitives.size());

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -9,6 +9,11 @@
 
 namespace MetalCppPathTracer {
 
+enum class ResidencyStrategy {
+  DistanceLOD = 0,
+  EnergyImportance = 1,
+};
+
 struct SceneObject {
   size_t firstPrimitive = 0;
   size_t primitiveCount = 0;
@@ -48,6 +53,9 @@ public:
   const std::vector<size_t> &getPrimitiveIndices() const;
   const std::vector<SceneObject> &getObjects() const;
 
+  ResidencyStrategy getResidencyStrategy() const;
+  void setResidencyStrategy(ResidencyStrategy strategy);
+
   void buildBVH();
   size_t getBVHNodeCount() const;
   const std::vector<BVHNode> &getBVHNodes() const;
@@ -74,6 +82,7 @@ private:
   std::vector<SceneObject> objects;
   std::vector<size_t> objectIndices;
   std::vector<TLASNode> tlasNodes;
+  ResidencyStrategy residencyStrategy;
 
   size_t addObjectInternal(const Primitive *prims, size_t count,
                           bool logPrimitives);

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -104,9 +104,15 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             return static_cast<char>(std::tolower(c));
         });
 
-        if (value == "energy" || value == "importance" || value == "energyimportance") {
+        if (value == "energy" || value == "importance" || value == "energyimportance" ||
+            value == "energy_importance") {
             scene->setResidencyStrategy(ResidencyStrategy::EnergyImportance);
+        } else if (value == "distance" || value == "lod" || value == "distance_lod" ||
+                   value == "distancelod" || value == "distancebased") {
+            scene->setResidencyStrategy(ResidencyStrategy::DistanceLOD);
         } else {
+            printf("Unknown residency strategy '%s', defaulting to distance LOD.\n",
+                   residencyAttr);
             scene->setResidencyStrategy(ResidencyStrategy::DistanceLOD);
         }
     }

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -2,10 +2,13 @@
 #include "Material.h"
 #include <tinyxml2.h>
 #include <simd/simd.h>
+#include <algorithm>
+#include <cctype>
 #include <cstdio>
 #include <fstream>
 #include <sstream>
 #include <filesystem>
+#include <string>
 #include "tiny_obj_loader.h"
 
 using namespace tinyxml2;
@@ -94,6 +97,19 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
     scene->screenSize.x = root->FloatAttribute("width", scene->screenSize.x);
     scene->screenSize.y = root->FloatAttribute("height", scene->screenSize.y);
     scene->maxRayDepth = root->UnsignedAttribute("maxRayDepth", scene->maxRayDepth);
+
+    if (const char* residencyAttr = root->Attribute("residencyStrategy")) {
+        std::string value = residencyAttr;
+        std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+            return static_cast<char>(std::tolower(c));
+        });
+
+        if (value == "energy" || value == "importance" || value == "energyimportance") {
+            scene->setResidencyStrategy(ResidencyStrategy::EnergyImportance);
+        } else {
+            scene->setResidencyStrategy(ResidencyStrategy::DistanceLOD);
+        }
+    }
 
     for (auto* e = root->FirstChildElement(); e; e = e->NextSiblingElement()) {
         std::string tag = e->Name();

--- a/MetalCpp Path Tracer/scene.xml
+++ b/MetalCpp Path Tracer/scene.xml
@@ -1,4 +1,4 @@
-<Scene width="1280" height="720" maxRayDepth="32">
+<Scene width="1280" height="720" maxRayDepth="32" residencyStrategy="distance">
     <CameraPath>
         <!-- Start near the objects -->
         <Keyframe frame="0" position="0,20,50" lookAt="0,20,0" />

--- a/MetalCpp Path Tracer/scene_active_nodes.xml
+++ b/MetalCpp Path Tracer/scene_active_nodes.xml
@@ -1,4 +1,4 @@
-<Scene width="1280" height="720" maxRayDepth="32">
+<Scene width="1280" height="720" maxRayDepth="32" residencyStrategy="distance">
     <CameraPath>
         <!-- Start near cluster A, then travel to cluster B to exercise node activation -->
         <Keyframe frame="0" position="0,20,50" lookAt="0,20,0" />

--- a/MetalCpp Path Tracer/scene_lod_clusters.xml
+++ b/MetalCpp Path Tracer/scene_lod_clusters.xml
@@ -1,4 +1,4 @@
-<Scene width="1280" height="720" maxRayDepth="32">
+<Scene width="1280" height="720" maxRayDepth="32" residencyStrategy="distance">
     <CameraPath>
         <!-- Start near cluster A, then travel to cluster B to observe node on/off loading -->
         <Keyframe frame="0" position="0,20,50" lookAt="0,20,0" />

--- a/MetalCpp Path Tracer/scene_lod_far.xml
+++ b/MetalCpp Path Tracer/scene_lod_far.xml
@@ -1,4 +1,4 @@
-<Scene width="1280" height="720" maxRayDepth="32">
+<Scene width="1280" height="720" maxRayDepth="32" residencyStrategy="distance">
     <CameraPath>
         <!-- Start well beyond full-detail distance to ensure primitives remain visible -->
         <Keyframe frame="0" position="0,20,400" lookAt="0,20,0" />

--- a/MetalCpp Path Tracer/scene_lod_linear.xml
+++ b/MetalCpp Path Tracer/scene_lod_linear.xml
@@ -1,4 +1,4 @@
-<Scene width="1280" height="720" maxRayDepth="32">
+<Scene width="1280" height="720" maxRayDepth="32" residencyStrategy="distance">
     <CameraPath>
         <!-- Move the camera through a line of primitives to exercise distance-based LOD -->
         <Keyframe frame="0" position="0,20,50" lookAt="0,20,0" />

--- a/MetalCpp Path Tracer/scene_lod_massive_drop.xml
+++ b/MetalCpp Path Tracer/scene_lod_massive_drop.xml
@@ -1,4 +1,4 @@
-<Scene width="1280" height="720" maxRayDepth="32">
+<Scene width="1280" height="720" maxRayDepth="32" residencyStrategy="distance">
     <CameraPath>
         <!-- Hold inside cluster A so all 64 meshes are resident -->
         <Keyframe frame="0" position="0,30,120" lookAt="0,20,0" />

--- a/MetalCpp Path Tracer/scene_residency_distance.xml
+++ b/MetalCpp Path Tracer/scene_residency_distance.xml
@@ -1,4 +1,11 @@
 <Scene width="1280" height="720" maxRayDepth="32" residencyStrategy="distance">
+    <CameraPath>
+        <!-- Matches the default layout but forces distance-based LOD residency -->
+        <Keyframe frame="0" position="0,20,50" lookAt="0,20,0" />
+        <Keyframe frame="10" position="0,20,50" lookAt="0,20,0" />
+        <Keyframe frame="20" position="20,20,50" lookAt="0,20,0" />
+        <Keyframe frame="120" position="100,20,50" lookAt="200,20,0" />
+    </CameraPath>
     <!-- Ground -->
     <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
 
@@ -21,4 +28,3 @@
         materialType="0"
         emissionPower="0" />
 </Scene>
-

--- a/MetalCpp Path Tracer/scene_residency_energy.xml
+++ b/MetalCpp Path Tracer/scene_residency_energy.xml
@@ -1,4 +1,11 @@
-<Scene width="1280" height="720" maxRayDepth="32" residencyStrategy="distance">
+<Scene width="1280" height="720" maxRayDepth="32" residencyStrategy="energy">
+    <CameraPath>
+        <!-- Camera path identical to the default scene so we can compare heuristics directly -->
+        <Keyframe frame="0" position="0,20,50" lookAt="0,20,0" />
+        <Keyframe frame="10" position="0,20,50" lookAt="0,20,0" />
+        <Keyframe frame="20" position="20,20,50" lookAt="0,20,0" />
+        <Keyframe frame="120" position="100,20,50" lookAt="200,20,0" />
+    </CameraPath>
     <!-- Ground -->
     <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
 
@@ -21,4 +28,3 @@
         materialType="0"
         emissionPower="0" />
 </Scene>
-


### PR DESCRIPTION
## Summary
- add a scene-level `residencyStrategy` toggle that lets scenes request distance LOD or energy-importance residency control
- precompute per-primitive importance scores and dispatch the active residency heuristic at frame time
- implement an energy-budget heuristic that keeps the brightest primitives resident and falls back to LOD when requested

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5ad22edd8832d89fc9c1859ab7ff8