### PR TITLE
Guard compaction cleanup with mutex

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -400,12 +400,24 @@ void Renderer::swapLiveBuffer(MTL::Buffer *&live, MTL::Buffer *&pending,
 }
 
 void Renderer::clearPendingCompaction() {
+  MTL::CommandBuffer *waitCommandBuffer = nullptr;
+
+  std::unique_lock<std::mutex> lock(_compactionMutex);
   _compactionRequested = false;
   _pendingCompactionGeneration = 0;
 
   if (_compactionUploadInFlight && _pCompactionUploadCommandBuffer) {
-    _pCompactionUploadCommandBuffer->waitUntilCompleted();
+    waitCommandBuffer = _pCompactionUploadCommandBuffer;
+    waitCommandBuffer->retain();
   }
+
+  lock.unlock();
+
+  if (waitCommandBuffer) {
+    waitCommandBuffer->waitUntilCompleted();
+  }
+
+  lock.lock();
 
   if (_pCompactionUploadCommandBuffer) {
     _pCompactionUploadCommandBuffer->release();
@@ -419,6 +431,10 @@ void Renderer::clearPendingCompaction() {
   if (_compactionFutureValid) {
     _compactionFuture.wait();
     _compactionFutureValid = false;
+  }
+
+  if (waitCommandBuffer) {
+    waitCommandBuffer->release();
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure `Renderer::clearPendingCompaction` mirrors the mutex discipline used by `finalizeCompactionUpload`
- wait for any in-flight command buffer completion outside the compaction mutex and tear down safely afterward

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da944019a0832d810d50e4d428ddaf