### PR TITLE
Guard ray hit counter processing when residency strategy changes

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -2507,18 +2507,27 @@ void Renderer::processRayHitCounters() {
   if (!_pPrimitiveHitReadback)
     return;
 
+  size_t bufferLength = _pPrimitiveHitReadback->length();
+  uint32_t *hitPtr =
+      static_cast<uint32_t *>(_pPrimitiveHitReadback->contents());
+  if (!hitPtr)
+    return;
+
+  if (!_pScene ||
+      _pScene->getResidencyStrategy() != ResidencyStrategy::RayHitBudget) {
+    std::memset(hitPtr, 0, bufferLength);
+    _primitiveHitScores.clear();
+    _primitiveHitLastFrame.clear();
+    return;
+  }
+
   size_t totalPrimitiveCount = _allPrimitives.size();
   if (totalPrimitiveCount == 0)
     return;
 
-  size_t bufferCount = _pPrimitiveHitReadback->length() / sizeof(uint32_t);
+  size_t bufferCount = bufferLength / sizeof(uint32_t);
   size_t count = std::min(totalPrimitiveCount, bufferCount);
   if (count == 0)
-    return;
-
-  uint32_t *hitPtr =
-      static_cast<uint32_t *>(_pPrimitiveHitReadback->contents());
-  if (!hitPtr)
     return;
 
   if (_primitiveHitScores.size() < totalPrimitiveCount)


### PR DESCRIPTION
## Summary
- skip processing the ray hit readback buffer when the scene is absent or not using the ray-hit residency strategy
- bulk clear the readback buffer and cached hit score vectors when the strategy is bypassed to avoid stale counters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbbf4b0fd8832d90e18616e46b51b7