### PR TITLE
Track cached primitive count separately

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -645,7 +645,7 @@ void Renderer::recalculateViewport() {
 
 void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   size_t totalPrimitiveCount = _allPrimitives.size();
-  size_t previousPrimitiveCount = _residentPrimitiveCount;
+  size_t cachedTotalPrimitiveCount = _cachedTotalPrimitiveCount;
 
   if (forceFullRebuild) {
     _residentCompacted = false;
@@ -666,7 +666,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   std::fill(_primitiveToResidentIndex.begin(), _primitiveToResidentIndex.end(),
             -1);
 
-  bool sizeChanged = previousPrimitiveCount != totalPrimitiveCount;
+  bool sizeChanged = cachedTotalPrimitiveCount != totalPrimitiveCount;
   bool needFullUpload =
       forceFullRebuild || !_residentBuffersInitialized || sizeChanged;
 
@@ -739,6 +739,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       }
     }
     _tlasNodeCount = tlasCount;
+    _cachedTotalPrimitiveCount = totalPrimitiveCount;
   }
 
   if (_cpuActiveMask.size() < totalPrimitiveCount)

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -131,6 +131,7 @@ private:
   uint32_t _rayHitRebuildCooldown = 0;
 
   size_t _residentPrimitiveCount = 0;
+  size_t _cachedTotalPrimitiveCount = 0;
   size_t _residentTriangleCount = 0;
   size_t _activePrimitiveCount = 0;
   size_t _activeTriangleCount = 0;


### PR DESCRIPTION
## Summary
- add a cached total primitive count to the renderer to detect scene size changes
- rely on the cached total primitive count rather than the resident count when deciding to rebuild resources
- refresh the cached total primitive count after populating CPU-side caches during full uploads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da678bee80832d98ccc235365910d0