### PR TITLE
Allow scenes to configure texture residency cap

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -73,7 +73,7 @@ size_t alignTo(size_t value, size_t alignment) {
 }
 
 constexpr size_t kTextureResidencyPrimitiveBudget = 1;
-constexpr double kTextureResidencyMemoryCapMB = 2048.0;
+constexpr double kDefaultTextureResidencyMemoryCapMB = 2048.0;
 
 size_t bytesPerPixel(MTL::PixelFormat format) {
   switch (format) {
@@ -507,6 +507,12 @@ void Renderer::updateVisibleScene() {
          _pScene->getTriangleCount(), _pScene->getRectangleCount());
 
   _residencyConfig = _pScene->getResidencyParameters();
+  _textureResidencyMemoryCapMB =
+      std::max(_pScene->getTextureResidencyMemoryCapMB(), 0.0);
+  if (_textureResidencyMemoryCapMB <= 0.0)
+    _textureResidencyMemoryCapMB = kDefaultTextureResidencyMemoryCapMB;
+  printf("Texture residency memory cap: %.1f MB\n",
+         _textureResidencyMemoryCapMB);
   _residentCompacted = _pScene->getStartCompacted();
   _compactionCooldown = 0;
 
@@ -1797,7 +1803,7 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
     return;
 
   bool belowBudget = _residentPrimitiveCount < kTextureResidencyPrimitiveBudget;
-  bool overMemory = currentGPUMemoryMB() > kTextureResidencyMemoryCapMB;
+  bool overMemory = currentGPUMemoryMB() > _textureResidencyMemoryCapMB;
   if (!belowBudget && !overMemory)
     return;
 
@@ -2042,7 +2048,7 @@ void Renderer::draw(MTK::View *pView) {
   bool belowBudget =
       _residentPrimitiveCount < kTextureResidencyPrimitiveBudget;
   double currentMemory = currentGPUMemoryMB();
-  bool overCap = currentMemory > kTextureResidencyMemoryCapMB;
+  bool overCap = currentMemory > _textureResidencyMemoryCapMB;
 
   if (!_needsAccumulationReset && (belowBudget || overCap))
     updateTextureResidency(pCmd);

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -150,6 +150,7 @@ private:
   std::vector<float> _primitiveScreenCoverage;
   std::vector<size_t> _screenCoverageSortedIndices;
   float _totalPrimitiveImportance = 0.0f;
+  double _textureResidencyMemoryCapMB = 2048.0;
 
   std::vector<BlasInstanceRecord> _instanceRecords;
   std::vector<Primitive> _residentPrimitives;

--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -26,6 +26,7 @@ void Scene::clear() {
   residencyStrategy = ResidencyStrategy::DistanceLOD;
   residencyParams = ResidencyParameters{};
   startCompacted = false;
+  textureResidencyMemoryCapMB = 2048.0;
 }
 
 size_t Scene::addPrimitive(const Primitive &p) {
@@ -126,6 +127,14 @@ void Scene::setResidencyParameters(const ResidencyParameters &params) {
 bool Scene::getStartCompacted() const { return startCompacted; }
 
 void Scene::setStartCompacted(bool start) { startCompacted = start; }
+
+double Scene::getTextureResidencyMemoryCapMB() const {
+  return textureResidencyMemoryCapMB;
+}
+
+void Scene::setTextureResidencyMemoryCapMB(double capMB) {
+  textureResidencyMemoryCapMB = capMB;
+}
 
 void Scene::buildBVH() {
   primitiveIndices.resize(primitives.size());

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -89,6 +89,9 @@ public:
   bool getStartCompacted() const;
   void setStartCompacted(bool start);
 
+  double getTextureResidencyMemoryCapMB() const;
+  void setTextureResidencyMemoryCapMB(double capMB);
+
   void buildBVH();
   size_t getBVHNodeCount() const;
   const std::vector<BVHNode> &getBVHNodes() const;
@@ -125,6 +128,7 @@ private:
   ResidencyStrategy residencyStrategy;
   ResidencyParameters residencyParams;
   bool startCompacted;
+  double textureResidencyMemoryCapMB;
 
   size_t addObjectInternal(const Primitive *prims, size_t count,
                           bool logPrimitives);

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -324,6 +324,10 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
     bool startCompacted = root->BoolAttribute("startCompacted", scene->getStartCompacted());
     scene->setStartCompacted(startCompacted);
 
+    double textureCap = root->DoubleAttribute(
+        "textureResidencyMemoryCapMB", scene->getTextureResidencyMemoryCapMB());
+    scene->setTextureResidencyMemoryCapMB(textureCap);
+
     for (auto* e = root->FirstChildElement(); e; e = e->NextSiblingElement()) {
         std::string tag = e->Name();
         if (tag == "Sphere") {

--- a/MetalCpp Path Tracer/scene.xml
+++ b/MetalCpp Path Tracer/scene.xml
@@ -1,4 +1,5 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="distance"
+       textureResidencyMemoryCapMB="16"
        lodEnterDistance="50" lodExitDistance="75" residencyCooldown="1" lodToggleBudget="10000">
     <CameraPath>
         <!-- Default regression path: retreat over a bridge of geometry so far clusters are unloaded -->

--- a/MetalCpp Path Tracer/scene_distance_lod_staggered.xml
+++ b/MetalCpp Path Tracer/scene_distance_lod_staggered.xml
@@ -1,4 +1,5 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="distance"
+       textureResidencyMemoryCapMB="16"
        lodEnterDistance="45" lodExitDistance="65" residencyCooldown="2" lodToggleBudget="8000">
     <CameraPath>
         <!-- Climb up and orbit so outer rings fall outside the distance budget -->

--- a/MetalCpp Path Tracer/scene_distance_lod_sweep.xml
+++ b/MetalCpp Path Tracer/scene_distance_lod_sweep.xml
@@ -1,4 +1,5 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="distance"
+       textureResidencyMemoryCapMB="16"
        lodEnterDistance="55" lodExitDistance="80" residencyCooldown="0" lodToggleBudget="12000">
     <CameraPath>
         <!-- Slow dolly backwards so distant clusters can be released from memory -->

--- a/MetalCpp Path Tracer/scene_energy_core_intensity.xml
+++ b/MetalCpp Path Tracer/scene_energy_core_intensity.xml
@@ -1,4 +1,5 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="energy"
+       textureResidencyMemoryCapMB="16"
        energyTargetFraction="0.42" energyMinActive="180" energyToggleBudget="1500">
     <CameraPath>
         <!-- Hovering orbit keeps the emissive core inside the frustum while darker shells drop residency -->

--- a/MetalCpp Path Tracer/scene_energy_decay_ramp.xml
+++ b/MetalCpp Path Tracer/scene_energy_decay_ramp.xml
@@ -1,4 +1,5 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="energy"
+       textureResidencyMemoryCapMB="16"
        energyTargetFraction="0.36" energyMinActive="160" energyToggleBudget="1300">
     <CameraPath>
         <!-- Glide from the dim outskirts toward the bright ramp so distant dark assets unload -->

--- a/MetalCpp Path Tracer/scene_rayhit_budget_crossfire.xml
+++ b/MetalCpp Path Tracer/scene_rayhit_budget_crossfire.xml
@@ -1,4 +1,5 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="rayHitBudget"
+       textureResidencyMemoryCapMB="16"
        rayHitTargetFraction="0.32" rayHitMinActive="150" rayHitToggleBudget="1100"
        rayHitCooldown="16" rayHitDecay="0.78">
     <CameraPath>

--- a/MetalCpp Path Tracer/scene_rayhit_budget_tunnel.xml
+++ b/MetalCpp Path Tracer/scene_rayhit_budget_tunnel.xml
@@ -1,4 +1,5 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="rayHitBudget"
+       textureResidencyMemoryCapMB="16"
        rayHitTargetFraction="0.28" rayHitMinActive="140" rayHitToggleBudget="900"
        rayHitCooldown="12" rayHitDecay="0.82">
     <CameraPath>

--- a/MetalCpp Path Tracer/scene_screenspace_panorama.xml
+++ b/MetalCpp Path Tracer/scene_screenspace_panorama.xml
@@ -1,4 +1,5 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="screenSpaceFootprint"
+       textureResidencyMemoryCapMB="16"
        screenTargetFraction="0.22" screenMinActive="120" screenToggleBudget="900"
        screenMinPixelCoverage="24">
     <CameraPath>

--- a/MetalCpp Path Tracer/scene_screenspace_zoom.xml
+++ b/MetalCpp Path Tracer/scene_screenspace_zoom.xml
@@ -1,4 +1,5 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="screenSpaceFootprint"
+       textureResidencyMemoryCapMB="16"
        screenTargetFraction="0.18" screenMinActive="100" screenToggleBudget="750"
        screenMinPixelCoverage="18">
     <CameraPath>


### PR DESCRIPTION
## Summary
- add a per-scene texture residency memory cap attribute that is stored on the Scene and parsed from XML
- use the scene-provided cap when the renderer decides whether to evict or restore accumulation textures
- update bundled scenes to request a low 16 MB cap so residency transitions are easy to reproduce

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd0bb11b54832dbf02f6ebed23283f