### PR TITLE
Default scenes start compacted

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -507,6 +507,8 @@ void Renderer::updateVisibleScene() {
          _pScene->getTriangleCount(), _pScene->getRectangleCount());
 
   _residencyConfig = _pScene->getResidencyParameters();
+  _residentCompacted = _pScene->getStartCompacted();
+  _compactionCooldown = 0;
 
   printf("LOD activation threshold: %.1f, deactivation threshold: %.1f (cooldown "
          "%u frames, toggle budget %zu)\n",
@@ -707,7 +709,8 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   size_t cachedTotalPrimitiveCount = _cachedTotalPrimitiveCount;
 
   if (forceFullRebuild) {
-    _residentCompacted = false;
+    bool startCompacted = _pScene ? _pScene->getStartCompacted() : false;
+    _residentCompacted = startCompacted;
     _compactionCooldown = 0;
   }
 

--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -25,6 +25,7 @@ void Scene::clear() {
   maxRayDepth = 32;
   residencyStrategy = ResidencyStrategy::DistanceLOD;
   residencyParams = ResidencyParameters{};
+  startCompacted = false;
 }
 
 size_t Scene::addPrimitive(const Primitive &p) {
@@ -121,6 +122,10 @@ const ResidencyParameters &Scene::getResidencyParameters() const {
 void Scene::setResidencyParameters(const ResidencyParameters &params) {
   residencyParams = params;
 }
+
+bool Scene::getStartCompacted() const { return startCompacted; }
+
+void Scene::setStartCompacted(bool start) { startCompacted = start; }
 
 void Scene::buildBVH() {
   primitiveIndices.resize(primitives.size());

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -86,6 +86,9 @@ public:
   const ResidencyParameters &getResidencyParameters() const;
   void setResidencyParameters(const ResidencyParameters &params);
 
+  bool getStartCompacted() const;
+  void setStartCompacted(bool start);
+
   void buildBVH();
   size_t getBVHNodeCount() const;
   const std::vector<BVHNode> &getBVHNodes() const;
@@ -121,6 +124,7 @@ private:
   std::vector<TLASNode> tlasNodes;
   ResidencyStrategy residencyStrategy;
   ResidencyParameters residencyParams;
+  bool startCompacted;
 
   size_t addObjectInternal(const Primitive *prims, size_t count,
                           bool logPrimitives);

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -321,6 +321,9 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
 
     scene->setResidencyParameters(params);
 
+    bool startCompacted = root->BoolAttribute("startCompacted", scene->getStartCompacted());
+    scene->setStartCompacted(startCompacted);
+
     for (auto* e = root->FirstChildElement(); e; e = e->NextSiblingElement()) {
         std::string tag = e->Name();
         if (tag == "Sphere") {

--- a/MetalCpp Path Tracer/scene.xml
+++ b/MetalCpp Path Tracer/scene.xml
@@ -1,4 +1,4 @@
-<Scene width="960" height="540" maxRayDepth="8" residencyStrategy="distance"
+<Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="distance"
        lodEnterDistance="50" lodExitDistance="75" residencyCooldown="1" lodToggleBudget="10000">
     <CameraPath>
         <!-- Default regression path: retreat over a bridge of geometry so far clusters are unloaded -->

--- a/MetalCpp Path Tracer/scene_distance_lod_staggered.xml
+++ b/MetalCpp Path Tracer/scene_distance_lod_staggered.xml
@@ -1,4 +1,4 @@
-<Scene width="960" height="540" maxRayDepth="8" residencyStrategy="distance"
+<Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="distance"
        lodEnterDistance="45" lodExitDistance="65" residencyCooldown="2" lodToggleBudget="8000">
     <CameraPath>
         <!-- Climb up and orbit so outer rings fall outside the distance budget -->

--- a/MetalCpp Path Tracer/scene_distance_lod_sweep.xml
+++ b/MetalCpp Path Tracer/scene_distance_lod_sweep.xml
@@ -1,4 +1,4 @@
-<Scene width="960" height="540" maxRayDepth="8" residencyStrategy="distance"
+<Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="distance"
        lodEnterDistance="55" lodExitDistance="80" residencyCooldown="0" lodToggleBudget="12000">
     <CameraPath>
         <!-- Slow dolly backwards so distant clusters can be released from memory -->

--- a/MetalCpp Path Tracer/scene_energy_core_intensity.xml
+++ b/MetalCpp Path Tracer/scene_energy_core_intensity.xml
@@ -1,4 +1,4 @@
-<Scene width="960" height="540" maxRayDepth="8" residencyStrategy="energy"
+<Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="energy"
        energyTargetFraction="0.42" energyMinActive="180" energyToggleBudget="1500">
     <CameraPath>
         <!-- Hovering orbit keeps the emissive core inside the frustum while darker shells drop residency -->

--- a/MetalCpp Path Tracer/scene_energy_decay_ramp.xml
+++ b/MetalCpp Path Tracer/scene_energy_decay_ramp.xml
@@ -1,4 +1,4 @@
-<Scene width="960" height="540" maxRayDepth="8" residencyStrategy="energy"
+<Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="energy"
        energyTargetFraction="0.36" energyMinActive="160" energyToggleBudget="1300">
     <CameraPath>
         <!-- Glide from the dim outskirts toward the bright ramp so distant dark assets unload -->

--- a/MetalCpp Path Tracer/scene_rayhit_budget_crossfire.xml
+++ b/MetalCpp Path Tracer/scene_rayhit_budget_crossfire.xml
@@ -1,4 +1,4 @@
-<Scene width="960" height="540" maxRayDepth="8" residencyStrategy="rayHitBudget"
+<Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="rayHitBudget"
        rayHitTargetFraction="0.32" rayHitMinActive="150" rayHitToggleBudget="1100"
        rayHitCooldown="16" rayHitDecay="0.78">
     <CameraPath>

--- a/MetalCpp Path Tracer/scene_rayhit_budget_tunnel.xml
+++ b/MetalCpp Path Tracer/scene_rayhit_budget_tunnel.xml
@@ -1,4 +1,4 @@
-<Scene width="960" height="540" maxRayDepth="8" residencyStrategy="rayHitBudget"
+<Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="rayHitBudget"
        rayHitTargetFraction="0.28" rayHitMinActive="140" rayHitToggleBudget="900"
        rayHitCooldown="12" rayHitDecay="0.82">
     <CameraPath>

--- a/MetalCpp Path Tracer/scene_screenspace_panorama.xml
+++ b/MetalCpp Path Tracer/scene_screenspace_panorama.xml
@@ -1,4 +1,4 @@
-<Scene width="960" height="540" maxRayDepth="8" residencyStrategy="screenSpaceFootprint"
+<Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="screenSpaceFootprint"
        screenTargetFraction="0.22" screenMinActive="120" screenToggleBudget="900"
        screenMinPixelCoverage="24">
     <CameraPath>

--- a/MetalCpp Path Tracer/scene_screenspace_zoom.xml
+++ b/MetalCpp Path Tracer/scene_screenspace_zoom.xml
@@ -1,4 +1,4 @@
-<Scene width="960" height="540" maxRayDepth="8" residencyStrategy="screenSpaceFootprint"
+<Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="screenSpaceFootprint"
        screenTargetFraction="0.18" screenMinActive="100" screenToggleBudget="750"
        screenMinPixelCoverage="18">
     <CameraPath>


### PR DESCRIPTION
## Summary
- add a startCompacted flag to Scene that is parsed from the XML descriptors
- initialize the renderer with the scene's startCompacted preference so the first residency build uses compaction
- enable startCompacted across all sample scene.xml files so they default to the compacted residency path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd087e3b1c832d97f609d8e4fdea64