### PR TITLE
Track resident BVH nodes separately

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -798,6 +798,8 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
 
   _tlasNodeCount = tlasNodes.size();
 
+  _residentNodeCount = _blasNodeCount + _tlasNodeCount;
+
   std::vector<simd::float4> bvhPacked(_blasNodeCount * 2,
                                       simd::float4{0.0f, 0.0f, 0.0f, 0.0f});
   for (size_t i = 0; i < _blasNodeCount; ++i) {
@@ -1162,8 +1164,6 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     _activeNodeCount = newActiveCount;
     printf("Active nodes: %zu\n", _activeNodeCount);
   }
-
-  _totalNodeCount = _blasNodeCount + _tlasNodeCount;
 }
 
 void Renderer::buildTextures() {
@@ -1831,8 +1831,8 @@ void Renderer::completeFrameMetrics(MTL::CommandBuffer *pCmd) {
     _lastRaysPerSecond = 0.0;
   }
   processRayHitCounters();
-  size_t offloaded = _totalNodeCount > _activeNodeCount ?
-                         _totalNodeCount - _activeNodeCount :
+  size_t offloaded = _totalNodeCount > _residentNodeCount ?
+                         _totalNodeCount - _residentNodeCount :
                          0;
   printf(
       "Nodes active: %zu offloaded: %zu CPU: %.3f ms GPU: %.3f ms Rays/s: %.2f\n",
@@ -1844,4 +1844,5 @@ double Renderer::lastCPUTime() const { return _lastCPUTime; }
 double Renderer::lastGPUTime() const { return _lastGPUTime; }
 double Renderer::lastRaysPerSecond() const { return _lastRaysPerSecond; }
 size_t Renderer::activeNodeCount() const { return _activeNodeCount; }
+size_t Renderer::residentNodeCount() const { return _residentNodeCount; }
 size_t Renderer::totalNodeCount() const { return _totalNodeCount; }

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -40,6 +40,7 @@ public:
   double lastGPUTime() const;
   double lastRaysPerSecond() const;
   size_t activeNodeCount() const;
+  size_t residentNodeCount() const;
   size_t totalNodeCount() const;
 
   std::vector<std::pair<simd::float3, float>> _allSpheres;
@@ -98,6 +99,7 @@ private:
   size_t _blasNodeCount = 0;
   size_t _tlasNodeCount = 0;
   size_t _activeNodeCount = 0;
+  size_t _residentNodeCount = 0;
   size_t _totalNodeCount = 0;
   // Accumulation framebuffers
   MTL::Texture *_accumulationTargets[2] = {nullptr, nullptr};

--- a/MetalCpp Path Tracer/Window/ViewDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.cpp
@@ -59,8 +59,9 @@ void ViewDelegate::drawInMTKView(MTK::View *pView) {
     double gpu_ms = _pRenderer->lastGPUTime() * 1000.0;
     double rays = _pRenderer->lastRaysPerSecond();
     size_t active = _pRenderer->activeNodeCount();
-    size_t offloaded = _pRenderer->totalNodeCount() > active
-                           ? _pRenderer->totalNodeCount() - active
+    size_t resident = _pRenderer->residentNodeCount();
+    size_t offloaded = _pRenderer->totalNodeCount() > resident
+                           ? _pRenderer->totalNodeCount() - resident
                            : 0;
     _perfLog << _frameCount << "," << fps << "," << cpu_ms << ","
              << gpu_ms << "," << rays << "," << active << "," << offloaded


### PR DESCRIPTION
## Summary
- keep the full-scene node total set during setup and track resident TLAS/BLAS nodes separately
- expose the resident node count and use it when reporting offloaded nodes in the renderer and view delegate

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d683bd09e0832d9df7c02b230a5be7