### PR TITLE
Add mesh caching to SceneLoader

### DIFF
--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -1,4 +1,5 @@
 #include "Scene.h"
+#include "SceneLoader.h"
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
@@ -11,6 +12,8 @@ namespace MetalCppPathTracer {
 Scene::Scene() { clear(); }
 
 void Scene::clear() {
+  // Reset any cached mesh data owned by the loader when the scene is cleared.
+  SceneLoader::ClearCache();
   primitives.clear();
   bvhNodes.clear();
   primitiveIndices.clear();

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -9,6 +9,9 @@
 #include <sstream>
 #include <filesystem>
 #include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 #include "tiny_obj_loader.h"
 
 using namespace tinyxml2;
@@ -19,6 +22,23 @@ static simd::float3 parseVec3(const char* str) {
     float x=0,y=0,z=0;
     sscanf(str, "%f,%f,%f", &x,&y,&z);
     return simd::make_float3(x,y,z);
+}
+
+namespace {
+
+// Stores previously loaded mesh vertex/index buffers keyed by resolved file
+// path so repeated references to the same mesh can reuse geometry data within a
+// single scene load.
+struct CachedMesh {
+    std::vector<simd::float3> vertices;
+    std::vector<simd::uint3> indices;
+};
+
+using MeshCache = std::unordered_map<std::string, CachedMesh>;
+
+MeshCache& GetMeshCache() {
+    static MeshCache cache;
+    return cache;
 }
 
 static void LoadOBJ(const std::string& path, std::vector<simd::float3>& verts, std::vector<simd::uint3>& tris) {
@@ -76,7 +96,16 @@ static void LoadOBJ(const std::string& path, std::vector<simd::float3>& verts, s
     printf("Loaded OBJ: %zu vertices, %zu triangles\n", verts.size(), tris.size());
 }
 
+} // namespace
+
+void SceneLoader::ClearCache() {
+    GetMeshCache().clear();
+}
+
 bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
+    // Ensure stale mesh data does not leak between scene loads.
+    ClearCache();
+
     XMLDocument doc;
     if (doc.LoadFile(path.c_str()) != XML_SUCCESS) {
         printf("Failed to load scene XML: %s\n", path.c_str());
@@ -192,13 +221,21 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             scene->addPrimitive(p);
         }
         else if (tag == "Mesh") {
-            std::vector<simd::float3> verts;
-            std::vector<simd::uint3> tris;
-
             // Build full path to mesh file relative to the scene's directory
             const char* fileAttr = e->Attribute("file");
             std::filesystem::path meshPath = baseDir / (fileAttr ? fileAttr : "");
-            LoadOBJ(meshPath.string(), verts, tris);
+            std::string normalizedPath = meshPath.lexically_normal().string();
+
+            auto& cache = GetMeshCache();
+            auto it = cache.find(normalizedPath);
+            if (it == cache.end()) {
+                // First time encountering this mesh path in the current load.
+                CachedMesh entry;
+                LoadOBJ(normalizedPath, entry.vertices, entry.indices);
+                it = cache.emplace(normalizedPath, std::move(entry)).first;
+            }
+
+            const CachedMesh& meshData = it->second;
 
             simd::float3 pos = parseVec3(e->Attribute("position"));
             float scale = e->FloatAttribute("scale", 1.0f);
@@ -210,13 +247,13 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             m.emissionPower = e->FloatAttribute("emissionPower", 0);
 
             std::vector<Primitive> meshPrimitives;
-            meshPrimitives.reserve(tris.size());
-            for (const auto& tri : tris) {
+            meshPrimitives.reserve(meshData.indices.size());
+            for (const auto& tri : meshData.indices) {
                 Primitive p{};
                 p.type = PrimitiveType::Triangle;
-                p.triangle.v0 = pos + scale * verts[tri.x];
-                p.triangle.v1 = pos + scale * verts[tri.y];
-                p.triangle.v2 = pos + scale * verts[tri.z];
+                p.triangle.v0 = pos + scale * meshData.vertices[tri.x];
+                p.triangle.v1 = pos + scale * meshData.vertices[tri.y];
+                p.triangle.v2 = pos + scale * meshData.vertices[tri.z];
                 p.material = m;
                 meshPrimitives.push_back(p);
             }

--- a/MetalCpp Path Tracer/Scene/SceneLoader.h
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.h
@@ -6,10 +6,17 @@
 
 namespace MetalCppPathTracer {
 
+// SceneLoader caches mesh vertex/index data during scene loading to avoid
+// re-reading the same meshes from disk. Call ClearCache before beginning a new
+// load (done automatically by Scene::clear and LoadSceneFromXML) to release
+// cached data.
 class SceneLoader {
 public:
     // Returns true on success, false if the XML could not be loaded or parsed
     static bool LoadSceneFromXML(const std::string& path, Scene* scene);
+
+    // Clears any cached mesh data so future loads re-read meshes from disk.
+    static void ClearCache();
 };
 
 }


### PR DESCRIPTION
## Summary
- add an internal mesh cache to SceneLoader so identical mesh references reuse loaded vertex/index data
- clear the cache when loading a scene or when Scene::clear is invoked to prevent stale geometry
- document the caching behaviour for future maintainers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d697997e3c832db5adc54dd7c398e8