### PR TITLE
Implement configurable mesh partitioning during scene load

### DIFF
--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -12,6 +12,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <limits>
 #include "tiny_obj_loader.h"
 
 using namespace tinyxml2;
@@ -25,6 +26,134 @@ static simd::float3 parseVec3(const char* str) {
 }
 
 namespace {
+
+static float AxisValue(const simd::float3& v, int axis) {
+    switch (axis) {
+        case 0: return v.x;
+        case 1: return v.y;
+        default: return v.z;
+    }
+}
+
+static void ComputeBounds(const std::vector<Primitive>& prims, size_t start,
+                          size_t end, simd::float3& outMin,
+                          simd::float3& outMax) {
+    const float maxFloat = std::numeric_limits<float>::max();
+    const float minFloat = -std::numeric_limits<float>::max();
+    simd::float3 bmin = simd::make_float3(maxFloat, maxFloat, maxFloat);
+    simd::float3 bmax = simd::make_float3(minFloat, minFloat, minFloat);
+
+    for (size_t i = start; i < end; ++i) {
+        const Primitive& p = prims[i];
+        const auto& tri = p.triangle;
+
+        bmin.x = std::min(bmin.x, tri.v0.x);
+        bmin.y = std::min(bmin.y, tri.v0.y);
+        bmin.z = std::min(bmin.z, tri.v0.z);
+        bmax.x = std::max(bmax.x, tri.v0.x);
+        bmax.y = std::max(bmax.y, tri.v0.y);
+        bmax.z = std::max(bmax.z, tri.v0.z);
+
+        bmin.x = std::min(bmin.x, tri.v1.x);
+        bmin.y = std::min(bmin.y, tri.v1.y);
+        bmin.z = std::min(bmin.z, tri.v1.z);
+        bmax.x = std::max(bmax.x, tri.v1.x);
+        bmax.y = std::max(bmax.y, tri.v1.y);
+        bmax.z = std::max(bmax.z, tri.v1.z);
+
+        bmin.x = std::min(bmin.x, tri.v2.x);
+        bmin.y = std::min(bmin.y, tri.v2.y);
+        bmin.z = std::min(bmin.z, tri.v2.z);
+        bmax.x = std::max(bmax.x, tri.v2.x);
+        bmax.y = std::max(bmax.y, tri.v2.y);
+        bmax.z = std::max(bmax.z, tri.v2.z);
+    }
+
+    outMin = bmin;
+    outMax = bmax;
+}
+
+static float PrimitiveCentroidAxis(const Primitive& prim, int axis) {
+    const auto& tri = prim.triangle;
+    float c0 = AxisValue(tri.v0, axis);
+    float c1 = AxisValue(tri.v1, axis);
+    float c2 = AxisValue(tri.v2, axis);
+    return (c0 + c1 + c2) / 3.0f;
+}
+
+static void PartitionTrianglesRecursive(std::vector<Primitive>& prims,
+                                        size_t start, size_t end,
+                                        size_t maxTriangles, float maxExtent,
+                                        std::vector<std::pair<size_t, size_t>>&
+                                            partitions) {
+    size_t count = end - start;
+    if (count == 0) {
+        return;
+    }
+
+    simd::float3 bmin, bmax;
+    ComputeBounds(prims, start, end, bmin, bmax);
+    simd::float3 extents = bmax - bmin;
+
+    float longest = extents.x;
+    int axis = 0;
+    if (extents.y > longest) {
+        longest = extents.y;
+        axis = 1;
+    }
+    if (extents.z > longest) {
+        longest = extents.z;
+        axis = 2;
+    }
+
+    bool withinTriangleBudget = (maxTriangles == 0 || count <= maxTriangles);
+    bool withinExtentBudget = (maxExtent <= 0.0f || longest <= maxExtent);
+
+    if ((withinTriangleBudget && withinExtentBudget) || count <= 1) {
+        partitions.emplace_back(start, end);
+        return;
+    }
+
+    size_t mid = start + count / 2;
+    if (mid == start || mid == end) {
+        partitions.emplace_back(start, end);
+        return;
+    }
+
+    std::nth_element(
+        prims.begin() + start, prims.begin() + mid, prims.begin() + end,
+        [axis](const Primitive& a, const Primitive& b) {
+            return PrimitiveCentroidAxis(a, axis) <
+                   PrimitiveCentroidAxis(b, axis);
+        });
+
+    PartitionTrianglesRecursive(prims, start, mid, maxTriangles, maxExtent,
+                                partitions);
+    PartitionTrianglesRecursive(prims, mid, end, maxTriangles, maxExtent,
+                                partitions);
+}
+
+static void EmitMeshPartitions(Scene* scene, std::vector<Primitive>& prims,
+                               size_t maxTriangles, float maxExtent) {
+    if (prims.empty()) {
+        return;
+    }
+
+    if ((maxTriangles == 0 && maxExtent <= 0.0f) || prims.size() <= 1) {
+        scene->addObject(prims);
+        return;
+    }
+
+    std::vector<std::pair<size_t, size_t>> partitions;
+    PartitionTrianglesRecursive(prims, 0, prims.size(), maxTriangles,
+                                maxExtent, partitions);
+
+    for (const auto& range : partitions) {
+        std::vector<Primitive> chunk(prims.begin() + range.first,
+                                     prims.begin() + range.second);
+        scene->addObject(chunk);
+    }
+}
 
 // Stores previously loaded mesh vertex/index buffers keyed by resolved file
 // path so repeated references to the same mesh can reuse geometry data within a
@@ -247,6 +376,11 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             m.materialType = e->FloatAttribute("materialType", 0);
             m.emissionPower = e->FloatAttribute("emissionPower", 0);
 
+            size_t clusterMaxTriangles = static_cast<size_t>(
+                e->Unsigned64Attribute("clusterMaxTriangles", 0));
+            float clusterMaxExtent =
+                e->FloatAttribute("clusterMaxExtent", 0.0f);
+
             std::vector<Primitive> meshPrimitives;
             meshPrimitives.reserve(meshData.indices.size());
             for (const auto& tri : meshData.indices) {
@@ -258,7 +392,8 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
                 p.material = m;
                 meshPrimitives.push_back(p);
             }
-            scene->addObject(meshPrimitives);
+            EmitMeshPartitions(scene, meshPrimitives, clusterMaxTriangles,
+                               clusterMaxExtent);
         }
         else if (tag == "CameraPath") {
             for (auto* kf = e->FirstChildElement("Keyframe"); kf; kf = kf->NextSiblingElement("Keyframe")) {

--- a/MetalCpp Path Tracer/scene.xml
+++ b/MetalCpp Path Tracer/scene.xml
@@ -22,7 +22,7 @@
     <Rectangle position="15,10,-120" u="10,0,0" v="0,10,0" albedo="1.0,1.0,1.0" emission="0,0,0" materialType="-1" emissionPower="0" />
 
     <!-- Bunny Mesh beside the mirror -->
-    <Mesh
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40"
         file="assets/bunny.obj"
         position="15,0,-100"
         scale="10.0"

--- a/MetalCpp Path Tracer/scene_active_nodes.xml
+++ b/MetalCpp Path Tracer/scene_active_nodes.xml
@@ -10,10 +10,10 @@
     <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
 
     <!-- Cluster A of mesh primitives -->
-    <Mesh file="assets/bunny.obj" position="0,0,0" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="30,0,0" scale="10.0" albedo="0.3,0.5,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="0,0,0" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="30,0,0" scale="10.0" albedo="0.3,0.5,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
 
     <!-- Cluster B of mesh primitives far away -->
-    <Mesh file="assets/bunny.obj" position="300,0,0" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="330,0,0" scale="10.0" albedo="0.3,0.9,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="300,0,0" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="330,0,0" scale="10.0" albedo="0.3,0.9,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
 </Scene>

--- a/MetalCpp Path Tracer/scene_lod_clusters.xml
+++ b/MetalCpp Path Tracer/scene_lod_clusters.xml
@@ -11,11 +11,11 @@
 
     <!-- Cluster A of primitives -->
     <Sphere position="-20,20,0" radius="10" albedo="0.9,0.3,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="0,0,0" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="0,0,0" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
     <Sphere position="20,20,0" radius="10" albedo="0.3,0.3,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
 
     <!-- Cluster B of primitives positioned far away -->
     <Sphere position="280,20,0" radius="10" albedo="0.9,0.3,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="300,0,0" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="300,0,0" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
     <Sphere position="320,20,0" radius="10" albedo="0.3,0.9,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
 </Scene>

--- a/MetalCpp Path Tracer/scene_lod_far.xml
+++ b/MetalCpp Path Tracer/scene_lod_far.xml
@@ -13,7 +13,7 @@
     <Sphere position="0,20,-50" radius="10" albedo="0.8,0.2,0.2" emission="0,0,0" materialType="0" emissionPower="0" />
 
     <!-- Mesh that should load as camera approaches -->
-    <Mesh file="assets/bunny.obj" position="0,0,-200" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="0,0,-200" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
 
     <!-- Distant sphere to remain off until very close -->
     <Sphere position="0,20,-350" radius="10" albedo="0.2,0.2,0.8" emission="0,0,0" materialType="0" emissionPower="0" />

--- a/MetalCpp Path Tracer/scene_lod_linear.xml
+++ b/MetalCpp Path Tracer/scene_lod_linear.xml
@@ -11,7 +11,7 @@
 
     <!-- Row of primitives to trigger LOD on/off as the camera moves -->
     <Sphere position="0,20,-50" radius="10" albedo="0.8,0.2,0.2" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="0,0,-150" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="0,0,-150" scale="10.0" albedo="0.9,0.5,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
     <Sphere position="0,20,-250" radius="10" albedo="0.2,0.2,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="0,0,-350" scale="10.0" albedo="0.3,0.5,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="0,0,-350" scale="10.0" albedo="0.3,0.5,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
 </Scene>

--- a/MetalCpp Path Tracer/scene_lod_massive_drop.xml
+++ b/MetalCpp Path Tracer/scene_lod_massive_drop.xml
@@ -14,134 +14,134 @@
     <Sphere position="0,-10000,0" radius="10000" albedo="0.8,0.8,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
 
     <!-- Dense cluster A of 64 high-vertex meshes -->
-    <Mesh file="assets/bunny.obj" position="-87.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-87.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-87.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-87.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-87.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-87.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-87.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-87.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-62.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-62.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-62.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-62.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-62.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-62.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-62.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-62.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-37.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-37.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-37.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-37.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-37.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-37.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-37.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-37.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-12.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-12.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-12.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-12.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-12.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-12.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-12.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-12.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="12.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="12.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="12.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="12.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="12.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="12.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="12.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="12.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="37.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="37.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="37.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="37.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="37.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="37.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="37.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="37.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="62.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="62.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="62.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="62.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="62.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="62.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="62.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="62.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="87.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="87.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="87.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="87.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="87.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="87.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="87.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="87.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-87.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-87.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-87.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-87.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-87.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-87.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-87.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-87.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-62.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-62.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-62.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-62.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-62.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-62.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-62.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-62.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-37.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-37.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-37.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-37.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-37.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-37.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-37.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-37.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-12.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-12.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-12.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-12.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-12.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-12.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-12.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-12.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="12.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="12.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="12.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="12.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="12.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="12.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="12.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="12.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="37.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="37.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="37.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="37.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="37.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="37.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="37.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="37.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="62.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="62.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="62.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="62.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="62.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="62.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="62.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="62.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="87.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="87.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="87.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="87.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="87.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="87.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="87.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="87.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
 
     <!-- Identical cluster B far away so everything unloads in transit -->
-    <Mesh file="assets/bunny.obj" position="1112.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1112.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1112.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1112.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1112.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1112.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1112.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1112.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1137.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1137.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1137.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1137.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1137.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1137.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1137.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1137.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1162.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1162.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1162.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1162.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1162.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1162.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1162.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1162.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1187.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1187.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1187.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1187.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1187.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1187.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1187.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1187.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1212.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1212.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1212.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1212.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1212.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1212.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1212.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1212.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1237.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1237.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1237.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1237.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1237.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1237.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1237.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1237.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1262.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1262.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1262.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1262.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1262.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1262.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1262.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1262.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1287.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1287.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1287.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1287.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1287.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1287.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1287.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="1287.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1112.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1112.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1112.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1112.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1112.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1112.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1112.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1112.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1137.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1137.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1137.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1137.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1137.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1137.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1137.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1137.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1162.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1162.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1162.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1162.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1162.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1162.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1162.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1162.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1187.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1187.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1187.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1187.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1187.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1187.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1187.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1187.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1212.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1212.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1212.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1212.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1212.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1212.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1212.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1212.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1237.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1237.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1237.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1237.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1237.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1237.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1237.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1237.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1262.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1262.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1262.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1262.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1262.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1262.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1262.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1262.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1287.5,0,-87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1287.5,0,-62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1287.5,0,-37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1287.5,0,-12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1287.5,0,12.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1287.5,0,37.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1287.5,0,62.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="1287.5,0,87.5" scale="12.0" albedo="0.85,0.6,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
 </Scene>

--- a/MetalCpp Path Tracer/scene_lod_memory_drop.xml
+++ b/MetalCpp Path Tracer/scene_lod_memory_drop.xml
@@ -12,11 +12,11 @@
     <Sphere position="0,-10000,0" radius="10000" albedo="0.7,0.7,0.7" emission="0,0,0" materialType="0" emissionPower="0" />
 
     <!-- Dense cluster near origin to create a large residency set. -->
-    <Mesh file="assets/bunny.obj" position="-12,0,-12" scale="12.0" albedo="0.8,0.4,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="12,0,-12" scale="12.0" albedo="0.8,0.6,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-12,0,12" scale="12.0" albedo="0.3,0.6,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="12,0,12" scale="12.0" albedo="0.3,0.8,0.6" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="0,0,0" scale="14.0" albedo="0.9,0.5,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-12,0,-12" scale="12.0" albedo="0.8,0.4,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="12,0,-12" scale="12.0" albedo="0.8,0.6,0.3" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-12,0,12" scale="12.0" albedo="0.3,0.6,0.8" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="12,0,12" scale="12.0" albedo="0.3,0.8,0.6" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="0,0,0" scale="14.0" albedo="0.9,0.5,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
     <Sphere position="0,15,0" radius="8" albedo="0.6,0.4,0.9" emission="0,0,0" materialType="0" emissionPower="0" />
     <Sphere position="-24,10,0" radius="6" albedo="0.9,0.5,0.2" emission="0,0,0" materialType="0" emissionPower="0" />
     <Sphere position="24,10,0" radius="6" albedo="0.2,0.5,0.9" emission="0,0,0" materialType="0" emissionPower="0" />

--- a/MetalCpp Path Tracer/scene_no_keyframes.xml
+++ b/MetalCpp Path Tracer/scene_no_keyframes.xml
@@ -12,7 +12,7 @@
     <Rectangle position="15,10,-120" u="10,0,0" v="0,10,0" albedo="1.0,1.0,1.0" emission="0,0,0" materialType="-1" emissionPower="0" />
 
     <!-- Bunny Mesh beside the mirror -->
-    <Mesh
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40"
         file="assets/bunny.obj"
         position="15,0,-100"
         scale="10.0"

--- a/MetalCpp Path Tracer/scene_residency_compaction_cycle.xml
+++ b/MetalCpp Path Tracer/scene_residency_compaction_cycle.xml
@@ -81,7 +81,7 @@
     <Sphere position="13.50,19.80,-152.65" radius="3.50" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
     <Sphere position="22.50,16.20,-153.14" radius="3.50" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
     <Sphere position="22.50,19.80,-154.23" radius="3.50" albedo="0.65,0.72,0.78" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="0,0,-95" scale="11" albedo="0.78,0.56,0.42" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="48,0,-118" scale="9.5" albedo="0.6,0.55,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-48,0,-118" scale="9.5" albedo="0.6,0.55,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="0,0,-95" scale="11" albedo="0.78,0.56,0.42" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="48,0,-118" scale="9.5" albedo="0.6,0.55,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-48,0,-118" scale="9.5" albedo="0.6,0.55,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
 </Scene>

--- a/MetalCpp Path Tracer/scene_residency_compaction_drop.xml
+++ b/MetalCpp Path Tracer/scene_residency_compaction_drop.xml
@@ -53,7 +53,7 @@
     <Sphere position="-46.50,9.49,-134.02" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
     <Sphere position="-46.50,12.46,-134.10" radius="3.50" albedo="0.7,0.7,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
     <!-- Triangle content to exercise BLAS/TLAS compaction alongside spheres -->
-    <Mesh file="assets/bunny.obj" position="0,0,-100" scale="12" albedo="0.85,0.55,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="60,0,-140" scale="10" albedo="0.75,0.6,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
-    <Mesh file="assets/bunny.obj" position="-60,0,-140" scale="10" albedo="0.75,0.6,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="0,0,-100" scale="12" albedo="0.85,0.55,0.4" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="60,0,-140" scale="10" albedo="0.75,0.6,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40" file="assets/bunny.obj" position="-60,0,-140" scale="10" albedo="0.75,0.6,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
 </Scene>

--- a/MetalCpp Path Tracer/scene_residency_distance.xml
+++ b/MetalCpp Path Tracer/scene_residency_distance.xml
@@ -19,7 +19,7 @@
     <Rectangle position="15,10,-120" u="10,0,0" v="0,10,0" albedo="1.0,1.0,1.0" emission="0,0,0" materialType="-1" emissionPower="0" />
 
     <!-- Bunny Mesh beside the mirror -->
-    <Mesh
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40"
         file="assets/bunny.obj"
         position="15,0,-100"
         scale="10.0"

--- a/MetalCpp Path Tracer/scene_residency_energy.xml
+++ b/MetalCpp Path Tracer/scene_residency_energy.xml
@@ -19,7 +19,7 @@
     <Rectangle position="15,10,-120" u="10,0,0" v="0,10,0" albedo="1.0,1.0,1.0" emission="0,0,0" materialType="-1" emissionPower="0" />
 
     <!-- Bunny Mesh beside the mirror -->
-    <Mesh
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40"
         file="assets/bunny.obj"
         position="15,0,-100"
         scale="10.0"

--- a/MetalCpp Path Tracer/scene_residency_rayhit.xml
+++ b/MetalCpp Path Tracer/scene_residency_rayhit.xml
@@ -19,7 +19,7 @@
     <Sphere position="12,18,-105" radius="10" albedo="0.75,0.75,0.75" emission="0,0,0" materialType="-1" emissionPower="0" />
 
     <!-- A detailed mesh that should become resident when the camera lingers on it -->
-    <Mesh
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40"
         file="assets/bunny.obj"
         position="0,0,-100"
         scale="10.0"

--- a/MetalCpp Path Tracer/scene_residency_screenspace.xml
+++ b/MetalCpp Path Tracer/scene_residency_screenspace.xml
@@ -20,7 +20,7 @@
     <Rectangle position="35,15,-80" u="12,0,0" v="0,12,0" albedo="0.2,0.8,0.5" emission="0,0,0" materialType="0" emissionPower="0" />
 
     <!-- Mesh elements to test footprint prioritization -->
-    <Mesh
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40"
         file="assets/bunny.obj"
         position="-25,0,-110"
         scale="11.0"
@@ -28,7 +28,7 @@
         emission="0,0,0"
         materialType="0"
         emissionPower="0" />
-    <Mesh
+    <Mesh clusterMaxTriangles="4096" clusterMaxExtent="40"
         file="assets/bunny.obj"
         position="28,0,-85"
         scale="8.0"


### PR DESCRIPTION
## Summary
- add a mesh partitioning helper that enforces triangle and extent budgets before emitting scene objects
- expose optional `clusterMaxTriangles` and `clusterMaxExtent` attributes on `<Mesh>` elements and honor them when loading
- update sample scene XML files to demonstrate the new mesh clustering controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dafb35c780832da1729d0156f07de2