### PR TITLE
Fix total node count calculation for residency diagnostics

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -581,16 +581,20 @@ void Renderer::updateVisibleScene() {
 
   _rayHitRebuildCooldown = 0;
 
+  _maxBlasNodeCount = 1;
+  _maxTlasNodeCount = 1;
+
   _pScene->buildBVH();
-  _maxBlasNodeCount = std::max<size_t>(_pScene->getBVHNodeCount(), 1);
+  size_t blasNodeCount = _pScene->getBVHNodeCount();
+  _maxBlasNodeCount = std::max<size_t>(blasNodeCount, _maxBlasNodeCount);
 
   size_t fullTlasCount = 0;
   if (primCount > 0) {
     simd::float4 *tmp = _pScene->createTLASBuffer(fullTlasCount);
     delete[] tmp;
   }
-  _maxTlasNodeCount = std::max<size_t>(fullTlasCount, 1);
-  _totalNodeCount = fullTlasCount + primCount;
+  _maxTlasNodeCount = std::max<size_t>(fullTlasCount, _maxTlasNodeCount);
+  _totalNodeCount = _maxBlasNodeCount + _maxTlasNodeCount;
 
   updateResidency(true, true);
 }


### PR DESCRIPTION
## Summary
- initialize the BLAS and TLAS node caps before computing residency totals
- compute the total acceleration-structure node budget from the BLAS and TLAS maxima so diagnostics reflect node availability

## Testing
- xcodebuild -list *(fails: command not found in the Linux container)*

------
https://chatgpt.com/codex/tasks/task_e_68d699f67d8c832d8d1f5111021ad2db