### PR TITLE
Fix MTL storage mode type usage

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -268,7 +268,7 @@ BufferCountInfo prepareBufferCounts(size_t current, size_t previous,
 void Renderer::ensureBufferCapacity(MTL::Buffer *&buffer, size_t requiredBytes,
                                     size_t &currentCapacity,
                                     bool allowShrink,
-                                    MTL::ResourceStorageMode storageMode) {
+                                    MTL::ResourceOptions storageMode) {
   if (requiredBytes == 0)
     requiredBytes = 1;
 

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -55,7 +55,7 @@ private:
   void ensureBufferCapacity(MTL::Buffer *&buffer, size_t requiredBytes,
                             size_t &currentCapacity,
                             bool allowShrink = false,
-                            MTL::ResourceStorageMode storageMode =
+                            MTL::ResourceOptions storageMode =
                                 MTL::ResourceStorageModeManaged);
   struct BoundingSphere {
     simd::float3 center;


### PR DESCRIPTION
## Summary
- update ensureBufferCapacity to take ResourceOptions instead of the removed ResourceStorageMode type
- use the ResourceOptions enum consistently with Metal's newBuffer API

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d67b319c7c832d8d24631d3471e35a