### PR TITLE
Implement compact residency rebuild

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -647,6 +647,11 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   size_t totalPrimitiveCount = _allPrimitives.size();
   size_t previousPrimitiveCount = _residentPrimitiveCount;
 
+  if (forceFullRebuild) {
+    _residentCompacted = false;
+    _compactionCooldown = 0;
+  }
+
   const size_t uniformsDataSize = sizeof(UniformsData);
   if (!_pUniformsBuffer) {
     _pUniformsBuffer =
@@ -658,13 +663,8 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
 
   if (_primitiveToResidentIndex.size() < totalPrimitiveCount)
     _primitiveToResidentIndex.resize(totalPrimitiveCount, -1);
-  if (_residentRemap.size() < totalPrimitiveCount)
-    _residentRemap.resize(totalPrimitiveCount, 0);
-
-  for (size_t i = 0; i < totalPrimitiveCount; ++i) {
-    _primitiveToResidentIndex[i] = static_cast<int32_t>(i);
-    _residentRemap[i] = static_cast<uint32_t>(i);
-  }
+  std::fill(_primitiveToResidentIndex.begin(), _primitiveToResidentIndex.end(),
+            -1);
 
   bool sizeChanged = previousPrimitiveCount != totalPrimitiveCount;
   bool needFullUpload =
@@ -739,150 +739,11 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       }
     }
     _tlasNodeCount = tlasCount;
-
-    size_t primitiveFloat4Count = totalPrimitiveCount * 3;
-    size_t primitiveBytes =
-        std::max<size_t>(primitiveFloat4Count, size_t(1)) *
-        sizeof(simd::float4);
-    ensureBufferCapacity(_pSphereBuffer, primitiveBytes, _sphereBufferCapacity,
-                         false);
-    if (_pSphereBuffer) {
-      simd::float4 *dst =
-          static_cast<simd::float4 *>(_pSphereBuffer->contents());
-      if (primitiveFloat4Count > 0)
-        std::memcpy(dst, _cachedPrimitiveData.data(),
-                    primitiveFloat4Count * sizeof(simd::float4));
-      else
-        dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-      _pSphereBuffer->didModifyRange(NS::Range::Make(0, primitiveBytes));
-    }
-
-    size_t materialFloat4Count = totalPrimitiveCount * 2;
-    size_t materialBytes =
-        std::max<size_t>(materialFloat4Count, size_t(1)) *
-        sizeof(simd::float4);
-    ensureBufferCapacity(_pSphereMaterialBuffer, materialBytes,
-                         _sphereMaterialBufferCapacity, false);
-    if (_pSphereMaterialBuffer) {
-      simd::float4 *dst = static_cast<simd::float4 *>(
-          _pSphereMaterialBuffer->contents());
-      if (materialFloat4Count > 0)
-        std::memcpy(dst, _cachedMaterialData.data(),
-                    materialFloat4Count * sizeof(simd::float4));
-      else {
-        dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-        if (materialBytes >= 2 * sizeof(simd::float4))
-          dst[1] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-      }
-      _pSphereMaterialBuffer->didModifyRange(NS::Range::Make(0, materialBytes));
-    }
-
-    size_t primitiveIndexCount = _cachedPrimitiveIndices.size();
-    size_t primitiveIndexBytes =
-        std::max<size_t>(primitiveIndexCount, size_t(1)) * sizeof(int);
-    ensureBufferCapacity(_pPrimitiveIndexBuffer, primitiveIndexBytes,
-                         _primitiveIndexBufferCapacity, false);
-    if (_pPrimitiveIndexBuffer) {
-      int *dst = static_cast<int *>(_pPrimitiveIndexBuffer->contents());
-      if (primitiveIndexCount > 0)
-        std::memcpy(dst, _cachedPrimitiveIndices.data(),
-                    primitiveIndexCount * sizeof(int));
-      else
-        dst[0] = 0;
-      _pPrimitiveIndexBuffer->didModifyRange(
-          NS::Range::Make(0, primitiveIndexBytes));
-    }
-
-    size_t blasFloat4Count = _cachedBVHNodes.size();
-    size_t bvhBytes =
-        std::max<size_t>(blasFloat4Count, size_t(1)) * sizeof(simd::float4);
-    ensureBufferCapacity(_pBVHBuffer, bvhBytes, _bvhBufferCapacity, false);
-    if (_pBVHBuffer) {
-      simd::float4 *dst =
-          static_cast<simd::float4 *>(_pBVHBuffer->contents());
-      if (blasFloat4Count > 0)
-        std::memcpy(dst, _cachedBVHNodes.data(),
-                    blasFloat4Count * sizeof(simd::float4));
-      else {
-        dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-        if (bvhBytes >= 2 * sizeof(simd::float4))
-          dst[1] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-      }
-      _pBVHBuffer->didModifyRange(NS::Range::Make(0, bvhBytes));
-    }
-
-    size_t tlasFloat4Count = _cachedTLASNodes.size();
-    size_t tlasBytes =
-        std::max<size_t>(tlasFloat4Count, size_t(1)) * sizeof(simd::float4);
-    ensureBufferCapacity(_pTLASBuffer, tlasBytes, _tlasBufferCapacity, false);
-    if (_pTLASBuffer) {
-      simd::float4 *dst =
-          static_cast<simd::float4 *>(_pTLASBuffer->contents());
-      if (tlasFloat4Count > 0)
-        std::memcpy(dst, _cachedTLASNodes.data(),
-                    tlasFloat4Count * sizeof(simd::float4));
-      else {
-        dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-        if (tlasBytes >= 2 * sizeof(simd::float4))
-          dst[1] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-      }
-      _pTLASBuffer->didModifyRange(NS::Range::Make(0, tlasBytes));
-    }
-
-    size_t remapCount = std::max<size_t>(totalPrimitiveCount, size_t(1));
-    ensureBufferCapacity(_pPrimitiveRemapBuffer, remapCount * sizeof(uint32_t),
-                         _primitiveRemapBufferCapacity, false);
-    if (_pPrimitiveRemapBuffer) {
-      uint32_t *dst = static_cast<uint32_t *>(
-          _pPrimitiveRemapBuffer->contents());
-      if (totalPrimitiveCount > 0) {
-        for (size_t i = 0; i < totalPrimitiveCount; ++i)
-          dst[i] = static_cast<uint32_t>(i);
-      } else {
-        dst[0] = 0;
-      }
-      _pPrimitiveRemapBuffer->didModifyRange(
-          NS::Range::Make(0, remapCount * sizeof(uint32_t)));
-    }
-
-    size_t vertexCount = _cachedTriangleVertices.size();
-    size_t vertexBytes =
-        std::max<size_t>(vertexCount, size_t(1)) * sizeof(simd::float3);
-    ensureBufferCapacity(_pTriangleVertexBuffer, vertexBytes,
-                         _triangleVertexBufferCapacity, false);
-    if (_pTriangleVertexBuffer) {
-      simd::float3 *dst = static_cast<simd::float3 *>(
-          _pTriangleVertexBuffer->contents());
-      if (vertexCount > 0)
-        std::memcpy(dst, _cachedTriangleVertices.data(),
-                    vertexCount * sizeof(simd::float3));
-      else
-        dst[0] = simd::float3{0.0f, 0.0f, 0.0f};
-      _pTriangleVertexBuffer->didModifyRange(NS::Range::Make(0, vertexBytes));
-    }
-
-    size_t indexCount = _cachedTriangleIndices.size();
-    size_t indexBytes =
-        std::max<size_t>(indexCount, size_t(1)) * sizeof(simd::uint3);
-    ensureBufferCapacity(_pTriangleIndexBuffer, indexBytes,
-                         _triangleIndexBufferCapacity, false);
-    if (_pTriangleIndexBuffer) {
-      simd::uint3 *dst = static_cast<simd::uint3 *>(
-          _pTriangleIndexBuffer->contents());
-      if (indexCount > 0)
-        std::memcpy(dst, _cachedTriangleIndices.data(),
-                    indexCount * sizeof(simd::uint3));
-      else
-        dst[0] = simd::make_uint3(0, 0, 0);
-      _pTriangleIndexBuffer->didModifyRange(NS::Range::Make(0, indexBytes));
-    }
-
-    _residentBuffersInitialized = true;
   }
 
   if (_cpuActiveMask.size() < totalPrimitiveCount)
     _cpuActiveMask.resize(totalPrimitiveCount, 0);
-  else if (needFullUpload)
+  if (needFullUpload)
     std::fill(_cpuActiveMask.begin(), _cpuActiveMask.end(), 0);
 
   auto deduplicate = [](std::vector<size_t> &values) {
@@ -906,13 +767,14 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   _cachedLightIndices.clear();
   _cachedLightCdf.clear();
   float totalLightWeight = 0.0f;
-  size_t activePrimitiveCount = 0;
+  std::vector<size_t> activeIndices;
+  activeIndices.reserve(totalPrimitiveCount);
   size_t activeTriangleCount = 0;
 
   for (size_t i = 0; i < totalPrimitiveCount; ++i) {
     bool active = i < _activePrimitive.size() && _activePrimitive[i];
     if (active) {
-      ++activePrimitiveCount;
+      activeIndices.push_back(i);
       if (_allPrimitives[i].type == PrimitiveType::Triangle)
         ++activeTriangleCount;
 
@@ -931,25 +793,364 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       }
     }
 
-    if (needFullUpload)
+    if (needFullUpload || _residentCompacted)
       _cpuActiveMask[i] = active ? 1 : 0;
   }
 
+  _activePrimitiveCount = activeIndices.size();
+  _activeTriangleCount = activeTriangleCount;
   _lightCount = _cachedLightIndices.size();
   _lightTotalWeight = totalLightWeight;
-  _activePrimitiveCount = activePrimitiveCount;
-  _activeTriangleCount = activeTriangleCount;
-  _residentPrimitiveCount = totalPrimitiveCount;
-  _residentTriangleCount = _cachedTriangleIndices.size();
 
+  constexpr float kCompactionEnterRatio = 0.45f;
+  constexpr float kCompactionExitRatio = 0.7f;
+  constexpr uint32_t kCompactionCooldownFrames = 30;
+
+  bool useCompaction = _residentCompacted;
+  if (!_residentCompacted) {
+    if (_compactionCooldown == 0 && totalPrimitiveCount > 0 &&
+        _activePrimitiveCount < totalPrimitiveCount) {
+      float occupancy = static_cast<float>(_activePrimitiveCount) /
+                        static_cast<float>(totalPrimitiveCount);
+      if (_activePrimitiveCount == 0 || occupancy <= kCompactionEnterRatio)
+        useCompaction = true;
+    }
+  } else {
+    float occupancy = (totalPrimitiveCount > 0)
+                          ? static_cast<float>(_activePrimitiveCount) /
+                                static_cast<float>(totalPrimitiveCount)
+                          : 1.0f;
+    if (_activePrimitiveCount == 0)
+      useCompaction = true;
+    else if (_activePrimitiveCount == totalPrimitiveCount ||
+             occupancy >= kCompactionExitRatio)
+      useCompaction = false;
+  }
+
+  bool compactionStateChanged = (useCompaction != _residentCompacted);
+  if (compactionStateChanged) {
+    _residentCompacted = useCompaction;
+    _compactionCooldown = kCompactionCooldownFrames;
+  }
+
+  std::vector<uint32_t> remapUpload;
+  std::vector<uint8_t> compactActiveMask;
+  std::vector<simd::float4> compactPrimitiveData;
+  std::vector<simd::float4> compactMaterialData;
+  std::vector<int> compactPrimitiveIndices;
+  std::vector<simd::float4> compactBVHNodes;
+  std::vector<simd::float4> compactTLASNodes;
+  std::vector<simd::float3> compactTriangleVertices;
+  std::vector<simd::uint3> compactTriangleIndices;
+  std::vector<BVHNode> compactBVHStructs;
+
+  const std::vector<simd::float4> *primitiveSource = &_cachedPrimitiveData;
+  const std::vector<simd::float4> *materialSource = &_cachedMaterialData;
+  const std::vector<int> *primitiveIndexSource = &_cachedPrimitiveIndices;
+  const std::vector<simd::float4> *bvhSource = &_cachedBVHNodes;
+  const std::vector<simd::float4> *tlasSource = &_cachedTLASNodes;
+  const std::vector<simd::float3> *triangleVertexSource =
+      &_cachedTriangleVertices;
+  const std::vector<simd::uint3> *triangleIndexSource =
+      &_cachedTriangleIndices;
+
+  if (!useCompaction) {
+    remapUpload.resize(totalPrimitiveCount);
+    for (size_t i = 0; i < totalPrimitiveCount; ++i) {
+      remapUpload[i] = static_cast<uint32_t>(i);
+      if (i < _primitiveToResidentIndex.size())
+        _primitiveToResidentIndex[i] = static_cast<int32_t>(i);
+    }
+    _residentPrimitiveCount = totalPrimitiveCount;
+    _residentTriangleCount = _cachedTriangleIndices.size();
+    _blasNodeCount = _cachedBVHNodes.size() / 2;
+    _tlasNodeCount = _cachedTLASNodes.size() / 2;
+  } else {
+    size_t residentPrimitiveCount = _activePrimitiveCount;
+    remapUpload.resize(residentPrimitiveCount);
+    compactPrimitiveData.assign(residentPrimitiveCount * 3,
+                                simd::float4{0.0f, 0.0f, 0.0f, 0.0f});
+    compactMaterialData.assign(residentPrimitiveCount * 2,
+                               simd::float4{0.0f, 0.0f, 0.0f, 0.0f});
+    compactPrimitiveIndices.resize(residentPrimitiveCount);
+
+    std::vector<Primitive> compactPrimitives;
+    compactPrimitives.reserve(residentPrimitiveCount);
+
+    size_t triangleVertexBase = 0;
+    for (size_t localIndex = 0; localIndex < residentPrimitiveCount;
+         ++localIndex) {
+      size_t globalIndex = activeIndices[localIndex];
+      remapUpload[localIndex] = static_cast<uint32_t>(globalIndex);
+      if (globalIndex < _primitiveToResidentIndex.size())
+        _primitiveToResidentIndex[globalIndex] =
+            static_cast<int32_t>(localIndex);
+
+      const Primitive &p = _allPrimitives[globalIndex];
+      compactPrimitives.push_back(p);
+      compactPrimitiveIndices[localIndex] = static_cast<int>(localIndex);
+
+      simd::float4 *primBase = &compactPrimitiveData[3 * localIndex];
+      simd::float4 *matBase = &compactMaterialData[2 * localIndex];
+
+      switch (p.type) {
+      case PrimitiveType::Sphere: {
+        primBase[0] =
+            simd::make_float4(p.sphere.center, static_cast<float>(p.type));
+        primBase[1] = simd::make_float4(
+            simd::make_float3(p.sphere.radius, 0.0f, 0.0f), 0.0f);
+        primBase[2] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+        break;
+      }
+      case PrimitiveType::Rectangle: {
+        primBase[0] =
+            simd::make_float4(p.rectangle.center, static_cast<float>(p.type));
+        primBase[1] = simd::make_float4(p.rectangle.u, 0.0f);
+        primBase[2] = simd::make_float4(p.rectangle.v, 0.0f);
+        break;
+      }
+      case PrimitiveType::Triangle: {
+        primBase[0] =
+            simd::make_float4(p.triangle.v0, static_cast<float>(p.type));
+        primBase[1] = simd::make_float4(p.triangle.v1, 0.0f);
+        primBase[2] = simd::make_float4(p.triangle.v2, 0.0f);
+        compactTriangleVertices.push_back(p.triangle.v0);
+        compactTriangleVertices.push_back(p.triangle.v1);
+        compactTriangleVertices.push_back(p.triangle.v2);
+        compactTriangleIndices.push_back(simd::make_uint3(
+            static_cast<uint32_t>(triangleVertexBase),
+            static_cast<uint32_t>(triangleVertexBase + 1),
+            static_cast<uint32_t>(triangleVertexBase + 2)));
+        triangleVertexBase += 3;
+        break;
+      }
+      }
+
+      const Material &m = p.material;
+      matBase[0] = simd::make_float4(m.albedo, m.materialType);
+      matBase[1] = simd::make_float4(m.emissionColor, m.emissionPower);
+    }
+
+    size_t compactBlasCount = 0;
+    simd::float4 *compactBVHRaw = _pScene->createBVHBuffer(
+        compactPrimitives, compactPrimitiveIndices, compactBlasCount,
+        compactBVHStructs);
+    if (compactBVHRaw && compactBlasCount > 0) {
+      compactBVHNodes.assign(compactBVHRaw,
+                             compactBVHRaw + compactBlasCount * 2);
+      delete[] compactBVHRaw;
+    } else {
+      compactBVHNodes.clear();
+      compactBVHStructs.clear();
+    }
+
+    size_t compactTlasCount = 0;
+    simd::float4 *compactTLASRaw = _pScene->createTLASBuffer(
+        compactTlasCount, compactPrimitives, compactBVHStructs);
+    if (compactTLASRaw && compactTlasCount > 0) {
+      compactTLASNodes.assign(compactTLASRaw,
+                              compactTLASRaw + compactTlasCount * 2);
+      delete[] compactTLASRaw;
+    } else {
+      compactTLASNodes.clear();
+    }
+
+    compactActiveMask.assign(residentPrimitiveCount, 1);
+
+    primitiveSource = &compactPrimitiveData;
+    materialSource = &compactMaterialData;
+    primitiveIndexSource = &compactPrimitiveIndices;
+    bvhSource = &compactBVHNodes;
+    tlasSource = &compactTLASNodes;
+    triangleVertexSource = &compactTriangleVertices;
+    triangleIndexSource = &compactTriangleIndices;
+
+    _residentPrimitiveCount = residentPrimitiveCount;
+    _residentTriangleCount = compactTriangleIndices.size();
+    _blasNodeCount = compactBVHNodes.size() / 2;
+    _tlasNodeCount = compactTLASNodes.size() / 2;
+
+    std::vector<uint32_t> remappedLights;
+    remappedLights.reserve(_cachedLightIndices.size());
+    for (uint32_t globalIndex : _cachedLightIndices) {
+      if (globalIndex < _primitiveToResidentIndex.size()) {
+        int32_t local = _primitiveToResidentIndex[globalIndex];
+        if (local >= 0)
+          remappedLights.push_back(static_cast<uint32_t>(local));
+      }
+    }
+    _cachedLightIndices.swap(remappedLights);
+    _lightCount = _cachedLightIndices.size();
+  }
+
+  _residentRemap = remapUpload;
+
+  bool uploadAll = needFullUpload || useCompaction || compactionStateChanged;
+  bool allowShrink = useCompaction;
+
+  if (uploadAll) {
+    size_t primitiveFloat4Count = primitiveSource->size();
+    size_t primitiveBytes =
+        std::max<size_t>(primitiveFloat4Count, size_t(1)) *
+        sizeof(simd::float4);
+    ensureBufferCapacity(_pSphereBuffer, primitiveBytes, _sphereBufferCapacity,
+                         allowShrink);
+    if (_pSphereBuffer) {
+      simd::float4 *dst =
+          static_cast<simd::float4 *>(_pSphereBuffer->contents());
+      if (primitiveFloat4Count > 0)
+        std::memcpy(dst, primitiveSource->data(),
+                    primitiveFloat4Count * sizeof(simd::float4));
+      else
+        dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+      _pSphereBuffer->didModifyRange(NS::Range::Make(0, primitiveBytes));
+    }
+
+    size_t materialFloat4Count = materialSource->size();
+    size_t materialBytes =
+        std::max<size_t>(materialFloat4Count, size_t(1)) *
+        sizeof(simd::float4);
+    ensureBufferCapacity(_pSphereMaterialBuffer, materialBytes,
+                         _sphereMaterialBufferCapacity, allowShrink);
+    if (_pSphereMaterialBuffer) {
+      simd::float4 *dst = static_cast<simd::float4 *>(
+          _pSphereMaterialBuffer->contents());
+      if (materialFloat4Count > 0)
+        std::memcpy(dst, materialSource->data(),
+                    materialFloat4Count * sizeof(simd::float4));
+      else {
+        dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+        if (materialBytes >= 2 * sizeof(simd::float4))
+          dst[1] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+      }
+      _pSphereMaterialBuffer->didModifyRange(NS::Range::Make(0, materialBytes));
+    }
+
+    size_t primitiveIndexCount = primitiveIndexSource->size();
+    size_t primitiveIndexBytes =
+        std::max<size_t>(primitiveIndexCount, size_t(1)) * sizeof(int);
+    ensureBufferCapacity(_pPrimitiveIndexBuffer, primitiveIndexBytes,
+                         _primitiveIndexBufferCapacity, allowShrink);
+    if (_pPrimitiveIndexBuffer) {
+      int *dst = static_cast<int *>(_pPrimitiveIndexBuffer->contents());
+      if (primitiveIndexCount > 0)
+        std::memcpy(dst, primitiveIndexSource->data(),
+                    primitiveIndexCount * sizeof(int));
+      else
+        dst[0] = 0;
+      _pPrimitiveIndexBuffer->didModifyRange(
+          NS::Range::Make(0, primitiveIndexBytes));
+    }
+
+    size_t blasFloat4Count = bvhSource->size();
+    size_t bvhBytes =
+        std::max<size_t>(blasFloat4Count, size_t(1)) * sizeof(simd::float4);
+    ensureBufferCapacity(_pBVHBuffer, bvhBytes, _bvhBufferCapacity, allowShrink);
+    if (_pBVHBuffer) {
+      simd::float4 *dst =
+          static_cast<simd::float4 *>(_pBVHBuffer->contents());
+      if (blasFloat4Count > 0)
+        std::memcpy(dst, bvhSource->data(),
+                    blasFloat4Count * sizeof(simd::float4));
+      else {
+        dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+        if (bvhBytes >= 2 * sizeof(simd::float4))
+          dst[1] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+      }
+      _pBVHBuffer->didModifyRange(NS::Range::Make(0, bvhBytes));
+    }
+
+    size_t tlasFloat4Count = tlasSource->size();
+    size_t tlasBytes =
+        std::max<size_t>(tlasFloat4Count, size_t(1)) * sizeof(simd::float4);
+    ensureBufferCapacity(_pTLASBuffer, tlasBytes, _tlasBufferCapacity,
+                         allowShrink);
+    if (_pTLASBuffer) {
+      simd::float4 *dst =
+          static_cast<simd::float4 *>(_pTLASBuffer->contents());
+      if (tlasFloat4Count > 0)
+        std::memcpy(dst, tlasSource->data(),
+                    tlasFloat4Count * sizeof(simd::float4));
+      else {
+        dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+        if (tlasBytes >= 2 * sizeof(simd::float4))
+          dst[1] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+      }
+      _pTLASBuffer->didModifyRange(NS::Range::Make(0, tlasBytes));
+    }
+
+    size_t remapCount = std::max<size_t>(_residentRemap.size(), size_t(1));
+    ensureBufferCapacity(_pPrimitiveRemapBuffer,
+                         remapCount * sizeof(uint32_t),
+                         _primitiveRemapBufferCapacity, allowShrink);
+    if (_pPrimitiveRemapBuffer) {
+      uint32_t *dst = static_cast<uint32_t *>(
+          _pPrimitiveRemapBuffer->contents());
+      if (_residentRemap.empty()) {
+        dst[0] = 0;
+      } else {
+        std::memcpy(dst, _residentRemap.data(),
+                    _residentRemap.size() * sizeof(uint32_t));
+        if (_residentRemap.size() < remapCount)
+          dst[_residentRemap.size()] = 0;
+      }
+      _pPrimitiveRemapBuffer->didModifyRange(
+          NS::Range::Make(0, remapCount * sizeof(uint32_t)));
+    }
+
+    size_t vertexCount = triangleVertexSource->size();
+    size_t vertexBytes =
+        std::max<size_t>(vertexCount, size_t(1)) * sizeof(simd::float3);
+    ensureBufferCapacity(_pTriangleVertexBuffer, vertexBytes,
+                         _triangleVertexBufferCapacity, allowShrink);
+    if (_pTriangleVertexBuffer) {
+      simd::float3 *dst = static_cast<simd::float3 *>(
+          _pTriangleVertexBuffer->contents());
+      if (vertexCount > 0)
+        std::memcpy(dst, triangleVertexSource->data(),
+                    vertexCount * sizeof(simd::float3));
+      else
+        dst[0] = simd::float3{0.0f, 0.0f, 0.0f};
+      _pTriangleVertexBuffer->didModifyRange(NS::Range::Make(0, vertexBytes));
+    }
+
+    size_t indexCount = triangleIndexSource->size();
+    size_t indexBytes =
+        std::max<size_t>(indexCount, size_t(1)) * sizeof(simd::uint3);
+    ensureBufferCapacity(_pTriangleIndexBuffer, indexBytes,
+                         _triangleIndexBufferCapacity, allowShrink);
+    if (_pTriangleIndexBuffer) {
+      simd::uint3 *dst = static_cast<simd::uint3 *>(
+          _pTriangleIndexBuffer->contents());
+      if (indexCount > 0)
+        std::memcpy(dst, triangleIndexSource->data(),
+                    indexCount * sizeof(simd::uint3));
+      else
+        dst[0] = simd::make_uint3(0, 0, 0);
+      _pTriangleIndexBuffer->didModifyRange(NS::Range::Make(0, indexBytes));
+    }
+
+    _residentBuffersInitialized = true;
+  }
+
+  size_t activeMaskCount =
+      useCompaction ? _residentPrimitiveCount : totalPrimitiveCount;
   size_t activeBytes =
-      std::max<size_t>(totalPrimitiveCount, size_t(1)) * sizeof(uint8_t);
+      std::max<size_t>(activeMaskCount, size_t(1)) * sizeof(uint8_t);
   ensureBufferCapacity(_pActiveBuffer, activeBytes, _activeBufferCapacity,
-                       false);
+                       allowShrink);
   if (_pActiveBuffer) {
     uint8_t *activePtr =
         static_cast<uint8_t *>(_pActiveBuffer->contents());
-    if (needFullUpload) {
+    if (useCompaction) {
+      if (_residentPrimitiveCount > 0) {
+        std::memcpy(activePtr, compactActiveMask.data(),
+                    _residentPrimitiveCount * sizeof(uint8_t));
+      } else {
+        activePtr[0] = 0;
+      }
+      _pActiveBuffer->didModifyRange(NS::Range::Make(0, activeBytes));
+    } else if (uploadAll) {
       if (totalPrimitiveCount > 0)
         std::memcpy(activePtr, _cpuActiveMask.data(),
                     totalPrimitiveCount * sizeof(uint8_t));
@@ -977,7 +1178,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       std::max<size_t>(_cachedLightIndices.size(), size_t(1)) *
       sizeof(uint32_t);
   ensureBufferCapacity(_pLightIndexBuffer, lightIndexBytes,
-                       _lightIndexBufferCapacity, false);
+                       _lightIndexBufferCapacity, allowShrink);
   if (_pLightIndexBuffer) {
     uint32_t *dst = static_cast<uint32_t *>(_pLightIndexBuffer->contents());
     if (_cachedLightIndices.empty())
@@ -991,7 +1192,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   size_t lightCdfBytes =
       std::max<size_t>(_cachedLightCdf.size(), size_t(1)) * sizeof(float);
   ensureBufferCapacity(_pLightCdfBuffer, lightCdfBytes, _lightCdfBufferCapacity,
-                       false);
+                       allowShrink);
   if (_pLightCdfBuffer) {
     float *dst = static_cast<float *>(_pLightCdfBuffer->contents());
     if (_cachedLightCdf.empty())
@@ -1004,19 +1205,26 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
 
   _residentNodeCount = _blasNodeCount + _tlasNodeCount;
   size_t activeBlasNodes = 0;
-  if (totalPrimitiveCount > 0 && _blasNodeCount > 0) {
+  size_t activeTlasNodes = 0;
+  if (useCompaction) {
+    activeBlasNodes = _blasNodeCount;
+    activeTlasNodes = (_residentPrimitiveCount > 0) ? _tlasNodeCount : 0;
+  } else if (totalPrimitiveCount > 0 && _blasNodeCount > 0) {
     size_t denom = std::max<size_t>(totalPrimitiveCount, size_t(1));
     activeBlasNodes = std::max<size_t>(
-        size_t(1), (_blasNodeCount * activePrimitiveCount + denom - 1) / denom);
+        size_t(1), (_blasNodeCount * _activePrimitiveCount + denom - 1) /
+                        denom);
+    activeTlasNodes = (_tlasNodeCount > 0 && _activePrimitiveCount > 0)
+                          ? _tlasNodeCount
+                          : size_t(0);
   }
-  size_t activeTlasNodes = (_tlasNodeCount > 0 && activePrimitiveCount > 0)
-                               ? _tlasNodeCount
-                               : size_t(0);
   _activeNodeCount = activeBlasNodes + activeTlasNodes;
 
   _recentlyActivated.clear();
   _recentlyDeactivated.clear();
 }
+
+
 
 
 void Renderer::buildTextures() {
@@ -1178,6 +1386,8 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   for (uint32_t &cooldown : _objectCooldown)
     if (cooldown > 0)
       --cooldown;
+  if (_compactionCooldown > 0)
+    --_compactionCooldown;
 
   bool changed = false;
   switch (_pScene->getResidencyStrategy()) {

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -138,6 +138,8 @@ private:
   float _lightTotalWeight = 0.0f;
 
   bool _residentBuffersInitialized = false;
+  bool _residentCompacted = false;
+  uint32_t _compactionCooldown = 0;
   std::vector<uint8_t> _cpuActiveMask;
   std::vector<simd::float4> _cachedPrimitiveData;
   std::vector<simd::float4> _cachedMaterialData;

--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -226,6 +226,161 @@ simd::float4 *Scene::createSphereMaterialsBuffer() {
   return buffer;
 }
 
+namespace {
+
+void subsetPrimitiveBounds(const Primitive &p, simd::float3 &pMin,
+                           simd::float3 &pMax) {
+  if (p.type == PrimitiveType::Sphere) {
+    float r = p.sphere.radius;
+    pMin = p.sphere.center - r;
+    pMax = p.sphere.center + r;
+  } else if (p.type == PrimitiveType::Rectangle) {
+    simd::float3 c = p.rectangle.center;
+    simd::float3 e1 = p.rectangle.u;
+    simd::float3 e2 = p.rectangle.v;
+    simd::float3 c1 = c - e1 - e2;
+    simd::float3 c2 = c - e1 + e2;
+    simd::float3 c3 = c + e1 - e2;
+    simd::float3 c4 = c + e1 + e2;
+    pMin = simd::min(simd::min(c1, c2), simd::min(c3, c4));
+    pMax = simd::max(simd::max(c1, c2), simd::max(c3, c4));
+  } else {
+    const auto &t = p.triangle;
+    pMin = simd::min(t.v0, simd::min(t.v1, t.v2));
+    pMax = simd::max(t.v0, simd::max(t.v1, t.v2));
+  }
+}
+
+float subsetPrimitiveAxisValue(const Primitive &p, int axis) {
+  switch (p.type) {
+  case PrimitiveType::Sphere:
+    return p.sphere.center[axis];
+  case PrimitiveType::Rectangle:
+    return p.rectangle.center[axis];
+  case PrimitiveType::Triangle:
+    return (p.triangle.v0[axis] + p.triangle.v1[axis] +
+            p.triangle.v2[axis]) /
+           3.0f;
+  }
+  return 0.0f;
+}
+
+float subsetSurfaceArea(const simd::float3 &bmin, const simd::float3 &bmax) {
+  simd::float3 d = bmax - bmin;
+  return 2.0f * (d.x * d.y + d.y * d.z + d.z * d.x);
+}
+
+int buildSubsetBVHRecursive(const std::vector<Primitive> &primitives,
+                            std::vector<int> &primitiveIndices,
+                            std::vector<BVHNode> &nodes, size_t start,
+                            size_t end) {
+  BVHNode node;
+  simd::float3 bMin(std::numeric_limits<float>::max());
+  simd::float3 bMax(-std::numeric_limits<float>::max());
+
+  for (size_t i = start; i < end; ++i) {
+    const Primitive &p = primitives[primitiveIndices[i]];
+    simd::float3 pMin, pMax;
+    subsetPrimitiveBounds(p, pMin, pMax);
+    bMin = simd::min(bMin, pMin);
+    bMax = simd::max(bMax, pMax);
+  }
+
+  node.boundsMin = bMin;
+  node.boundsMax = bMax;
+  node.leftFirst = static_cast<int>(start);
+  node.count = static_cast<int>(end - start);
+
+  int nodeIndex = static_cast<int>(nodes.size());
+  nodes.push_back(node);
+
+  size_t range = end - start;
+  if (range <= 8)
+    return nodeIndex;
+
+  const float parentArea = subsetSurfaceArea(bMin, bMax);
+  if (parentArea <= 0.0f)
+    return nodeIndex;
+
+  float bestCost = std::numeric_limits<float>::max();
+  int bestAxis = -1;
+  size_t bestSplit = start + range / 2;
+
+  std::vector<simd::float3> leftMin(range);
+  std::vector<simd::float3> leftMax(range);
+  std::vector<simd::float3> rightMin(range);
+  std::vector<simd::float3> rightMax(range);
+
+  for (int axis = 0; axis < 3; ++axis) {
+    std::sort(primitiveIndices.begin() + start, primitiveIndices.begin() + end,
+              [&](int a, int b) {
+                return subsetPrimitiveAxisValue(primitives[a], axis) <
+                       subsetPrimitiveAxisValue(primitives[b], axis);
+              });
+
+    simd::float3 currMin(std::numeric_limits<float>::max());
+    simd::float3 currMax(-std::numeric_limits<float>::max());
+    for (size_t i = start; i < end; ++i) {
+      const Primitive &p = primitives[primitiveIndices[i]];
+      simd::float3 pMin, pMax;
+      subsetPrimitiveBounds(p, pMin, pMax);
+      currMin = simd::min(currMin, pMin);
+      currMax = simd::max(currMax, pMax);
+      leftMin[i - start] = currMin;
+      leftMax[i - start] = currMax;
+    }
+
+    currMin = simd::float3(std::numeric_limits<float>::max());
+    currMax = simd::float3(-std::numeric_limits<float>::max());
+    for (size_t i = end; i-- > start;) {
+      const Primitive &p = primitives[primitiveIndices[i]];
+      simd::float3 pMin, pMax;
+      subsetPrimitiveBounds(p, pMin, pMax);
+      currMin = simd::min(currMin, pMin);
+      currMax = simd::max(currMax, pMax);
+      rightMin[i - start] = currMin;
+      rightMax[i - start] = currMax;
+    }
+
+    for (size_t i = 1; i < range; ++i) {
+      float saLeft = subsetSurfaceArea(leftMin[i - 1], leftMax[i - 1]);
+      float saRight = subsetSurfaceArea(rightMin[i], rightMax[i]);
+
+      size_t leftCount = i;
+      size_t rightCount = range - i;
+
+      float cost = 0.125f + (saLeft / parentArea) * leftCount +
+                   (saRight / parentArea) * rightCount;
+
+      if (cost < bestCost) {
+        bestCost = cost;
+        bestAxis = axis;
+        bestSplit = start + i;
+      }
+    }
+  }
+
+  if (bestAxis == -1)
+    return nodeIndex;
+
+  std::sort(primitiveIndices.begin() + start, primitiveIndices.begin() + end,
+            [&](int a, int b) {
+              return subsetPrimitiveAxisValue(primitives[a], bestAxis) <
+                     subsetPrimitiveAxisValue(primitives[b], bestAxis);
+            });
+
+  int leftChild = buildSubsetBVHRecursive(primitives, primitiveIndices, nodes,
+                                          start, bestSplit);
+  int rightChild = buildSubsetBVHRecursive(primitives, primitiveIndices, nodes,
+                                           bestSplit, end);
+
+  nodes[nodeIndex].leftFirst = leftChild;
+  nodes[nodeIndex].count = -rightChild;
+  return nodeIndex;
+}
+
+} // namespace
+
 simd::float4 *Scene::createBVHBuffer() const {
   simd::float4 *buffer = new simd::float4[bvhNodes.size() * 2];
   for (size_t i = 0; i < bvhNodes.size(); ++i) {
@@ -233,6 +388,42 @@ simd::float4 *Scene::createBVHBuffer() const {
     buffer[2 * i + 0] = simd::make_float4(n.boundsMin, *(float *)&n.leftFirst);
     buffer[2 * i + 1] = simd::make_float4(n.boundsMax, *(float *)&n.count);
   }
+  return buffer;
+}
+
+simd::float4 *Scene::createBVHBuffer(const std::vector<Primitive> &subset,
+                                     std::vector<int> &primitiveIndices,
+                                     size_t &outCount,
+                                     std::vector<BVHNode> &outNodes) const {
+  outCount = 0;
+  outNodes.clear();
+  if (subset.empty())
+    return nullptr;
+
+  if (primitiveIndices.size() != subset.size()) {
+    primitiveIndices.resize(subset.size());
+    std::iota(primitiveIndices.begin(), primitiveIndices.end(), 0);
+  }
+
+  outNodes.reserve(subset.size() * 2);
+  buildSubsetBVHRecursive(subset, primitiveIndices, outNodes, 0,
+                          primitiveIndices.size());
+  outCount = outNodes.size();
+
+  if (outCount == 0)
+    return nullptr;
+
+  simd::float4 *buffer = new simd::float4[outCount * 2];
+  for (size_t i = 0; i < outNodes.size(); ++i) {
+    const BVHNode &node = outNodes[i];
+    float leftFirstBits = 0.0f;
+    float countBits = 0.0f;
+    std::memcpy(&leftFirstBits, &node.leftFirst, sizeof(int));
+    std::memcpy(&countBits, &node.count, sizeof(int));
+    buffer[2 * i] = simd::make_float4(node.boundsMin, leftFirstBits);
+    buffer[2 * i + 1] = simd::make_float4(node.boundsMax, countBits);
+  }
+
   return buffer;
 }
 
@@ -253,6 +444,30 @@ simd::float4 *Scene::createTLASBuffer(size_t &outCount) const {
     buffer[2 * i] = simd::make_float4(node.boundsMin, leftBits);
     buffer[2 * i + 1] = simd::make_float4(node.boundsMax, rightBits);
   }
+
+  return buffer;
+}
+
+simd::float4 *Scene::createTLASBuffer(size_t &outCount,
+                                      const std::vector<Primitive> &subset,
+                                      const std::vector<BVHNode> &blasNodes) const {
+  outCount = 0;
+  if (subset.empty() || blasNodes.empty())
+    return nullptr;
+
+  outCount = 1;
+  simd::float4 *buffer = new simd::float4[outCount * 2];
+
+  const BVHNode &root = blasNodes.front();
+  int encodedLeaf = -1;
+  int blasRootIndex = 0;
+  float leftBits = 0.0f;
+  float rightBits = 0.0f;
+  std::memcpy(&leftBits, &encodedLeaf, sizeof(int));
+  std::memcpy(&rightBits, &blasRootIndex, sizeof(int));
+
+  buffer[0] = simd::make_float4(root.boundsMin, leftBits);
+  buffer[1] = simd::make_float4(root.boundsMax, rightBits);
 
   return buffer;
 }

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -95,7 +95,14 @@ public:
   simd::float4 *createSphereBuffer();
   simd::float4 *createSphereMaterialsBuffer();
   simd::float4 *createBVHBuffer() const;
+  simd::float4 *createBVHBuffer(const std::vector<Primitive> &subset,
+                                std::vector<int> &primitiveIndices,
+                                size_t &outCount,
+                                std::vector<BVHNode> &outNodes) const;
   simd::float4 *createTLASBuffer(size_t &outCount) const;
+  simd::float4 *createTLASBuffer(size_t &outCount,
+                                 const std::vector<Primitive> &subset,
+                                 const std::vector<BVHNode> &blasNodes) const;
   int *createPrimitiveIndexBuffer() const;
   void createTriangleBuffers(std::vector<simd::float3> &outVertices,
                              std::vector<simd::uint3> &outIndices) const;

--- a/MetalCpp Path Tracer/scene_residency_compaction_cycle.xml
+++ b/MetalCpp Path Tracer/scene_residency_compaction_cycle.xml
@@ -1,0 +1,87 @@
+<Scene width="1920" height="1080" maxRayDepth="32" residencyStrategy="distance" lodEnterDistance="70" lodExitDistance="95" residencyCooldown="0" lodToggleBudget="1200">
+    <CameraPath>
+        <!-- Start far enough that compaction should trigger immediately -->
+        <Keyframe frame="0" position="0,32,260" lookAt="0,10,220" />
+        <Keyframe frame="80" position="80,36,260" lookAt="50,16,210" />
+        <!-- Accelerate toward the clusters so the renderer has to expand residency -->
+        <Keyframe frame="160" position="0,16,60" lookAt="0,8,-100" />
+        <!-- Orbit through the dense center to keep the active set high for a while -->
+        <Keyframe frame="240" position="-70,14,-10" lookAt="0,6,-100" />
+        <Keyframe frame="320" position="70,16,-20" lookAt="0,6,-100" />
+        <!-- Exit again to force the hysteresis cooldown to elapse before re-compacting -->
+        <Keyframe frame="420" position="0,28,220" lookAt="0,4,160" />
+    </CameraPath>
+    <!-- Wide ground plane -->
+    <Rectangle position="0,-18,-120" u="420,0,0" v="0,0,-420" albedo="0.45,0.44,0.43" emission="0,0,0" materialType="0" emissionPower="0" />
+    <!-- Back light to keep silhouettes readable -->
+    <Sphere position="0,60,-40" radius="15" albedo="0,0,0" emission="0.8,0.9,1.0" materialType="0" emissionPower="5" />
+    <!-- Rim light near the far pull-away to illuminate geometry when far -->
+    <Sphere position="0,30,140" radius="25" albedo="0,0,0" emission="0.4,0.5,0.8" materialType="0" emissionPower="2" />
+    <Sphere position="-13.00,1.60,-85.00" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-13.00,4.20,-85.27" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-13.00,6.80,-86.05" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-13.00,9.40,-87.26" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-6.50,1.60,-85.50" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-6.50,4.20,-86.45" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-6.50,6.80,-87.78" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-6.50,9.40,-89.35" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="0.00,1.60,-86.89" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="0.00,4.20,-88.33" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="0.00,6.80,-89.95" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="0.00,9.40,-91.57" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="6.50,1.60,-88.90" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="6.50,4.20,-90.54" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="6.50,6.80,-92.13" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="6.50,9.40,-93.48" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="13.00,1.60,-91.14" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="13.00,4.20,-92.65" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="13.00,6.80,-93.88" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="13.00,9.40,-94.69" radius="2.60" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="34.50,1.80,-105.00" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="34.50,4.60,-105.27" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="34.50,7.40,-106.05" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="34.50,10.20,-107.26" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="41.50,1.80,-105.50" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="41.50,4.60,-106.45" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="41.50,7.40,-107.78" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="41.50,10.20,-109.35" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="48.50,1.80,-106.89" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="48.50,4.60,-108.33" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="48.50,7.40,-109.95" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="48.50,10.20,-111.57" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="55.50,1.80,-108.90" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="55.50,4.60,-110.54" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="55.50,7.40,-112.13" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="55.50,10.20,-113.48" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-55.50,1.80,-105.00" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-55.50,4.60,-105.27" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-55.50,7.40,-106.05" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-55.50,10.20,-107.26" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-48.50,1.80,-105.50" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-48.50,4.60,-106.45" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-48.50,7.40,-107.78" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-48.50,10.20,-109.35" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-41.50,1.80,-106.89" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-41.50,4.60,-108.33" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-41.50,7.40,-109.95" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-41.50,10.20,-111.57" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-34.50,1.80,-108.90" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-34.50,4.60,-110.54" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-34.50,7.40,-112.13" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-34.50,10.20,-113.48" radius="3.00" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-22.50,16.20,-145.00" radius="3.50" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-22.50,19.80,-145.27" radius="3.50" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-13.50,16.20,-145.50" radius="3.50" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-13.50,19.80,-146.45" radius="3.50" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-4.50,16.20,-146.89" radius="3.50" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-4.50,19.80,-148.33" radius="3.50" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="4.50,16.20,-148.90" radius="3.50" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="4.50,19.80,-150.54" radius="3.50" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="13.50,16.20,-151.14" radius="3.50" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="13.50,19.80,-152.65" radius="3.50" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="22.50,16.20,-153.14" radius="3.50" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="22.50,19.80,-154.23" radius="3.50" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="0,0,-95" scale="11" albedo="0.78,0.56,0.42" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="48,0,-118" scale="9.5" albedo="0.6,0.55,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-48,0,-118" scale="9.5" albedo="0.6,0.55,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
+</Scene>

--- a/MetalCpp Path Tracer/scene_residency_compaction_drop.xml
+++ b/MetalCpp Path Tracer/scene_residency_compaction_drop.xml
@@ -1,0 +1,59 @@
+<Scene width="1920" height="1080" maxRayDepth="32" residencyStrategy="distance" lodEnterDistance="65" lodExitDistance="90" residencyCooldown="0" lodToggleBudget="1000">
+    <CameraPath>
+        <!-- Begin amidst dense geometry to ensure a high active count -->
+        <Keyframe frame="0" position="0,12,0" lookAt="0,6,-110" />
+        <Keyframe frame="40" position="0,12,0" lookAt="0,6,-110" />
+        <!-- Pull far away so distance-based residency deactivates most primitives -->
+        <Keyframe frame="160" position="0,12,220" lookAt="0,0,120" />
+        <!-- Drift sideways while far to keep the scene sparse for several frames -->
+        <Keyframe frame="260" position="140,20,260" lookAt="140,0,200" />
+    </CameraPath>
+    <!-- Distant ground plane to provide context even when far away -->
+    <Rectangle position="0,-20,-120" u="400,0,0" v="0,0,-400" albedo="0.5,0.5,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
+    <!-- Soft fill light to keep the clusters visible -->
+    <Sphere position="0,40,-60" radius="12" albedo="0,0,0" emission="1.0,0.95,0.9" materialType="0" emissionPower="4" />
+    <Sphere position="-11.25,2.06,-100.00" radius="3.00" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-11.25,4.69,-98.52" radius="3.00" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-11.25,7.31,-97.12" radius="3.00" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-11.25,9.94,-95.91" radius="3.00" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-3.75,2.06,-97.12" radius="3.00" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-3.75,4.69,-95.91" radius="3.00" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-3.75,7.31,-94.95" radius="3.00" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-3.75,9.94,-94.31" radius="3.00" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="3.75,2.06,-94.95" radius="3.00" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="3.75,4.69,-94.31" radius="3.00" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="3.75,7.31,-94.02" radius="3.00" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="3.75,9.94,-94.10" radius="3.00" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="11.25,2.06,-94.02" radius="3.00" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="11.25,4.69,-94.10" radius="3.00" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="11.25,7.31,-94.54" radius="3.00" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="11.25,9.94,-95.33" radius="3.00" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="42.25,7.03,-140.00" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="42.25,10.00,-138.52" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="42.25,12.97,-137.12" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="50.75,7.03,-137.12" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="50.75,10.00,-135.91" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="50.75,12.97,-134.95" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="59.25,7.03,-134.95" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="59.25,10.00,-134.31" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="59.25,12.97,-134.02" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="67.75,7.03,-134.02" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="67.75,10.00,-134.10" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="67.75,12.97,-134.54" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-63.50,3.54,-140.00" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-63.50,6.51,-138.52" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-63.50,9.49,-137.12" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-63.50,12.46,-135.91" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-55.00,3.54,-137.12" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-55.00,6.51,-135.91" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-55.00,9.49,-134.95" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-55.00,12.46,-134.31" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-46.50,3.54,-134.95" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-46.50,6.51,-134.31" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-46.50,9.49,-134.02" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Sphere position="-46.50,12.46,-134.10" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+    <!-- Triangle content to exercise BLAS/TLAS compaction alongside spheres -->
+    <Mesh file="assets/bunny.obj" position="0,0,-100" scale="12" albedo="0.85,0.55,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="60,0,-140" scale="10" albedo="0.75,0.6,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-60,0,-140" scale="10" albedo="0.75,0.6,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
+</Scene>


### PR DESCRIPTION
## Summary
- compact the resident primitive payload when the active set shrinks and rebuild Metal buffers with the packed order
- rebuild BLAS/TLAS data for compacted residency using new Scene helpers that operate on explicit primitive lists
- track compaction state with cooldown hysteresis and allow GPU buffer allocations to shrink when uploading the packed resources

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da585b85e4832d955395266063aba4