### PR TITLE
Clamp residency sort values to finite range

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -93,8 +93,15 @@ float primitiveImportance(const Primitive &p) {
 }
 
 float sanitizeSortValue(float value) {
-  if (!std::isfinite(value))
-    return -std::numeric_limits<float>::infinity();
+  if (std::isnan(value))
+    return -std::numeric_limits<float>::max();
+
+  const float finiteMax = std::numeric_limits<float>::max();
+  if (value >= finiteMax)
+    return finiteMax;
+  if (value <= -finiteMax)
+    return -finiteMax;
+
   return value;
 }
 


### PR DESCRIPTION
## Summary
- clamp residency scoring values to a finite range before sorting to avoid violating strict weak ordering

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d67db64ef8832db7d2d28e0a6f3757