### PR TITLE
Refactor accumulation reset to use caller command buffer

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1642,8 +1642,8 @@ void Renderer::buildTextures() {
   _needsAccumulationReset = true;
 }
 
-void Renderer::resetAccumulationTargets() {
-  if (!_pCommandQueue)
+void Renderer::resetAccumulationTargets(MTL::CommandBuffer *cmd) {
+  if (!cmd)
     return;
 
   std::array<MTL::Texture *, 4> textures = {
@@ -1667,35 +1667,21 @@ void Renderer::resetAccumulationTargets() {
     maxBytes = std::max(maxBytes, totalBytes);
   }
 
-  if (maxBytes == 0) {
-    _needsAccumulationReset = false;
+  if (maxBytes == 0)
     return;
-  }
 
   ensureBufferCapacity(_pTextureClearBuffer, maxBytes,
                        _textureClearBufferCapacity, false,
                        MTL::ResourceStorageModeShared);
-  if (!_pTextureClearBuffer) {
-    _needsAccumulationReset = false;
+  if (!_pTextureClearBuffer)
     return;
-  }
 
   if (void *ptr = _pTextureClearBuffer->contents())
     std::memset(ptr, 0, maxBytes);
 
-  MTL::CommandBuffer *cmd = _pCommandQueue->commandBuffer();
-  if (!cmd) {
-    _needsAccumulationReset = false;
-    return;
-  }
-
   MTL::BlitCommandEncoder *blit = cmd->blitCommandEncoder();
-  if (!blit) {
-    cmd->commit();
-    cmd->waitUntilCompleted();
-    _needsAccumulationReset = false;
+  if (!blit)
     return;
-  }
 
   for (MTL::Texture *texture : textures) {
     if (!texture)
@@ -1720,10 +1706,6 @@ void Renderer::resetAccumulationTargets() {
   }
 
   blit->endEncoding();
-  cmd->commit();
-  cmd->waitUntilCompleted();
-
-  _needsAccumulationReset = false;
 }
 
 void Renderer::updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd) {
@@ -1818,9 +1800,11 @@ void Renderer::updateUniforms() {
     _needsAccumulationReset = true;
 
   if (_needsAccumulationReset) {
-    resetAccumulationTargets();
+    if (!_accumulationTargetsNeedClear) {
+      _accumulationTargetsNeedClear = true;
+      u.randomSeed = {randomFloat(), randomFloat(), randomFloat()};
+    }
     u.frameCount = 0;
-    u.randomSeed = {randomFloat(), randomFloat(), randomFloat()};
   } else {
     u.frameCount++;
   }
@@ -1858,6 +1842,20 @@ void Renderer::draw(MTK::View *pView) {
   NS::AutoreleasePool *pPool = NS::AutoreleasePool::alloc()->init();
 
   MTL::CommandBuffer *pCmd = _pCommandQueue->commandBuffer();
+  if (!pCmd) {
+    if (_accumulationTargetsNeedClear) {
+      _accumulationTargetsNeedClear = false;
+      _needsAccumulationReset = false;
+    }
+    pPool->release();
+    return;
+  }
+
+  if (_accumulationTargetsNeedClear) {
+    resetAccumulationTargets(pCmd);
+    _accumulationTargetsNeedClear = false;
+    _needsAccumulationReset = false;
+  }
   pCmd->addCompletedHandler([this](MTL::CommandBuffer *cmd) {
     this->completeFrameMetrics(cmd);
   });

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -81,7 +81,7 @@ private:
   void completeFrameMetrics(MTL::CommandBuffer *pCmd);
   void processRayHitCounters();
   void updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd);
-  void resetAccumulationTargets();
+  void resetAccumulationTargets(MTL::CommandBuffer *cmd);
 
   MTL::Device *_pDevice = nullptr;
   MTL::CommandQueue *_pCommandQueue = nullptr;
@@ -203,6 +203,7 @@ private:
   uint32_t _minSamplesPerPixel = 1;
   uint32_t _maxSamplesPerPixel = 4;
   bool _needsAccumulationReset = true;
+  bool _accumulationTargetsNeedClear = false;
   MTL::Buffer *_pTextureClearBuffer = nullptr;
   size_t _textureClearBufferCapacity = 0;
 


### PR DESCRIPTION
## Summary
- refactor accumulation reset helper to encode clears into a supplied command buffer without blocking on completion
- track a pending accumulation clear flag in updateUniforms so frameCount/randomSeed reset occurs once per camera change
- ensure draw encodes texture clears on the frame command buffer before rendering and clears the pending flag

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbc175e178832db6152f8b4722a8c1