### PR TITLE
Implement adaptive sampling with compute-driven sample budgets

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -5,6 +5,7 @@
 #include "Scene.h"
 #include "SceneLoader.h"
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cmath>
 #include <cstdio>
@@ -46,8 +47,10 @@ struct UniformsData {
   uint32_t debugAS;
   uint32_t lightCount;
   float lightTotalWeight;
-  uint32_t padding0 = 0;
-  uint32_t padding1 = 0;
+  uint32_t sampleCountTextureIndex = 0;
+  uint32_t sampleImportanceTextureIndex = 0;
+  uint32_t minSamplesPerPixel = 1;
+  uint32_t maxSamplesPerPixel = 1;
 };
 
 inline uint32_t bitm_random() {
@@ -62,6 +65,23 @@ inline float randomFloat() {
 }
 
 namespace {
+
+size_t alignTo(size_t value, size_t alignment) {
+  if (alignment == 0)
+    return value;
+  return (value + alignment - 1) & ~(alignment - 1);
+}
+
+size_t bytesPerPixel(MTL::PixelFormat format) {
+  switch (format) {
+  case MTL::PixelFormat::PixelFormatRGBA32Float:
+    return sizeof(float) * 4;
+  case MTL::PixelFormat::PixelFormatR32Float:
+    return sizeof(float);
+  default:
+    return 0;
+  }
+}
 
 float luminance(const simd::float3 &c) {
   return 0.2126f * c.x + 0.7152f * c.y + 0.0722f * c.z;
@@ -377,6 +397,17 @@ Renderer::~Renderer() {
     if (_accumulationTargets[i])
       _accumulationTargets[i]->release();
 
+  if (_sampleCountTarget)
+    _sampleCountTarget->release();
+  if (_sampleImportanceTarget)
+    _sampleImportanceTarget->release();
+
+  if (_pTextureClearBuffer)
+    _pTextureClearBuffer->release();
+
+  if (_pAdaptiveSamplingPSO)
+    _pAdaptiveSamplingPSO->release();
+
   if (_pPSO)
     _pPSO->release();
   if (_pCommandQueue)
@@ -397,6 +428,15 @@ void Renderer::setDeltaTime(double deltaSeconds) {
 
 void Renderer::buildShaders() {
   using NS::StringEncoding::UTF8StringEncoding;
+
+  if (_pPSO) {
+    _pPSO->release();
+    _pPSO = nullptr;
+  }
+  if (_pAdaptiveSamplingPSO) {
+    _pAdaptiveSamplingPSO->release();
+    _pAdaptiveSamplingPSO = nullptr;
+  }
 
   NS::Error *pError = nullptr;
   MTL::Library *pLibrary = _pDevice->newDefaultLibrary();
@@ -422,6 +462,18 @@ void Renderer::buildShaders() {
   if (!_pPSO) {
     __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
     assert(false);
+  }
+
+  pError = nullptr;
+  MTL::Function *pAdaptiveFn = pLibrary->newFunction(
+      NS::String::string("adaptiveSamplingMain", UTF8StringEncoding));
+  if (pAdaptiveFn) {
+    _pAdaptiveSamplingPSO =
+        _pDevice->newComputePipelineState(pAdaptiveFn, &pError);
+    if (!_pAdaptiveSamplingPSO && pError) {
+      __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
+    }
+    pAdaptiveFn->release();
   }
 
   pVertexFn->release();
@@ -1512,25 +1564,195 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
 
   _recentlyActivated.clear();
   _recentlyDeactivated.clear();
+
+  _needsAccumulationReset = true;
 }
 
 
 
 
 void Renderer::buildTextures() {
+  for (MTL::Texture *&target : _accumulationTargets) {
+    if (target) {
+      target->release();
+      target = nullptr;
+    }
+  }
+  if (_sampleCountTarget) {
+    _sampleCountTarget->release();
+    _sampleCountTarget = nullptr;
+  }
+  if (_sampleImportanceTarget) {
+    _sampleImportanceTarget->release();
+    _sampleImportanceTarget = nullptr;
+  }
+
+  NS::UInteger width = std::max<NS::UInteger>(
+      1, static_cast<NS::UInteger>(Camera::screenSize.x));
+  NS::UInteger height = std::max<NS::UInteger>(
+      1, static_cast<NS::UInteger>(Camera::screenSize.y));
+
   MTL::TextureDescriptor *textureDescriptor =
       MTL::TextureDescriptor::alloc()->init();
-
   textureDescriptor->setPixelFormat(MTL::PixelFormat::PixelFormatRGBA32Float);
   textureDescriptor->setTextureType(MTL::TextureType::TextureType2D);
-  textureDescriptor->setWidth(Camera::screenSize.x);
-  textureDescriptor->setHeight(Camera::screenSize.y);
+  textureDescriptor->setWidth(width);
+  textureDescriptor->setHeight(height);
   textureDescriptor->setStorageMode(MTL::StorageMode::StorageModePrivate);
   textureDescriptor->setUsage(MTL::TextureUsageShaderRead |
                               MTL::TextureUsageShaderWrite);
 
   for (uint i = 0; i < 2; i++)
     _accumulationTargets[i] = _pDevice->newTexture(textureDescriptor);
+  textureDescriptor->release();
+
+  MTL::TextureDescriptor *sampleCountDescriptor =
+      MTL::TextureDescriptor::alloc()->init();
+  sampleCountDescriptor->setPixelFormat(
+      MTL::PixelFormat::PixelFormatR32Float);
+  sampleCountDescriptor->setTextureType(MTL::TextureType::TextureType2D);
+  sampleCountDescriptor->setWidth(width);
+  sampleCountDescriptor->setHeight(height);
+  sampleCountDescriptor->setStorageMode(MTL::StorageMode::StorageModePrivate);
+  sampleCountDescriptor->setUsage(MTL::TextureUsageShaderRead |
+                                  MTL::TextureUsageShaderWrite);
+  _sampleCountTarget = _pDevice->newTexture(sampleCountDescriptor);
+  sampleCountDescriptor->release();
+
+  MTL::TextureDescriptor *sampleImportanceDescriptor =
+      MTL::TextureDescriptor::alloc()->init();
+  sampleImportanceDescriptor->setPixelFormat(
+      MTL::PixelFormat::PixelFormatR32Float);
+  sampleImportanceDescriptor->setTextureType(
+      MTL::TextureType::TextureType2D);
+  sampleImportanceDescriptor->setWidth(width);
+  sampleImportanceDescriptor->setHeight(height);
+  sampleImportanceDescriptor->setStorageMode(
+      MTL::StorageMode::StorageModePrivate);
+  sampleImportanceDescriptor->setUsage(MTL::TextureUsageShaderRead |
+                                       MTL::TextureUsageShaderWrite);
+  _sampleImportanceTarget =
+      _pDevice->newTexture(sampleImportanceDescriptor);
+  sampleImportanceDescriptor->release();
+
+  _needsAccumulationReset = true;
+}
+
+void Renderer::resetAccumulationTargets() {
+  if (!_pCommandQueue)
+    return;
+
+  std::array<MTL::Texture *, 4> textures = {
+      _accumulationTargets[0], _accumulationTargets[1], _sampleCountTarget,
+      _sampleImportanceTarget};
+
+  size_t maxBytes = 0;
+  for (MTL::Texture *texture : textures) {
+    if (!texture)
+      continue;
+    size_t pixelBytes = bytesPerPixel(texture->pixelFormat());
+    if (pixelBytes == 0)
+      continue;
+    size_t width = texture->width();
+    size_t height = texture->height();
+    if (width == 0 || height == 0)
+      continue;
+    size_t rowBytes = width * pixelBytes;
+    size_t alignedRowBytes = alignTo(rowBytes, 256);
+    size_t totalBytes = alignedRowBytes * height;
+    maxBytes = std::max(maxBytes, totalBytes);
+  }
+
+  if (maxBytes == 0) {
+    _needsAccumulationReset = false;
+    return;
+  }
+
+  ensureBufferCapacity(_pTextureClearBuffer, maxBytes,
+                       _textureClearBufferCapacity, false,
+                       MTL::ResourceStorageModeShared);
+  if (!_pTextureClearBuffer) {
+    _needsAccumulationReset = false;
+    return;
+  }
+
+  if (void *ptr = _pTextureClearBuffer->contents())
+    std::memset(ptr, 0, maxBytes);
+
+  MTL::CommandBuffer *cmd = _pCommandQueue->commandBuffer();
+  if (!cmd) {
+    _needsAccumulationReset = false;
+    return;
+  }
+
+  MTL::BlitCommandEncoder *blit = cmd->blitCommandEncoder();
+  if (!blit) {
+    cmd->commit();
+    cmd->waitUntilCompleted();
+    _needsAccumulationReset = false;
+    return;
+  }
+
+  for (MTL::Texture *texture : textures) {
+    if (!texture)
+      continue;
+    size_t pixelBytes = bytesPerPixel(texture->pixelFormat());
+    if (pixelBytes == 0)
+      continue;
+    size_t width = texture->width();
+    size_t height = texture->height();
+    if (width == 0 || height == 0)
+      continue;
+    size_t rowBytes = width * pixelBytes;
+    size_t alignedRowBytes = alignTo(rowBytes, 256);
+    size_t totalBytes = alignedRowBytes * height;
+    if (totalBytes == 0)
+      continue;
+
+    MTL::Size size = MTL::Size::Make(width, height, 1);
+    MTL::Origin origin = MTL::Origin::Make(0, 0, 0);
+    blit->copyFromBuffer(_pTextureClearBuffer, 0, alignedRowBytes, totalBytes,
+                         size, texture, 0, 0, origin);
+  }
+
+  blit->endEncoding();
+  cmd->commit();
+  cmd->waitUntilCompleted();
+
+  _needsAccumulationReset = false;
+}
+
+void Renderer::updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd) {
+  if (!_pAdaptiveSamplingPSO || !pCmd)
+    return;
+  if (!_sampleImportanceTarget || !_accumulationTargets[0] ||
+      !_pUniformsBuffer)
+    return;
+
+  NS::UInteger width = _sampleImportanceTarget->width();
+  NS::UInteger height = _sampleImportanceTarget->height();
+  if (width == 0 || height == 0)
+    return;
+
+  MTL::ComputeCommandEncoder *pCompute = pCmd->computeCommandEncoder();
+  if (!pCompute)
+    return;
+
+  pCompute->setComputePipelineState(_pAdaptiveSamplingPSO);
+  pCompute->setTexture(_accumulationTargets[0], 0);
+  pCompute->setTexture(_sampleImportanceTarget, 1);
+  pCompute->setBuffer(_pUniformsBuffer, 0, 0);
+
+  const NS::UInteger threadWidth = 8;
+  const NS::UInteger threadHeight = 8;
+  MTL::Size threadsPerThreadgroup =
+      MTL::Size::Make(threadWidth, threadHeight, 1);
+  MTL::Size threadgroups = MTL::Size::Make(
+      (width + threadWidth - 1) / threadWidth,
+      (height + threadHeight - 1) / threadHeight, 1);
+
+  pCompute->dispatchThreadgroups(threadgroups, threadsPerThreadgroup);
+  pCompute->endEncoding();
 }
 
 bool Renderer::updateCamera() {
@@ -1587,12 +1809,27 @@ bool Renderer::updateCamera() {
 void Renderer::updateUniforms() {
   UniformsData &u = *((UniformsData *)_pUniformsBuffer->contents());
 
-  if (updateCamera()) {
+  bool cameraChanged = updateCamera();
+  if (cameraChanged)
+    _needsAccumulationReset = true;
+
+  if (_needsAccumulationReset) {
+    resetAccumulationTargets();
     u.frameCount = 0;
     u.randomSeed = {randomFloat(), randomFloat(), randomFloat()};
   } else {
     u.frameCount++;
   }
+
+  uint32_t minSamples = std::min(_minSamplesPerPixel, _maxSamplesPerPixel);
+  uint32_t maxSamples = std::max(_minSamplesPerPixel, _maxSamplesPerPixel);
+  minSamples = std::max<uint32_t>(minSamples, 1);
+  maxSamples = std::max(maxSamples, minSamples);
+
+  u.sampleCountTextureIndex = 2;
+  u.sampleImportanceTextureIndex = 3;
+  u.minSamplesPerPixel = minSamples;
+  u.maxSamplesPerPixel = maxSamples;
 
   u.primitiveCount = _residentPrimitiveCount;
   u.triangleCount = _residentTriangleCount;
@@ -1620,6 +1857,9 @@ void Renderer::draw(MTK::View *pView) {
   pCmd->addCompletedHandler([this](MTL::CommandBuffer *cmd) {
     this->completeFrameMetrics(cmd);
   });
+
+  updateAdaptiveSamplingMaps(pCmd);
+
   MTL::RenderPassDescriptor *pRpd = pView->currentRenderPassDescriptor();
   MTL::RenderCommandEncoder *pEnc = pCmd->renderCommandEncoder(pRpd);
 
@@ -1643,6 +1883,8 @@ void Renderer::draw(MTK::View *pView) {
 
   pEnc->setFragmentTexture(_accumulationTargets[0], 0);
   pEnc->setFragmentTexture(_accumulationTargets[1], 1);
+  pEnc->setFragmentTexture(_sampleCountTarget, 2);
+  pEnc->setFragmentTexture(_sampleImportanceTarget, 3);
 
   pEnc->drawPrimitives(MTL::PrimitiveType::PrimitiveTypeTriangle,
                        NS::UInteger(0), NS::UInteger(6));
@@ -2125,10 +2367,6 @@ void Renderer::flushResidencyChanges(bool forceFullRebuild) {
 }
 
 void Renderer::drawableSizeWillChange(MTK::View *pView, CGSize size) {
-  for (uint i = 0; i < 2; i++)
-    if (_accumulationTargets[i])
-      _accumulationTargets[i]->release();
-
   Camera::screenSize = {(float)size.width, (float)size.height};
 
   buildTextures();

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -80,10 +80,13 @@ private:
   void beginFrameMetrics();
   void completeFrameMetrics(MTL::CommandBuffer *pCmd);
   void processRayHitCounters();
+  void updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd);
+  void resetAccumulationTargets();
 
   MTL::Device *_pDevice = nullptr;
   MTL::CommandQueue *_pCommandQueue = nullptr;
   MTL::RenderPipelineState *_pPSO = nullptr;
+  MTL::ComputePipelineState *_pAdaptiveSamplingPSO = nullptr;
 
   // Core scene and geometry data
   Scene *_pScene = nullptr;
@@ -111,6 +114,8 @@ private:
   size_t _totalNodeCount = 0;
   // Accumulation framebuffers
   MTL::Texture *_accumulationTargets[2] = {nullptr, nullptr};
+  MTL::Texture *_sampleCountTarget = nullptr;
+  MTL::Texture *_sampleImportanceTarget = nullptr;
 
   std::vector<Primitive> _allPrimitives;
   std::vector<bool> _activePrimitive;
@@ -194,6 +199,12 @@ private:
   size_t _animationFrame = 0;
 
   ResidencyParameters _residencyConfig;
+
+  uint32_t _minSamplesPerPixel = 1;
+  uint32_t _maxSamplesPerPixel = 4;
+  bool _needsAccumulationReset = true;
+  MTL::Buffer *_pTextureClearBuffer = nullptr;
+  size_t _textureClearBufferCapacity = 0;
 
   size_t setObjectActive(size_t objectIndex, bool active);
 };

--- a/MetalCpp Path Tracer/Renderer/Shaders/AdaptiveSampling.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/AdaptiveSampling.metal
@@ -1,0 +1,58 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+#include "Structs.h"
+
+inline float luminance(float3 color)
+{
+    return dot(color, float3(0.2126, 0.7152, 0.0722));
+}
+
+inline float fetchLuminance(texture2d<float, access::read> accumulation,
+                            uint width, uint height, int2 coord)
+{
+    int x = clamp(coord.x, 0, int(width - 1));
+    int y = clamp(coord.y, 0, int(height - 1));
+    return luminance(accumulation.read(uint2(x, y)).xyz);
+}
+
+kernel void adaptiveSamplingMain(
+    texture2d<float, access::read> accumulation [[texture(0)]],
+    texture2d<float, access::write> importance [[texture(1)]],
+    constant UniformsData& uniforms [[buffer(0)]],
+    uint2 gid [[thread_position_in_grid]])
+{
+    uint width = accumulation.get_width();
+    uint height = accumulation.get_height();
+
+    if (gid.x >= width || gid.y >= height)
+    {
+        return;
+    }
+
+    int2 coord = int2(gid);
+
+    float center = fetchLuminance(accumulation, width, height, coord);
+    float left = fetchLuminance(accumulation, width, height, coord + int2(-1, 0));
+    float right = fetchLuminance(accumulation, width, height, coord + int2(1, 0));
+    float up = fetchLuminance(accumulation, width, height, coord + int2(0, -1));
+    float down = fetchLuminance(accumulation, width, height, coord + int2(0, 1));
+    float diag0 = fetchLuminance(accumulation, width, height, coord + int2(-1, -1));
+    float diag1 = fetchLuminance(accumulation, width, height, coord + int2(1, -1));
+    float diag2 = fetchLuminance(accumulation, width, height, coord + int2(-1, 1));
+    float diag3 = fetchLuminance(accumulation, width, height, coord + int2(1, 1));
+
+    float gradient = fabs(right - left) + fabs(down - up);
+    float diagonal = fabs(diag0 - diag3) + fabs(diag1 - diag2);
+    float contrast = fabs(center - 0.25f * (left + right + up + down));
+
+    float detail = gradient + 0.5f * diagonal + 4.0f * contrast;
+    detail = clamp(detail, 0.0f, 1.0f);
+
+    float minSamples = float(max(uniforms.minSamplesPerPixel, 1u));
+    float maxSamples = float(max(uniforms.maxSamplesPerPixel, uniforms.minSamplesPerPixel));
+    float sampleBudget = mix(minSamples, maxSamples, detail);
+
+    importance.write(sampleBudget, gid);
+}

--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -22,73 +22,88 @@ float4 fragment fragmentMain(
     device atomic_uint* primitiveHitCounts [[buffer(12)]],
     device const InstanceRecord* instanceRecords [[buffer(13)]],
     texture2d<float, access::read_write> lastFrame [[texture(0)]],
-    texture2d<float, access::read_write> currentFrame [[texture(1)]])
+    texture2d<float, access::read_write> currentFrame [[texture(1)]],
+    texture2d<float, access::read_write> sampleCount [[texture(2)]],
+    texture2d<float, access::read> sampleImportance [[texture(3)]])
 
 {
     const device UniformsData& u = *uniforms;
 
-    if (u.frameCount == 0)
-    {
-        uint2 coord = uint2(in.uv * u.screenSize);
-        lastFrame.write(0, coord);
-    }
-
     uint32_t seed = random(in.uv, u.randomSeed.xyz) * ((uint32_t)-1);
 
-    float xOff = (randomFloat(seed) - 0.5) / u.screenSize.x;
-    seed = random(seed);
-    float yOff = (randomFloat(seed) - 0.5) / u.screenSize.y;
-    seed = random(seed);
+    uint2 coord = uint2(in.uv * u.screenSize);
 
-    float3 rayDir = (
-        u.firstPixelPosition +
-        (in.uv.x + xOff) * u.viewportU +
-        (in.uv.y + yOff) * u.viewportV
-    ) - u.cameraPosition;
+    float desiredSamples = sampleImportance.read(coord).x;
+    if (!isfinite(desiredSamples))
+    {
+        desiredSamples = float(u.minSamplesPerPixel);
+    }
 
-    ray r{u.cameraPosition, normalize(rayDir)};
-    r.min_distance = 0.0001;
-    r.max_distance = INFINITY; // or INFINITY
+    uint samplesThisFrame = uint(round(desiredSamples));
+    samplesThisFrame = clamp(samplesThisFrame, u.minSamplesPerPixel, u.maxSamplesPerPixel);
+    samplesThisFrame = max(samplesThisFrame, 1u);
+
+    float previousSampleCount = sampleCount.read(coord).x;
+    float4 previousColor = lastFrame.read(coord);
+
+    float4 accumulatedColor = float4(0.0);
 
     float3 rayDx = u.rayDx;
     float3 rayDy = u.rayDy;
 
-    float4 color = rayColor(
-        r,
-        rayDx,
-        rayDy,
-        tlasNodes,
-        u.tlasNodeCount,
-        bvhNodes,
-        primitives,       // <- Each primitive is 3 float4s
-        materials,
-        u.primitiveCount,
-        primitiveIndices,
-        activeMask,
-        instanceRecords,
-        lightIndices,
-        lightCdf,
-        primitiveRemap,
-        primitiveHitCounts,
-        seed,
-        u.maxRayDepth,
-        u.debugAS,
-        u.blasNodeCount,
-        u.lightCount,
-        u.lightTotalWeight,
-        static_cast<uint>(u.totalPrimitiveCount)
-    );
+    for (uint sample = 0; sample < samplesThisFrame; ++sample)
+    {
+        float xOff = (randomFloat(seed) - 0.5) / u.screenSize.x;
+        seed = random(seed);
+        float yOff = (randomFloat(seed) - 0.5) / u.screenSize.y;
+        seed = random(seed);
 
+        float3 rayDir = (
+            u.firstPixelPosition +
+            (in.uv.x + xOff) * u.viewportU +
+            (in.uv.y + yOff) * u.viewportV
+        ) - u.cameraPosition;
 
+        ray r{u.cameraPosition, normalize(rayDir)};
+        r.min_distance = 0.0001;
+        r.max_distance = INFINITY;
 
-    uint2 coord = uint2(in.uv * u.screenSize);
-    uint64_t frameCount = u.frameCount + 1;
+        accumulatedColor += rayColor(
+            r,
+            rayDx,
+            rayDy,
+            tlasNodes,
+            u.tlasNodeCount,
+            bvhNodes,
+            primitives,
+            materials,
+            u.primitiveCount,
+            primitiveIndices,
+            activeMask,
+            instanceRecords,
+            lightIndices,
+            lightCdf,
+            primitiveRemap,
+            primitiveHitCounts,
+            seed,
+            u.maxRayDepth,
+            u.debugAS,
+            u.blasNodeCount,
+            u.lightCount,
+            u.lightTotalWeight,
+            static_cast<uint>(u.totalPrimitiveCount)
+        );
+    }
 
-    color += lastFrame.read(coord) * (float)(frameCount - 1);
-    color /= frameCount;
-    color = clamp(color, 0.0, 1.0);
+    float totalSamples = previousSampleCount + float(samplesThisFrame);
+    float3 previousSum = previousColor.xyz * previousSampleCount;
+    float3 combinedSum = previousSum + accumulatedColor.xyz;
+    float3 averaged = (totalSamples > 0.0f) ? combinedSum / totalSamples : float3(0.0);
+    averaged = clamp(averaged, 0.0, 1.0);
 
-    currentFrame.write(color, coord);
-    color.w = 1;
-    return color;
+    float4 result = float4(averaged, 1.0);
+    currentFrame.write(result, coord);
+    sampleCount.write(totalSamples, coord);
+
+    return result;
 }

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -53,8 +53,10 @@ struct UniformsData
     uint debugAS;
     uint lightCount;
     float lightTotalWeight;
-    uint padding0;
-    uint padding1;
+    uint sampleCountTextureIndex;
+    uint sampleImportanceTextureIndex;
+    uint minSamplesPerPixel;
+    uint maxSamplesPerPixel;
 };
 
 


### PR DESCRIPTION
## Summary
- add adaptive sampling textures, configuration knobs, and uniform data so the renderer can track per-pixel sampling state
- allocate and reset the new textures while wiring up a compute pipeline that analyzes last-frame accumulation to build importance maps each frame
- update the fragment shader to consume the per-pixel budgets, loop the requested samples, update per-pixel counters, and introduce an AdaptiveSampling.metal compute shader

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dba1098e84832d894d245f61af3004