### PR TITLE
Switch accumulation targets to half precision

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -78,6 +78,10 @@ size_t bytesPerPixel(MTL::PixelFormat format) {
     return sizeof(float) * 4;
   case MTL::PixelFormat::PixelFormatR32Float:
     return sizeof(float);
+  case MTL::PixelFormat::PixelFormatRGBA16Float:
+    return sizeof(uint16_t) * 4;
+  case MTL::PixelFormat::PixelFormatR16Float:
+    return sizeof(uint16_t);
   default:
     return 0;
   }
@@ -1594,7 +1598,7 @@ void Renderer::buildTextures() {
 
   MTL::TextureDescriptor *textureDescriptor =
       MTL::TextureDescriptor::alloc()->init();
-  textureDescriptor->setPixelFormat(MTL::PixelFormat::PixelFormatRGBA32Float);
+  textureDescriptor->setPixelFormat(MTL::PixelFormat::PixelFormatRGBA16Float);
   textureDescriptor->setTextureType(MTL::TextureType::TextureType2D);
   textureDescriptor->setWidth(width);
   textureDescriptor->setHeight(height);
@@ -1609,7 +1613,7 @@ void Renderer::buildTextures() {
   MTL::TextureDescriptor *sampleCountDescriptor =
       MTL::TextureDescriptor::alloc()->init();
   sampleCountDescriptor->setPixelFormat(
-      MTL::PixelFormat::PixelFormatR32Float);
+      MTL::PixelFormat::PixelFormatR16Float);
   sampleCountDescriptor->setTextureType(MTL::TextureType::TextureType2D);
   sampleCountDescriptor->setWidth(width);
   sampleCountDescriptor->setHeight(height);
@@ -1622,7 +1626,7 @@ void Renderer::buildTextures() {
   MTL::TextureDescriptor *sampleImportanceDescriptor =
       MTL::TextureDescriptor::alloc()->init();
   sampleImportanceDescriptor->setPixelFormat(
-      MTL::PixelFormat::PixelFormatR32Float);
+      MTL::PixelFormat::PixelFormatR16Float);
   sampleImportanceDescriptor->setTextureType(
       MTL::TextureType::TextureType2D);
   sampleImportanceDescriptor->setWidth(width);

--- a/MetalCpp Path Tracer/Renderer/Shaders/AdaptiveSampling.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/AdaptiveSampling.metal
@@ -9,17 +9,17 @@ inline float luminance(float3 color)
     return dot(color, float3(0.2126, 0.7152, 0.0722));
 }
 
-inline float fetchLuminance(texture2d<float, access::read> accumulation,
+inline float fetchLuminance(texture2d<half, access::read> accumulation,
                             uint width, uint height, int2 coord)
 {
     int x = clamp(coord.x, 0, int(width - 1));
     int y = clamp(coord.y, 0, int(height - 1));
-    return luminance(accumulation.read(uint2(x, y)).xyz);
+    return luminance(float3(accumulation.read(uint2(x, y)).xyz));
 }
 
 kernel void adaptiveSamplingMain(
-    texture2d<float, access::read> accumulation [[texture(0)]],
-    texture2d<float, access::write> importance [[texture(1)]],
+    texture2d<half, access::read> accumulation [[texture(0)]],
+    texture2d<half, access::write> importance [[texture(1)]],
     constant UniformsData& uniforms [[buffer(0)]],
     uint2 gid [[thread_position_in_grid]])
 {
@@ -54,5 +54,5 @@ kernel void adaptiveSamplingMain(
     float maxSamples = float(max(uniforms.maxSamplesPerPixel, uniforms.minSamplesPerPixel));
     float sampleBudget = mix(minSamples, maxSamples, detail);
 
-    importance.write(sampleBudget, gid);
+    importance.write(half4(sampleBudget, half(0.0), half(0.0), half(0.0)), gid);
 }

--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -21,10 +21,10 @@ float4 fragment fragmentMain(
     device const uint* primitiveRemap [[buffer(11)]],
     device atomic_uint* primitiveHitCounts [[buffer(12)]],
     device const InstanceRecord* instanceRecords [[buffer(13)]],
-    texture2d<float, access::read_write> lastFrame [[texture(0)]],
-    texture2d<float, access::read_write> currentFrame [[texture(1)]],
-    texture2d<float, access::read_write> sampleCount [[texture(2)]],
-    texture2d<float, access::read> sampleImportance [[texture(3)]])
+    texture2d<half, access::read_write> lastFrame [[texture(0)]],
+    texture2d<half, access::read_write> currentFrame [[texture(1)]],
+    texture2d<half, access::read_write> sampleCount [[texture(2)]],
+    texture2d<half, access::read> sampleImportance [[texture(3)]])
 
 {
     const device UniformsData& u = *uniforms;
@@ -33,7 +33,7 @@ float4 fragment fragmentMain(
 
     uint2 coord = uint2(in.uv * u.screenSize);
 
-    float desiredSamples = sampleImportance.read(coord).x;
+    float desiredSamples = float(sampleImportance.read(coord).x);
     if (!isfinite(desiredSamples))
     {
         desiredSamples = float(u.minSamplesPerPixel);
@@ -43,8 +43,8 @@ float4 fragment fragmentMain(
     samplesThisFrame = clamp(samplesThisFrame, u.minSamplesPerPixel, u.maxSamplesPerPixel);
     samplesThisFrame = max(samplesThisFrame, 1u);
 
-    float previousSampleCount = sampleCount.read(coord).x;
-    float4 previousColor = lastFrame.read(coord);
+    float previousSampleCount = float(sampleCount.read(coord).x);
+    float4 previousColor = float4(lastFrame.read(coord));
 
     float4 accumulatedColor = float4(0.0);
 
@@ -102,8 +102,8 @@ float4 fragment fragmentMain(
     averaged = clamp(averaged, 0.0, 1.0);
 
     float4 result = float4(averaged, 1.0);
-    currentFrame.write(result, coord);
-    sampleCount.write(totalSamples, coord);
+    currentFrame.write(half4(result), coord);
+    sampleCount.write(half4(totalSamples, half(0.0), half(0.0), half(0.0)), coord);
 
     return result;
 }


### PR DESCRIPTION
## Summary
- update accumulation, sample count, and importance textures to use 16-bit floating point formats
- adjust fragment and adaptive sampling shaders to read and write half-precision targets while performing computations in float
- extend texture clearing helpers to account for the new pixel formats

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dbbe10ced4832d840e715d1f64077d