### PR TITLE
Adjust buffer shrink hysteresis

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -293,7 +293,7 @@ void Renderer::ensureBufferCapacity(MTL::Buffer *&buffer, size_t requiredBytes,
     desiredCapacity = std::max(requiredBytes, currentCapacity);
   } else if (buffer) {
     size_t shrinkThreshold = currentCapacity / 2;
-    if (requiredBytes <= currentCapacity && requiredBytes >= shrinkThreshold)
+    if (requiredBytes <= currentCapacity && requiredBytes > shrinkThreshold)
       return;
     if (requiredBytes > currentCapacity)
       desiredCapacity = std::max(requiredBytes, currentCapacity * 2);

--- a/MetalCpp Path Tracer/scene_lod_memory_drop.xml
+++ b/MetalCpp Path Tracer/scene_lod_memory_drop.xml
@@ -1,0 +1,28 @@
+<Scene width="1280" height="720" maxRayDepth="32" residencyStrategy="distance">
+    <CameraPath>
+        <!-- Begin inside a dense cluster of meshes to force maximum residency. -->
+        <Keyframe frame="0" position="0,12,40" lookAt="0,12,0" />
+        <Keyframe frame="60" position="0,12,40" lookAt="0,12,0" />
+        <!-- Fly the camera to an empty overlook so the dense cluster unloads. -->
+        <Keyframe frame="140" position="0,40,220" lookAt="0,0,220" />
+        <Keyframe frame="200" position="0,40,220" lookAt="0,0,220" />
+    </CameraPath>
+
+    <!-- Ground plane -->
+    <Sphere position="0,-10000,0" radius="10000" albedo="0.7,0.7,0.7" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Dense cluster near origin to create a large residency set. -->
+    <Mesh file="assets/bunny.obj" position="-12,0,-12" scale="12.0" albedo="0.8,0.4,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="12,0,-12" scale="12.0" albedo="0.8,0.6,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-12,0,12" scale="12.0" albedo="0.3,0.6,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="12,0,12" scale="12.0" albedo="0.3,0.8,0.6" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="0,0,0" scale="14.0" albedo="0.9,0.5,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="0,15,0" radius="8" albedo="0.6,0.4,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-24,10,0" radius="6" albedo="0.9,0.5,0.2" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="24,10,0" radius="6" albedo="0.2,0.5,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Sparse distant elements stay visible after the camera leaves the cluster. -->
+    <Sphere position="0,30,220" radius="20" albedo="0.4,0.6,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-60,5,220" radius="12" albedo="0.6,0.8,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="60,5,220" radius="12" albedo="0.8,0.4,0.6" emission="0,0,0" materialType="0" emissionPower="0" />
+</Scene>


### PR DESCRIPTION
## Summary
- loosen the shrink threshold in ensureBufferCapacity so buffers resize sooner when demand drops
- add a dedicated `scene_lod_memory_drop.xml` path that starts in a dense cluster before moving to a sparse overlook so memory use visibly releases once the cluster unloads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d68b49e90c832d96067cb1c8aadb65