### PR TITLE
Fix PendingBufferHandles definition in header

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -283,20 +283,6 @@ BufferCountInfo prepareBufferCounts(size_t current, size_t previous,
 
 } // namespace
 
-struct Renderer::PendingBufferHandles {
-  MTL::Buffer *primitive = nullptr;
-  MTL::Buffer *material = nullptr;
-  MTL::Buffer *primitiveIndices = nullptr;
-  MTL::Buffer *bvh = nullptr;
-  MTL::Buffer *triangleVertices = nullptr;
-  MTL::Buffer *triangleIndices = nullptr;
-  MTL::Buffer *remap = nullptr;
-  MTL::Buffer *activeMask = nullptr;
-  MTL::Buffer *instance = nullptr;
-  MTL::Buffer *lightIndices = nullptr;
-  MTL::Buffer *lightCdf = nullptr;
-};
-
 struct Renderer::CompactionBuildInput {
   uint64_t generation = 0;
   const Scene *scene = nullptr;

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -85,7 +85,19 @@ private:
 
   struct CompactionBuildInput;
   struct CompactionResultData;
-  struct PendingBufferHandles;
+  struct PendingBufferHandles {
+    MTL::Buffer *primitive = nullptr;
+    MTL::Buffer *material = nullptr;
+    MTL::Buffer *primitiveIndices = nullptr;
+    MTL::Buffer *bvh = nullptr;
+    MTL::Buffer *triangleVertices = nullptr;
+    MTL::Buffer *triangleIndices = nullptr;
+    MTL::Buffer *remap = nullptr;
+    MTL::Buffer *activeMask = nullptr;
+    MTL::Buffer *instance = nullptr;
+    MTL::Buffer *lightIndices = nullptr;
+    MTL::Buffer *lightCdf = nullptr;
+  };
   void launchCompactionBuild(CompactionBuildInput &&input);
   std::shared_ptr<CompactionResultData>
   buildCompactionResult(CompactionBuildInput input) const;


### PR DESCRIPTION
## Summary
- define the PendingBufferHandles struct in Renderer.h so class members have a complete type
- remove the now redundant struct definition from Renderer.cpp

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da907b6220832dbe0b9f9947294f74