### PR TITLE
Restore TLAS hierarchy for active objects

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <cstdint>
 #include <limits>
+#include <functional>
 #include <filesystem>
 #include <fstream>
 #include <chrono>
@@ -812,13 +813,159 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   _blasNodeCount = bvhNodes.size();
 
   std::vector<TLASNode> tlasNodes;
-  if (_residentPrimitiveCount > 0 && !bvhNodes.empty()) {
-    TLASNode root;
-    root.boundsMin = bvhNodes.front().boundsMin;
-    root.boundsMax = bvhNodes.front().boundsMax;
-    root.leftChild = -1;
-    root.rightChild = 0;
-    tlasNodes.push_back(root);
+  if (_residentPrimitiveCount > 0) {
+    std::vector<size_t> activeObjectIndices;
+    activeObjectIndices.reserve(_allSceneObjects.size());
+    std::vector<uint8_t> objectSeen(_allSceneObjects.size(), 0);
+
+    for (size_t remapIndex : _residentRemap) {
+      if (remapIndex >= _primitiveToObject.size())
+        continue;
+      size_t objectIndex = _primitiveToObject[remapIndex];
+      if (objectIndex >= _allSceneObjects.size())
+        continue;
+      if (objectSeen[objectIndex])
+        continue;
+      const SceneObject &obj = _allSceneObjects[objectIndex];
+      if (obj.blasRootIndex < 0)
+        continue;
+      objectSeen[objectIndex] = 1;
+      activeObjectIndices.push_back(objectIndex);
+    }
+
+    if (!activeObjectIndices.empty()) {
+      auto objectAxisValue = [this](size_t objectIndex, int axis) {
+        const SceneObject &obj = _allSceneObjects[objectIndex];
+        return 0.5f * (obj.boundsMin[axis] + obj.boundsMax[axis]);
+      };
+
+      std::function<int(size_t, size_t)> buildTLASRecursive =
+          [&](size_t start, size_t end) -> int {
+        TLASNode node;
+        simd::float3 bMin(std::numeric_limits<float>::max());
+        simd::float3 bMax(-std::numeric_limits<float>::max());
+
+        for (size_t i = start; i < end; ++i) {
+          const SceneObject &obj = _allSceneObjects[activeObjectIndices[i]];
+          bMin = simd::min(bMin, obj.boundsMin);
+          bMax = simd::max(bMax, obj.boundsMax);
+        }
+
+        node.boundsMin = bMin;
+        node.boundsMax = bMax;
+        node.leftChild = -1;
+        node.rightChild = -1;
+
+        int nodeIndex = static_cast<int>(tlasNodes.size());
+        tlasNodes.push_back(node);
+
+        size_t count = end - start;
+        if (count == 1) {
+          size_t objectIndex = activeObjectIndices[start];
+          const SceneObject &obj = _allSceneObjects[objectIndex];
+          tlasNodes[nodeIndex].leftChild =
+              -static_cast<int>(objectIndex) - 1;
+          tlasNodes[nodeIndex].rightChild = obj.blasRootIndex;
+          return nodeIndex;
+        }
+
+        const float parentArea =
+            boundingSurfaceArea(bMin, bMax);
+        if (parentArea <= 0.0f) {
+          size_t mid = start + count / 2;
+          int leftChild = buildTLASRecursive(start, mid);
+          int rightChild = buildTLASRecursive(mid, end);
+          tlasNodes[nodeIndex].leftChild = leftChild;
+          tlasNodes[nodeIndex].rightChild = rightChild;
+          return nodeIndex;
+        }
+
+        size_t range = count;
+        float bestCost = std::numeric_limits<float>::max();
+        int bestAxis = -1;
+        size_t bestSplit = start + range / 2;
+
+        for (int axis = 0; axis < 3; ++axis) {
+          std::sort(activeObjectIndices.begin() + start,
+                    activeObjectIndices.begin() + end,
+                    [&](size_t a, size_t b) {
+                      return objectAxisValue(a, axis) <
+                             objectAxisValue(b, axis);
+                    });
+
+          std::vector<simd::float3> leftMin(range);
+          std::vector<simd::float3> leftMax(range);
+          std::vector<simd::float3> rightMin(range);
+          std::vector<simd::float3> rightMax(range);
+
+          simd::float3 currMin(std::numeric_limits<float>::max());
+          simd::float3 currMax(-std::numeric_limits<float>::max());
+          for (size_t i = 0; i < range; ++i) {
+            const SceneObject &obj =
+                _allSceneObjects[activeObjectIndices[start + i]];
+            currMin = simd::min(currMin, obj.boundsMin);
+            currMax = simd::max(currMax, obj.boundsMax);
+            leftMin[i] = currMin;
+            leftMax[i] = currMax;
+          }
+
+          currMin = simd::float3(std::numeric_limits<float>::max());
+          currMax =
+              simd::float3(-std::numeric_limits<float>::max());
+          for (size_t i = range; i-- > 0;) {
+            const SceneObject &obj =
+                _allSceneObjects[activeObjectIndices[start + i]];
+            currMin = simd::min(currMin, obj.boundsMin);
+            currMax = simd::max(currMax, obj.boundsMax);
+            rightMin[i] = currMin;
+            rightMax[i] = currMax;
+          }
+
+          for (size_t i = 1; i < range; ++i) {
+            float saLeft = boundingSurfaceArea(leftMin[i - 1], leftMax[i - 1]);
+            float saRight =
+                boundingSurfaceArea(rightMin[i], rightMax[i]);
+
+            size_t leftCount = i;
+            size_t rightCount = range - i;
+
+            float cost = 0.125f + (saLeft / parentArea) * leftCount +
+                         (saRight / parentArea) * rightCount;
+
+            if (cost < bestCost) {
+              bestCost = cost;
+              bestAxis = axis;
+              bestSplit = start + i;
+            }
+          }
+        }
+
+        if (bestAxis == -1) {
+          size_t mid = start + range / 2;
+          int leftChild = buildTLASRecursive(start, mid);
+          int rightChild = buildTLASRecursive(mid, end);
+          tlasNodes[nodeIndex].leftChild = leftChild;
+          tlasNodes[nodeIndex].rightChild = rightChild;
+          return nodeIndex;
+        }
+
+        std::sort(activeObjectIndices.begin() + start,
+                  activeObjectIndices.begin() + end,
+                  [&](size_t a, size_t b) {
+                    return objectAxisValue(a, bestAxis) <
+                           objectAxisValue(b, bestAxis);
+                  });
+
+        int leftChild = buildTLASRecursive(start, bestSplit);
+        int rightChild = buildTLASRecursive(bestSplit, end);
+        tlasNodes[nodeIndex].leftChild = leftChild;
+        tlasNodes[nodeIndex].rightChild = rightChild;
+
+        return nodeIndex;
+      };
+
+      buildTLASRecursive(0, activeObjectIndices.size());
+    }
   }
 
   _tlasNodeCount = tlasNodes.size();


### PR DESCRIPTION
## Summary
- rebuild the renderer TLAS using the per-object SAH splitter from the scene so each active object becomes its own leaf
- emit TLAS nodes with the original object index/BLAS root encoding based on cached scene object bounds
- upload the expanded TLAS node list so GPU traversal uses the restored hierarchy

## Testing
- not run (Metal tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6a1844b70832da2e4952036e23915