### PR TITLE
Reduce LOD residency stutter and show GPU memory in overlay

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -65,6 +65,9 @@ namespace {
 constexpr float LOD_ENTER_DISTANCE = 225.0f;
 constexpr float LOD_EXIT_DISTANCE = 275.0f;
 constexpr uint32_t LOD_STATE_COOLDOWN_FRAMES = 5;
+// Avoid large per-frame rebuild spikes by throttling how many primitives can
+// toggle residency at once.
+constexpr size_t LOD_MAX_TOGGLES_PER_FRAME = 24;
 constexpr float ENERGY_TARGET_FRACTION = 0.9f;
 constexpr size_t ENERGY_MIN_ACTIVE_PRIMITIVES = 16;
 constexpr float RAY_HIT_DECAY = 0.85f;
@@ -861,6 +864,7 @@ void Renderer::updateLODByDistance() {
   // active until the camera has moved beyond LOD_EXIT_DISTANCE.
 
   size_t activeCount = 0;
+  size_t toggles = 0;
   bool changed = false;
   for (size_t g = 0; g < _allPrimitives.size(); ++g) {
     float dist =
@@ -872,9 +876,13 @@ void Renderer::updateLODByDistance() {
                                           : dist < LOD_ENTER_DISTANCE;
     bool canToggle =
         g >= _primitiveCooldown.size() || _primitiveCooldown[g] == 0;
-    if (canToggle && shouldBeActive != currentlyActive &&
-        setPrimitiveActive(g, shouldBeActive))
-      changed = true;
+    if (canToggle && shouldBeActive != currentlyActive) {
+      if (toggles < LOD_MAX_TOGGLES_PER_FRAME &&
+          setPrimitiveActive(g, shouldBeActive)) {
+        changed = true;
+        ++toggles;
+      }
+    }
     if (_activePrimitive[g])
       activeCount++;
   }

--- a/MetalCpp Path Tracer/Window/ControllerView.hpp
+++ b/MetalCpp Path Tracer/Window/ControllerView.hpp
@@ -15,7 +15,7 @@ public:
 // Update the FPS text overlay on the rendering view.
 void updateFPS(double fps);
 
-// Update the memory usage text overlay on the rendering view.
+// Update the GPU memory usage text overlay on the rendering view.
 void updateMemoryUsage(double memoryMB);
 
 };

--- a/MetalCpp Path Tracer/Window/ControllerView.mm
+++ b/MetalCpp Path Tracer/Window/ControllerView.mm
@@ -36,14 +36,14 @@ MTK::View *MetalCppPathTracer::ControllerView::get(CGRect frame) {
     [fpsLabel setTextColor:[NSColor whiteColor]];
     [fpsLabel setStringValue:@"0 FPS"];
     [adapter addSubview:fpsLabel];
-    memoryLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(10, frame.size.height - 55, 120, 20)];
+    memoryLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(10, frame.size.height - 55, 150, 20)];
     [memoryLabel setBezeled:NO];
     [memoryLabel setDrawsBackground:YES];
     [memoryLabel setBackgroundColor:[NSColor colorWithCalibratedWhite:0 alpha:0.5]];
     [memoryLabel setEditable:NO];
     [memoryLabel setSelectable:NO];
     [memoryLabel setTextColor:[NSColor whiteColor]];
-    [memoryLabel setStringValue:@"0 MB"];
+    [memoryLabel setStringValue:@"GPU: 0.0 MB"];
     [adapter addSubview:memoryLabel];
     [pool release];
 }
@@ -57,7 +57,7 @@ MTK::View *MetalCppPathTracer::ControllerView::get(CGRect frame) {
 }
 
 + (void)updateMemory:(double)mem {
-    [memoryLabel setStringValue:[NSString stringWithFormat:@"%.1f MB", mem]];
+    [memoryLabel setStringValue:[NSString stringWithFormat:@"GPU: %.1f MB", mem]];
 }
 
 - (id)init {

--- a/MetalCpp Path Tracer/Window/ViewDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.cpp
@@ -6,19 +6,9 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
-#include <mach/mach.h>
 #include <limits>
 
 using namespace MetalCppPathTracer;
-
-static double getMemoryUsageMB() {
-  mach_task_basic_info_data_t info;
-  mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
-  if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO,
-                reinterpret_cast<task_info_t>(&info), &count) != KERN_SUCCESS)
-    return 0.0;
-  return static_cast<double>(info.resident_size) / (1024.0 * 1024.0);
-}
 
 ViewDelegate::ViewDelegate(MTL::Device *pDevice)
     : MTK::ViewDelegate(), _pRenderer(new Renderer(pDevice)),
@@ -61,7 +51,7 @@ void ViewDelegate::drawInMTKView(MTK::View *pView) {
   double fps = 1.0 / deltaSeconds;
   _lastTime = current;
   updateFPS(fps);
-  updateMemoryUsage(getMemoryUsageMB());
+  updateMemoryUsage(_pRenderer->currentGPUMemoryMB());
   _pRenderer->setDeltaTime(deltaSeconds);
   _pRenderer->draw(pView);
   if (_perfLog.is_open()) {


### PR DESCRIPTION
## Summary
- throttle distance-based LOD residency toggles per frame to avoid large rebuild spikes and reduce stutter
- update the on-screen overlay to display GPU memory usage and widen the label for longer text
- source GPU memory data directly from the renderer and remove unused CPU memory tracking

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6641a75ac832da6f2578084ecc4fd