### PR TITLE
Scale camera controls by frame time

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Camera.h
+++ b/MetalCpp Path Tracer/Renderer/Camera.h
@@ -16,6 +16,7 @@ inline simd::float3 up;
 inline float verticalFov;
 inline float focalLength;
 inline simd::float2 screenSize;
+inline float deltaTime = 0.0f;
 
 inline constexpr float movementSpeed = 0.1;
 inline constexpr float rotationSpeed = 0.002;
@@ -29,45 +30,52 @@ inline static void reset()
 
     verticalFov = 60.0;
     focalLength = 1.0;
+    deltaTime = 0.0f;
 }
 
 
 inline bool move(simd::float3 movementDirection)
 {
-    if(simd::length_squared(movementDirection) == 0) return false;
+    if(simd::length_squared(movementDirection) == 0 || deltaTime <= 0.0f) return false;
     
     const simd::float3 cameraRight = simd::normalize(simd::cross(forward, simd::float3{0, 1, 0}));
     
     const simd::float3 forwardMovementDirection = simd::cross(simd::float3{0, 1, 0}, cameraRight);
     
-    position += movementSpeed * simd::normalize(cameraRight*InputSystem::movementInput.x +
+    const float frameMovementSpeed = movementSpeed * deltaTime;
+
+    position += frameMovementSpeed * simd::normalize(cameraRight*InputSystem::movementInput.x +
                                                 simd::float3{0, 1, 0}*InputSystem::movementInput.y +
                                                 forwardMovementDirection*InputSystem::movementInput.z);
     return true;
-    
+
 }
 
 inline bool rotate(simd::float2 angles)
 {
-    if(simd::length_squared(angles) == 0) return false;
-    
+    if(simd::length_squared(angles) == 0 || deltaTime <= 0.0f) return false;
+
     simd::float3 cameraRight = simd::cross(forward, simd::float3{0, 1, 0});
-    simd::quatf rotationUp = simd::quatf(-InputSystem::rotationInput.y*rotationSpeed, cameraRight);
+    const float frameRotationSpeed = rotationSpeed * deltaTime;
+
+    simd::quatf rotationUp = simd::quatf(-InputSystem::rotationInput.y*frameRotationSpeed, cameraRight);
     Camera::forward = simd::normalize(simd_act(rotationUp, forward));
-    
+
     cameraRight = simd::cross(Camera::forward, simd::float3{0, 1, 0});
     up = simd::normalize(simd::cross(cameraRight, forward));
-    simd::quatf rotationRight = simd::quatf(-InputSystem::rotationInput.x*rotationSpeed, up);
+    simd::quatf rotationRight = simd::quatf(-InputSystem::rotationInput.x*frameRotationSpeed, up);
     forward = simd::normalize(simd_act(rotationRight, forward));
-    
+
     return true;
 }
 
 inline bool zoom(float zoomAmount)
 {
-    if (zoomAmount == 0) return false;
-    
-    verticalFov = simd::clamp(verticalFov + zoomAmount * zoomSpeed, 30.0f, 120.0f);
+    if (zoomAmount == 0 || deltaTime <= 0.0f) return false;
+
+    const float frameZoomSpeed = zoomSpeed * deltaTime;
+
+    verticalFov = simd::clamp(verticalFov + zoomAmount * frameZoomSpeed, 30.0f, 120.0f);
     
     return true;
 }

--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -202,6 +202,14 @@ Renderer::~Renderer() {
   delete _pScene;
 }
 
+void Renderer::setDeltaTime(double deltaSeconds) {
+  if (deltaSeconds < 0.0)
+    deltaSeconds = 0.0;
+
+  _deltaTimeSeconds = deltaSeconds;
+  Camera::deltaTime = static_cast<float>(_deltaTimeSeconds);
+}
+
 void Renderer::buildShaders() {
   using NS::StringEncoding::UTF8StringEncoding;
 
@@ -725,6 +733,10 @@ bool Renderer::updateCamera() {
     }
 
     Camera::up = {0, 1, 0};
+    // Reset the frame delta while scripted motion drives the camera so the
+    // timeline remains frame-locked.
+    _deltaTimeSeconds = 0.0;
+    Camera::deltaTime = 0.0f;
     InputSystem::clearInputs();
 
     // Update view dependent data for the new camera transform

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -27,6 +27,7 @@ public:
   void updateUniforms();
   void draw(MTK::View *pView);
   void drawableSizeWillChange(MTK::View *pView, CGSize size);
+  void setDeltaTime(double deltaSeconds);
 
   bool hasKeyframes() const;
   bool setPrimitiveActive(size_t index, bool active);
@@ -142,6 +143,8 @@ private:
   double _lastGPUTime = 0.0;
   double _lastRaysPerSecond = 0.0;
   size_t _lastRayCount = 0;
+
+  double _deltaTimeSeconds = 0.0;
 
   size_t _animationFrame = 0;
 };

--- a/MetalCpp Path Tracer/Window/ViewDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.cpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <fstream>
 #include <mach/mach.h>
+#include <limits>
 
 using namespace MetalCppPathTracer;
 
@@ -53,10 +54,15 @@ ViewDelegate::~ViewDelegate() {
 
 void ViewDelegate::drawInMTKView(MTK::View *pView) {
   auto current = std::chrono::steady_clock::now();
-  double fps = 1.0 / std::chrono::duration<double>(current - _lastTime).count();
+  double deltaSeconds =
+      std::chrono::duration<double>(current - _lastTime).count();
+  if (deltaSeconds <= 0.0)
+    deltaSeconds = std::numeric_limits<double>::min();
+  double fps = 1.0 / deltaSeconds;
   _lastTime = current;
   updateFPS(fps);
   updateMemoryUsage(getMemoryUsageMB());
+  _pRenderer->setDeltaTime(deltaSeconds);
   _pRenderer->draw(pView);
   if (_perfLog.is_open()) {
     double cpu_ms = _pRenderer->lastCPUTime() * 1000.0;


### PR DESCRIPTION
## Summary
- capture the per-frame delta in the view delegate and pass it to the renderer
- cache the delta on the renderer, reset it for scripted keyframes, and expose a setter
- scale camera movement, rotation, and zoom speeds by the elapsed frame time

## Testing
- not run (platform-specific project)


------
https://chatgpt.com/codex/tasks/task_e_68d5c6e9e7c0832d94c0d11f7399357c