### PR TITLE
Guard BVH traversal against invalid children

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -169,6 +169,8 @@ inline intersection firstHitBVH(thread const ray &r,
 
     if (second > 0) {
       int count = second;
+      if (count <= 0 || leftFirst < 0)
+        continue;
       for (int i = 0; i < count; ++i) {
         int primIdx = primitiveIndices[leftFirst + i];
         if (!activeMask[primIdx])
@@ -265,8 +267,16 @@ inline intersection firstHitBVH(thread const ray &r,
       }
     } else {
       int rightChild = -second;
-      stack[stackPtr++] = leftFirst;
-      stack[stackPtr++] = rightChild;
+      bool leftValid = leftFirst >= 0;
+      bool rightValid = rightChild >= 0;
+
+      if (!leftValid && !rightValid)
+        continue;
+
+      if (leftValid && stackPtr < stackSize)
+        stack[stackPtr++] = leftFirst;
+      if (rightValid && stackPtr < stackSize)
+        stack[stackPtr++] = rightChild;
     }
   }
 


### PR DESCRIPTION
## Summary
- skip BVH nodes that do not expose valid primitive ranges before traversal
- validate child indices before pushing them and guard the traversal stack against overflow

## Testing
- xcodebuild -project 'MetalCpp Path Tracer.xcodeproj' -scheme MetalCpp Path Tracer build *(fails: xcodebuild not available in container)*
- scene_residency_screenspace *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daebe3fe0c832d99e431c8a8931cb2