### PR TITLE
Increase residency compaction LOD toggle budgets

### DIFF
--- a/MetalCpp Path Tracer/scene_residency_compaction_cycle.xml
+++ b/MetalCpp Path Tracer/scene_residency_compaction_cycle.xml
@@ -1,4 +1,4 @@
-<Scene width="1920" height="1080" maxRayDepth="32" residencyStrategy="distance" lodEnterDistance="70" lodExitDistance="95" residencyCooldown="0" lodToggleBudget="1200">
+<Scene width="1920" height="1080" maxRayDepth="32" residencyStrategy="distance" lodEnterDistance="70" lodExitDistance="95" residencyCooldown="0" lodToggleBudget="6000">
     <CameraPath>
         <!-- Start far enough that compaction should trigger immediately -->
         <Keyframe frame="0" position="0,32,260" lookAt="0,10,220" />

--- a/MetalCpp Path Tracer/scene_residency_compaction_drop.xml
+++ b/MetalCpp Path Tracer/scene_residency_compaction_drop.xml
@@ -1,4 +1,4 @@
-<Scene width="1920" height="1080" maxRayDepth="32" residencyStrategy="distance" lodEnterDistance="65" lodExitDistance="90" residencyCooldown="0" lodToggleBudget="1000">
+<Scene width="1920" height="1080" maxRayDepth="32" residencyStrategy="distance" lodEnterDistance="65" lodExitDistance="90" residencyCooldown="0" lodToggleBudget="6000">
     <CameraPath>
         <!-- Begin amidst dense geometry to ensure a high active count -->
         <Keyframe frame="0" position="0,12,0" lookAt="0,6,-110" />


### PR DESCRIPTION
## Summary
- raise the LOD toggle budget in the residency compaction cycle and drop demo scenes so a full bunny cluster can activate

## Testing
- not run (Metal renderer requires macOS/Metal runtime which is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68da6511ee18832d80585731a506b290