### PR TITLE
Adjust LOD toggle budget to be per-object

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1707,13 +1707,14 @@ bool Renderer::updateLODByDistance(bool forceAllToggles) {
     if (togglesNeeded == 0)
       continue;
 
+    size_t toggleCost = forceAllToggles ? togglesNeeded : size_t(1);
     if (!forceAllToggles &&
-        toggles + togglesNeeded > _residencyConfig.lodMaxTogglesPerFrame)
+        toggles + toggleCost > _residencyConfig.lodMaxTogglesPerFrame)
       continue;
 
     size_t toggled = setObjectActive(objectIndex, shouldBeActive);
     if (toggled > 0) {
-      toggles += toggled;
+      toggles += toggleCost;
       changed = true;
     }
   }


### PR DESCRIPTION
## Summary
- adjust the LOD toggle budget to charge once per object so large meshes can enter range
- update the per-frame toggle accumulation to use the per-object cost

## Testing
- not run (environment not configured for renderer)


------
https://chatgpt.com/codex/tasks/task_e_68daad0d2c0c832dae3dec61d8959962