### PR TITLE
Add async residency rebuild pipeline

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -15,6 +15,7 @@
 #include <filesystem>
 #include <fstream>
 #include <chrono>
+#include <future>
 #include <numeric>
 #include <simd/simd.h>
 #include <string>
@@ -340,6 +341,7 @@ Renderer::Renderer(MTL::Device *pDevice)
 }
 
 Renderer::~Renderer() {
+  drainResidencyJob();
   if (_pSphereBuffer)
     _pSphereBuffer->release();
   if (_pSphereMaterialBuffer)
@@ -384,6 +386,19 @@ Renderer::~Renderer() {
 
   delete _pScene;
 }
+
+void Renderer::setAsyncResidencyEnabled(bool enabled) {
+  if (_asyncResidencyEnabled == enabled)
+    return;
+  drainResidencyJob();
+  _asyncResidencyEnabled = enabled;
+  printf("Async residency rebuilds %s.\n",
+         _asyncResidencyEnabled ? "enabled" : "disabled");
+  if (!_asyncResidencyEnabled)
+    _telemetryAsyncUsed = false;
+}
+
+bool Renderer::asyncResidencyEnabled() const { return _asyncResidencyEnabled; }
 
 void Renderer::setDeltaTime(double deltaSeconds) {
   if (deltaSeconds < 0.0)
@@ -499,9 +514,15 @@ void Renderer::updateVisibleScene() {
   _objectCooldown.assign(objectCount, 0);
 
   _residentPrimitives.clear();
-  _residentRemap.clear();
+  _liveResidencyBuffers = ResidencyBuffers{};
+  _stagingResidencyBuffers = ResidencyBuffers{};
   _recentlyActivated.clear();
   _recentlyDeactivated.clear();
+  _pendingActivated.clear();
+  _pendingDeactivated.clear();
+  _pendingForceFullRebuild = false;
+  _residencyJobActive = false;
+  _residencyJob = std::future<ResidencyBuffers>();
   _residentBuffersInitialized = false;
   _cachedPrimitiveData.clear();
   _cachedMaterialData.clear();
@@ -645,7 +666,13 @@ void Renderer::recalculateViewport() {
 
 }
 
-void Renderer::rebuildResidentResources(bool forceFullRebuild) {
+Renderer::ResidencyBuffers Renderer::buildResidencyBuffers(
+    bool forceFullRebuild, ResidencyBuffers &&seed,
+    const std::vector<size_t> &recentlyActivated,
+    const std::vector<size_t> &recentlyDeactivated) {
+  ResidencyBuffers buffers = std::move(seed);
+  std::vector<size_t> activated = recentlyActivated;
+  std::vector<size_t> deactivated = recentlyDeactivated;
   size_t totalPrimitiveCount = _allPrimitives.size();
   size_t cachedTotalPrimitiveCount = _cachedTotalPrimitiveCount;
 
@@ -758,14 +785,14 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   };
 
   if (!needFullUpload) {
-    deduplicate(_recentlyActivated);
-    deduplicate(_recentlyDeactivated);
-    if (!_recentlyActivated.empty() && !_recentlyDeactivated.empty()) {
-      for (size_t idx : _recentlyDeactivated) {
-        auto it = std::lower_bound(_recentlyActivated.begin(),
-                                   _recentlyActivated.end(), idx);
-        if (it != _recentlyActivated.end() && *it == idx)
-          _recentlyActivated.erase(it);
+    deduplicate(activated);
+    deduplicate(deactivated);
+    if (!activated.empty() && !deactivated.empty()) {
+      for (size_t idx : deactivated) {
+        auto it =
+            std::lower_bound(activated.begin(), activated.end(), idx);
+        if (it != activated.end() && *it == idx)
+          activated.erase(it);
       }
     }
   }
@@ -1203,58 +1230,150 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     _lightCount = _cachedLightIndices.size();
   }
 
-  _residentRemap = remapUpload;
-
   bool uploadAll = needFullUpload || useCompaction || compactionStateChanged;
   bool allowShrink = useCompaction;
+buffers.residentRemap = std::move(remapUpload);
+  if (primitiveSource == &compactPrimitiveData)
+    buffers.primitiveData = std::move(compactPrimitiveData);
+  else
+    buffers.primitiveData = *primitiveSource;
+  if (materialSource == &compactMaterialData)
+    buffers.materialData = std::move(compactMaterialData);
+  else
+    buffers.materialData = *materialSource;
+  if (primitiveIndexSource == &compactPrimitiveIndices)
+    buffers.primitiveIndices = std::move(compactPrimitiveIndices);
+  else
+    buffers.primitiveIndices = *primitiveIndexSource;
+  if (bvhSource == &compactBVHNodes)
+    buffers.blasNodes = std::move(compactBVHNodes);
+  else
+    buffers.blasNodes = *bvhSource;
+  if (tlasSource == &_cachedTLASNodes)
+    buffers.tlasNodes = _cachedTLASNodes;
+  else
+    buffers.tlasNodes = *tlasSource;
+  if (triangleVertexSource == &compactTriangleVertices)
+    buffers.triangleVertices = std::move(compactTriangleVertices);
+  else
+    buffers.triangleVertices = *triangleVertexSource;
+  if (triangleIndexSource == &compactTriangleIndices)
+    buffers.triangleIndices = std::move(compactTriangleIndices);
+  else
+    buffers.triangleIndices = *triangleIndexSource;
+  if (useCompaction)
+    buffers.activeMask = std::move(compactActiveMask);
+  else
+    buffers.activeMask = _cpuActiveMask;
+  buffers.lightIndices = _cachedLightIndices;
+  buffers.lightCdf = _cachedLightCdf;
+  buffers.instanceRecords = _instanceRecords;
+  buffers.totalPrimitiveCount = totalPrimitiveCount;
+  buffers.residentPrimitiveCount = _residentPrimitiveCount;
+  buffers.residentTriangleCount = _residentTriangleCount;
+  buffers.blasNodeCount = _blasNodeCount;
+  buffers.tlasNodeCount = _tlasNodeCount;
+  buffers.activePrimitiveCount = _activePrimitiveCount;
+  buffers.activeTriangleCount = _activeTriangleCount;
+  buffers.lightCount = _lightCount;
+  buffers.lightTotalWeight = _lightTotalWeight;
+  buffers.residentCompacted = _residentCompacted;
+  buffers.residentBuffersInitialized = _residentBuffersInitialized;
+  buffers.needFullUpload = needFullUpload;
+  buffers.uploadAll = uploadAll;
+  buffers.allowShrink = allowShrink;
+  buffers.compactionStateChanged = compactionStateChanged;
+  buffers.useCompaction = useCompaction;
+  buffers.activeNodeCount = _activeNodeCount;
+  buffers.recentlyActivated = std::move(activated);
+  buffers.recentlyDeactivated = std::move(deactivated);
+  return buffers;
+}
+
+void Renderer::applyResidencyBuffers(const ResidencyBuffers &buffers) {
+  const size_t uniformsDataSize = sizeof(UniformsData);
+  if (!_pUniformsBuffer) {
+    _pUniformsBuffer =
+        _pDevice->newBuffer(uniformsDataSize, MTL::ResourceStorageModeManaged);
+    if (_pUniformsBuffer)
+      _pUniformsBuffer->didModifyRange(
+          NS::Range::Make(0, uniformsDataSize));
+  }
+
+  _liveResidencyBuffers = buffers;
+
+  _residentPrimitiveCount = buffers.residentPrimitiveCount;
+  _residentTriangleCount = buffers.residentTriangleCount;
+  _blasNodeCount = buffers.blasNodeCount;
+  _tlasNodeCount = buffers.tlasNodeCount;
+  _activePrimitiveCount = buffers.activePrimitiveCount;
+  _activeTriangleCount = buffers.activeTriangleCount;
+  _lightCount = buffers.lightCount;
+  _lightTotalWeight = buffers.lightTotalWeight;
+  _residentCompacted = buffers.residentCompacted;
+  _residentBuffersInitialized =
+      _residentBuffersInitialized || buffers.residentBuffersInitialized ||
+      buffers.uploadAll;
+
+  const bool uploadAll = buffers.uploadAll;
+  const bool allowShrink = buffers.allowShrink;
+  const bool useCompaction = buffers.useCompaction;
+
+  const auto &primitiveSource = _liveResidencyBuffers.primitiveData;
+  const auto &materialSource = _liveResidencyBuffers.materialData;
+  const auto &primitiveIndexSource = _liveResidencyBuffers.primitiveIndices;
+  const auto &bvhSource = _liveResidencyBuffers.blasNodes;
+  const auto &tlasSource = _liveResidencyBuffers.tlasNodes;
+  const auto &triangleVertexSource =
+      _liveResidencyBuffers.triangleVertices;
+  const auto &triangleIndexSource = _liveResidencyBuffers.triangleIndices;
+  const auto &residentRemap = _liveResidencyBuffers.residentRemap;
 
   if (uploadAll) {
-    size_t primitiveFloat4Count = primitiveSource->size();
+    size_t primitiveFloat4Count = primitiveSource.size();
     size_t primitiveBytes =
         std::max<size_t>(primitiveFloat4Count, size_t(1)) *
         sizeof(simd::float4);
     ensureBufferCapacity(_pSphereBuffer, primitiveBytes, _sphereBufferCapacity,
                          allowShrink);
     if (_pSphereBuffer) {
-      simd::float4 *dst =
+      auto *dst =
           static_cast<simd::float4 *>(_pSphereBuffer->contents());
       if (primitiveFloat4Count > 0)
-        std::memcpy(dst, primitiveSource->data(),
+        std::memcpy(dst, primitiveSource.data(),
                     primitiveFloat4Count * sizeof(simd::float4));
       else
         dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
       _pSphereBuffer->didModifyRange(NS::Range::Make(0, primitiveBytes));
     }
 
-    size_t materialFloat4Count = materialSource->size();
+    size_t materialFloat4Count = materialSource.size();
     size_t materialBytes =
         std::max<size_t>(materialFloat4Count, size_t(1)) *
         sizeof(simd::float4);
     ensureBufferCapacity(_pSphereMaterialBuffer, materialBytes,
                          _sphereMaterialBufferCapacity, allowShrink);
     if (_pSphereMaterialBuffer) {
-      simd::float4 *dst = static_cast<simd::float4 *>(
+      auto *dst = static_cast<simd::float4 *>(
           _pSphereMaterialBuffer->contents());
       if (materialFloat4Count > 0)
-        std::memcpy(dst, materialSource->data(),
+        std::memcpy(dst, materialSource.data(),
                     materialFloat4Count * sizeof(simd::float4));
-      else {
+      else
         dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-        if (materialBytes >= 2 * sizeof(simd::float4))
-          dst[1] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-      }
-      _pSphereMaterialBuffer->didModifyRange(NS::Range::Make(0, materialBytes));
+      _pSphereMaterialBuffer->didModifyRange(
+          NS::Range::Make(0, materialBytes));
     }
 
-    size_t primitiveIndexCount = primitiveIndexSource->size();
+    size_t primitiveIndexCount = primitiveIndexSource.size();
     size_t primitiveIndexBytes =
         std::max<size_t>(primitiveIndexCount, size_t(1)) * sizeof(int);
     ensureBufferCapacity(_pPrimitiveIndexBuffer, primitiveIndexBytes,
                          _primitiveIndexBufferCapacity, allowShrink);
     if (_pPrimitiveIndexBuffer) {
-      int *dst = static_cast<int *>(_pPrimitiveIndexBuffer->contents());
+      auto *dst = static_cast<int *>(_pPrimitiveIndexBuffer->contents());
       if (primitiveIndexCount > 0)
-        std::memcpy(dst, primitiveIndexSource->data(),
+        std::memcpy(dst, primitiveIndexSource.data(),
                     primitiveIndexCount * sizeof(int));
       else
         dst[0] = 0;
@@ -1262,97 +1381,94 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
           NS::Range::Make(0, primitiveIndexBytes));
     }
 
-    size_t blasFloat4Count = bvhSource->size();
+    size_t bvhFloat4Count = bvhSource.size();
     size_t bvhBytes =
-        std::max<size_t>(blasFloat4Count, size_t(1)) * sizeof(simd::float4);
+        std::max<size_t>(bvhFloat4Count, size_t(1)) * sizeof(simd::float4);
     ensureBufferCapacity(_pBVHBuffer, bvhBytes, _bvhBufferCapacity, allowShrink);
     if (_pBVHBuffer) {
-      simd::float4 *dst =
+      auto *dst =
           static_cast<simd::float4 *>(_pBVHBuffer->contents());
-      if (blasFloat4Count > 0)
-        std::memcpy(dst, bvhSource->data(),
-                    blasFloat4Count * sizeof(simd::float4));
+      if (bvhFloat4Count > 0)
+        std::memcpy(dst, bvhSource.data(),
+                    bvhFloat4Count * sizeof(simd::float4));
       else {
         dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-        if (bvhBytes >= 2 * sizeof(simd::float4))
-          dst[1] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+        dst[1] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
       }
       _pBVHBuffer->didModifyRange(NS::Range::Make(0, bvhBytes));
     }
 
-    size_t tlasFloat4Count = tlasSource->size();
+    size_t tlasFloat4Count = tlasSource.size();
     size_t tlasBytes =
         std::max<size_t>(tlasFloat4Count, size_t(1)) * sizeof(simd::float4);
     ensureBufferCapacity(_pTLASBuffer, tlasBytes, _tlasBufferCapacity,
                          allowShrink);
     if (_pTLASBuffer) {
-      simd::float4 *dst =
+      auto *dst =
           static_cast<simd::float4 *>(_pTLASBuffer->contents());
       if (tlasFloat4Count > 0)
-        std::memcpy(dst, tlasSource->data(),
+        std::memcpy(dst, tlasSource.data(),
                     tlasFloat4Count * sizeof(simd::float4));
       else {
         dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-        if (tlasBytes >= 2 * sizeof(simd::float4))
-          dst[1] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+        dst[1] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
       }
       _pTLASBuffer->didModifyRange(NS::Range::Make(0, tlasBytes));
     }
 
-    size_t remapCount = std::max<size_t>(_residentRemap.size(), size_t(1));
-    ensureBufferCapacity(_pPrimitiveRemapBuffer,
-                         remapCount * sizeof(uint32_t),
-                         _primitiveRemapBufferCapacity, allowShrink);
-    if (_pPrimitiveRemapBuffer) {
-      uint32_t *dst = static_cast<uint32_t *>(
-          _pPrimitiveRemapBuffer->contents());
-      if (_residentRemap.empty()) {
-        dst[0] = 0;
-      } else {
-        std::memcpy(dst, _residentRemap.data(),
-                    _residentRemap.size() * sizeof(uint32_t));
-        if (_residentRemap.size() < remapCount)
-          dst[_residentRemap.size()] = 0;
-      }
-      _pPrimitiveRemapBuffer->didModifyRange(
-          NS::Range::Make(0, remapCount * sizeof(uint32_t)));
-    }
-
-    size_t vertexCount = triangleVertexSource->size();
+    size_t vertexCount = triangleVertexSource.size();
     size_t vertexBytes =
         std::max<size_t>(vertexCount, size_t(1)) * sizeof(simd::float3);
     ensureBufferCapacity(_pTriangleVertexBuffer, vertexBytes,
                          _triangleVertexBufferCapacity, allowShrink);
     if (_pTriangleVertexBuffer) {
-      simd::float3 *dst = static_cast<simd::float3 *>(
+      auto *dst = static_cast<simd::float3 *>(
           _pTriangleVertexBuffer->contents());
       if (vertexCount > 0)
-        std::memcpy(dst, triangleVertexSource->data(),
+        std::memcpy(dst, triangleVertexSource.data(),
                     vertexCount * sizeof(simd::float3));
       else
         dst[0] = simd::float3{0.0f, 0.0f, 0.0f};
       _pTriangleVertexBuffer->didModifyRange(NS::Range::Make(0, vertexBytes));
     }
 
-    size_t indexCount = triangleIndexSource->size();
+    size_t indexCount = triangleIndexSource.size();
     size_t indexBytes =
         std::max<size_t>(indexCount, size_t(1)) * sizeof(simd::uint3);
     ensureBufferCapacity(_pTriangleIndexBuffer, indexBytes,
                          _triangleIndexBufferCapacity, allowShrink);
     if (_pTriangleIndexBuffer) {
-      simd::uint3 *dst = static_cast<simd::uint3 *>(
+      auto *dst = static_cast<simd::uint3 *>(
           _pTriangleIndexBuffer->contents());
       if (indexCount > 0)
-        std::memcpy(dst, triangleIndexSource->data(),
+        std::memcpy(dst, triangleIndexSource.data(),
                     indexCount * sizeof(simd::uint3));
       else
         dst[0] = simd::make_uint3(0, 0, 0);
       _pTriangleIndexBuffer->didModifyRange(NS::Range::Make(0, indexBytes));
     }
-
-    _residentBuffersInitialized = true;
   }
 
+  size_t remapCount = std::max<size_t>(residentRemap.size(), size_t(1));
+  ensureBufferCapacity(_pPrimitiveRemapBuffer,
+                       remapCount * sizeof(uint32_t),
+                       _primitiveRemapBufferCapacity, allowShrink);
+  if (_pPrimitiveRemapBuffer) {
+    auto *dst = static_cast<uint32_t *>(
+        _pPrimitiveRemapBuffer->contents());
+    if (residentRemap.empty()) {
+      dst[0] = 0;
+    } else {
+      std::memcpy(dst, residentRemap.data(),
+                  residentRemap.size() * sizeof(uint32_t));
+      if (residentRemap.size() < remapCount)
+        dst[residentRemap.size()] = 0;
+    }
+    _pPrimitiveRemapBuffer->didModifyRange(
+        NS::Range::Make(0, remapCount * sizeof(uint32_t)));
+  }
+
+  _instanceRecords = buffers.instanceRecords;
   size_t instanceCount = std::max<size_t>(_instanceRecords.size(), size_t(1));
   size_t instanceBytes = instanceCount * sizeof(BlasInstanceRecord);
   ensureBufferCapacity(_pInstanceBuffer, instanceBytes, _instanceBufferCapacity,
@@ -1372,33 +1488,33 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   }
 
   size_t activeMaskCount =
-      useCompaction ? _residentPrimitiveCount : totalPrimitiveCount;
+      useCompaction ? _residentPrimitiveCount : buffers.totalPrimitiveCount;
   size_t activeBytes =
       std::max<size_t>(activeMaskCount, size_t(1)) * sizeof(uint8_t);
   ensureBufferCapacity(_pActiveBuffer, activeBytes, _activeBufferCapacity,
                        allowShrink);
   if (_pActiveBuffer) {
-    uint8_t *activePtr =
+    auto *activePtr =
         static_cast<uint8_t *>(_pActiveBuffer->contents());
     if (useCompaction) {
       if (_residentPrimitiveCount > 0) {
-        std::memcpy(activePtr, compactActiveMask.data(),
+        std::memcpy(activePtr, buffers.activeMask.data(),
                     _residentPrimitiveCount * sizeof(uint8_t));
       } else {
         activePtr[0] = 0;
       }
       _pActiveBuffer->didModifyRange(NS::Range::Make(0, activeBytes));
     } else if (uploadAll) {
-      if (totalPrimitiveCount > 0)
+      if (buffers.totalPrimitiveCount > 0)
         std::memcpy(activePtr, _cpuActiveMask.data(),
-                    totalPrimitiveCount * sizeof(uint8_t));
+                    buffers.totalPrimitiveCount * sizeof(uint8_t));
       else
         activePtr[0] = 0;
       _pActiveBuffer->didModifyRange(NS::Range::Make(0, activeBytes));
     } else {
       auto updateMask = [&](const std::vector<size_t> &indices) {
         for (size_t idx : indices) {
-          if (idx >= totalPrimitiveCount)
+          if (idx >= buffers.totalPrimitiveCount)
             continue;
           bool active = idx < _activePrimitive.size() && _activePrimitive[idx];
           uint8_t value = active ? 1 : 0;
@@ -1407,10 +1523,13 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
           _pActiveBuffer->didModifyRange(NS::Range::Make(idx, 1));
         }
       };
-      updateMask(_recentlyActivated);
-      updateMask(_recentlyDeactivated);
+      updateMask(buffers.recentlyActivated);
+      updateMask(buffers.recentlyDeactivated);
     }
   }
+
+  _cachedLightIndices = buffers.lightIndices;
+  _cachedLightCdf = buffers.lightCdf;
 
   size_t lightIndexBytes =
       std::max<size_t>(_cachedLightIndices.size(), size_t(1)) *
@@ -1418,7 +1537,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   ensureBufferCapacity(_pLightIndexBuffer, lightIndexBytes,
                        _lightIndexBufferCapacity, allowShrink);
   if (_pLightIndexBuffer) {
-    uint32_t *dst = static_cast<uint32_t *>(_pLightIndexBuffer->contents());
+    auto *dst = static_cast<uint32_t *>(_pLightIndexBuffer->contents());
     if (_cachedLightIndices.empty())
       dst[0] = 0;
     else
@@ -1432,7 +1551,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   ensureBufferCapacity(_pLightCdfBuffer, lightCdfBytes, _lightCdfBufferCapacity,
                        allowShrink);
   if (_pLightCdfBuffer) {
-    float *dst = static_cast<float *>(_pLightCdfBuffer->contents());
+    auto *dst = static_cast<float *>(_pLightCdfBuffer->contents());
     if (_cachedLightCdf.empty())
       dst[0] = 0.0f;
     else
@@ -1442,24 +1561,114 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   }
 
   _residentNodeCount = _blasNodeCount + _tlasNodeCount;
-  size_t activeBlasNodes = 0;
-  size_t activeTlasNodes = 0;
-  if (useCompaction) {
-    activeBlasNodes = _blasNodeCount;
-    activeTlasNodes = (_residentPrimitiveCount > 0) ? _tlasNodeCount : 0;
-  } else if (totalPrimitiveCount > 0 && _blasNodeCount > 0) {
-    size_t denom = std::max<size_t>(totalPrimitiveCount, size_t(1));
-    activeBlasNodes = std::max<size_t>(
-        size_t(1), (_blasNodeCount * _activePrimitiveCount + denom - 1) /
-                        denom);
-    activeTlasNodes = (_tlasNodeCount > 0 && _activePrimitiveCount > 0)
-                          ? _tlasNodeCount
-                          : size_t(0);
-  }
-  _activeNodeCount = activeBlasNodes + activeTlasNodes;
+  _activeNodeCount = buffers.activeNodeCount;
 
-  _recentlyActivated.clear();
-  _recentlyDeactivated.clear();
+  if (_asyncResidencyEnabled && !_telemetryAsyncUsed) {
+    printf("Async residency rebuilds enabled (double-buffered).\n");
+    _telemetryAsyncUsed = true;
+  }
+}
+
+void Renderer::scheduleResidencyJob(bool forceFullRebuild) {
+  std::vector<size_t> jobActivated;
+  std::vector<size_t> jobDeactivated;
+  bool jobForce = forceFullRebuild;
+  bool launchJob = false;
+
+  {
+    std::lock_guard<std::mutex> lock(_residencyToggleMutex);
+    if (forceFullRebuild)
+      _pendingForceFullRebuild = true;
+
+    if (!_recentlyActivated.empty()) {
+      _pendingActivated.insert(_pendingActivated.end(),
+                               _recentlyActivated.begin(),
+                               _recentlyActivated.end());
+      _recentlyActivated.clear();
+    }
+    if (!_recentlyDeactivated.empty()) {
+      _pendingDeactivated.insert(_pendingDeactivated.end(),
+                                 _recentlyDeactivated.begin(),
+                                 _recentlyDeactivated.end());
+      _recentlyDeactivated.clear();
+    }
+
+    if (!_asyncResidencyEnabled) {
+      if (!_pendingActivated.empty() || !_pendingDeactivated.empty() ||
+          _pendingForceFullRebuild) {
+        jobActivated = std::move(_pendingActivated);
+        jobDeactivated = std::move(_pendingDeactivated);
+        jobForce = _pendingForceFullRebuild;
+        _pendingForceFullRebuild = false;
+        launchJob = true;
+      }
+    } else if (!_residencyJobActive) {
+      if (_pendingForceFullRebuild || !_pendingActivated.empty() ||
+          !_pendingDeactivated.empty()) {
+        jobActivated = std::move(_pendingActivated);
+        jobDeactivated = std::move(_pendingDeactivated);
+        jobForce = _pendingForceFullRebuild;
+        _pendingForceFullRebuild = false;
+        _residencyJobActive = true;
+        launchJob = true;
+      }
+    }
+  }
+
+  if (!launchJob)
+    return;
+
+  if (!_asyncResidencyEnabled) {
+    ResidencyBuffers result;
+    {
+      std::lock_guard<std::mutex> lock(_residencyToggleMutex);
+      result = buildResidencyBuffers(jobForce, std::move(_stagingResidencyBuffers),
+                                     jobActivated, jobDeactivated);
+    }
+    applyResidencyBuffers(result);
+    _stagingResidencyBuffers = std::move(result);
+    return;
+  }
+
+  ResidencyBuffers seed = std::move(_stagingResidencyBuffers);
+  _residencyJob = std::async(std::launch::async,
+                             [this, jobForce, act = std::move(jobActivated),
+                              deact = std::move(jobDeactivated),
+                              seed = std::move(seed)]() mutable {
+                               std::lock_guard<std::mutex> lock(
+                                   _residencyToggleMutex);
+                               return buildResidencyBuffers(jobForce,
+                                                            std::move(seed), act,
+                                                            deact);
+                             });
+}
+
+void Renderer::drainResidencyJob() {
+  if (!_residencyJobActive)
+    return;
+  ResidencyBuffers buffers = _residencyJob.get();
+  _residencyJobActive = false;
+  _stagingResidencyBuffers = std::move(buffers);
+  applyResidencyBuffers(_stagingResidencyBuffers);
+}
+
+void Renderer::rebuildResidentResources(bool forceFullRebuild) {
+  scheduleResidencyJob(forceFullRebuild);
+
+  if (_asyncResidencyEnabled) {
+    if (_residencyJobActive) {
+      if (_residencyJob.wait_for(std::chrono::milliseconds(0)) ==
+          std::future_status::ready) {
+        ResidencyBuffers buffers = _residencyJob.get();
+        _residencyJobActive = false;
+        _stagingResidencyBuffers = std::move(buffers);
+        applyResidencyBuffers(_stagingResidencyBuffers);
+        scheduleResidencyJob(false);
+      }
+    }
+  } else {
+    drainResidencyJob();
+  }
 }
 
 
@@ -2051,11 +2260,14 @@ bool Renderer::updateScreenSpaceFootprint(bool forceAllToggles) {
 }
 
 void Renderer::flushResidencyChanges(bool forceFullRebuild) {
-  if (!forceFullRebuild && _recentlyActivated.empty() &&
-      _recentlyDeactivated.empty()) {
-    // No state changes to apply this frame.
+  bool hasImmediateChanges =
+      forceFullRebuild || !_recentlyActivated.empty() ||
+      !_recentlyDeactivated.empty();
+  bool jobInFlight = _residencyJobActive;
+  bool queuedChanges = _pendingForceFullRebuild || !_pendingActivated.empty() ||
+                       !_pendingDeactivated.empty();
+  if (!hasImmediateChanges && !jobInFlight && !queuedChanges)
     return;
-  }
   rebuildResidentResources(forceFullRebuild);
 }
 
@@ -2075,6 +2287,9 @@ bool Renderer::hasKeyframes() const { return !_pScene->cameraPath.empty(); }
 bool Renderer::setPrimitiveActive(size_t index, bool active) {
   if (index >= _activePrimitive.size())
     return false;
+
+  std::lock_guard<std::mutex> lock(_residencyToggleMutex);
+
   if (_activePrimitive[index] == active)
     return false;
   _activePrimitive[index] = active;

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -5,6 +5,9 @@
 #include <MetalKit/MetalKit.hpp>
 #include <chrono>
 #include <cstdint>
+#include <future>
+#include <mutex>
+#include <optional>
 #include <simd/simd.h>
 #include <vector>
 
@@ -57,6 +60,9 @@ public:
         spheres; // (transform, material)
     simd::int3 chunkCoords;
   };
+
+  void setAsyncResidencyEnabled(bool enabled);
+  bool asyncResidencyEnabled() const;
 
 private:
   void rebuildResidentResources(bool forceFullRebuild);
@@ -133,9 +139,50 @@ private:
 
   std::vector<BlasInstanceRecord> _instanceRecords;
   std::vector<Primitive> _residentPrimitives;
-  std::vector<uint32_t> _residentRemap;
+  struct ResidencyBuffers {
+    std::vector<uint32_t> residentRemap;
+    std::vector<simd::float4> primitiveData;
+    std::vector<simd::float4> materialData;
+    std::vector<int> primitiveIndices;
+    std::vector<simd::float4> blasNodes;
+    std::vector<simd::float4> tlasNodes;
+    std::vector<simd::float3> triangleVertices;
+    std::vector<simd::uint3> triangleIndices;
+    std::vector<uint8_t> activeMask;
+    std::vector<uint32_t> lightIndices;
+    std::vector<float> lightCdf;
+    std::vector<BlasInstanceRecord> instanceRecords;
+    std::vector<size_t> recentlyActivated;
+    std::vector<size_t> recentlyDeactivated;
+
+    size_t totalPrimitiveCount = 0;
+    size_t residentPrimitiveCount = 0;
+    size_t residentTriangleCount = 0;
+    size_t blasNodeCount = 0;
+    size_t tlasNodeCount = 0;
+    size_t activePrimitiveCount = 0;
+    size_t activeTriangleCount = 0;
+    size_t lightCount = 0;
+    size_t activeNodeCount = 0;
+    float lightTotalWeight = 0.0f;
+
+    bool residentCompacted = false;
+    bool residentBuffersInitialized = false;
+    bool needFullUpload = false;
+    bool uploadAll = false;
+    bool allowShrink = false;
+    bool compactionStateChanged = false;
+    bool useCompaction = false;
+  };
+
+  ResidencyBuffers _liveResidencyBuffers;
+  ResidencyBuffers _stagingResidencyBuffers;
   std::vector<size_t> _recentlyActivated;
   std::vector<size_t> _recentlyDeactivated;
+  std::vector<size_t> _pendingActivated;
+  std::vector<size_t> _pendingDeactivated;
+  bool _pendingForceFullRebuild = false;
+  std::mutex _residencyToggleMutex;
 
   uint32_t _rayHitRebuildCooldown = 0;
 
@@ -195,6 +242,19 @@ private:
   ResidencyParameters _residencyConfig;
 
   size_t setObjectActive(size_t objectIndex, bool active);
+
+  ResidencyBuffers buildResidencyBuffers(
+      bool forceFullRebuild, ResidencyBuffers &&seed,
+      const std::vector<size_t> &recentlyActivated,
+      const std::vector<size_t> &recentlyDeactivated);
+  void applyResidencyBuffers(const ResidencyBuffers &buffers);
+  void scheduleResidencyJob(bool forceFullRebuild);
+  void drainResidencyJob();
+
+  std::future<ResidencyBuffers> _residencyJob;
+  bool _asyncResidencyEnabled = true;
+  bool _residencyJobActive = false;
+  bool _telemetryAsyncUsed = false;
 };
 
 } // namespace MetalCppPathTracer


### PR DESCRIPTION
## Summary
- refactor residency rebuilds to run inside a background job that populates staging buffers before swapping to the live GPU buffers
- double-buffer residency data, add mutex-protected toggle queues, and expose controls/telemetry for enabling or disabling async rebuilds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da9e41dbb4832dbb614041f19a5920