### PR TITLE
Add GPU heap resource scaffolding for renderer scene objects

### DIFF
--- a/MetalCpp Path Tracer/Renderer/GpuHeapResources.h
+++ b/MetalCpp Path Tracer/Renderer/GpuHeapResources.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <Metal/Metal.hpp>
+#include <cstddef>
+
+namespace MetalCppPathTracer {
+
+class GpuHeapResources {
+public:
+  enum class BufferKind { Vertex, Index };
+
+  GpuHeapResources() = default;
+  ~GpuHeapResources();
+
+  void initialize(MTL::Device *device,
+                  NS::UInteger heapSize = 0,
+                  MTL::StorageMode storageMode =
+                      MTL::StorageMode::StorageModePrivate,
+                  MTL::HazardTrackingMode hazardMode =
+                      MTL::HazardTrackingModeTracked);
+  void destroy();
+
+  MTL::Buffer *ensureOnHeapBuffer(BufferKind kind,
+                                  NS::UInteger requiredBytes,
+                                  MTL::ResourceOptions options,
+                                  MTL::ResourceUsage usage,
+                                  const char *label = nullptr);
+
+  MTL::Heap *heap() const { return _heap; }
+  MTL::Device *device() const { return _device; }
+
+  MTL::Buffer *vertexBuffer() const { return _vertex.buffer; }
+  MTL::Buffer *indexBuffer() const { return _index.buffer; }
+  NS::UInteger vertexCapacity() const { return _vertex.capacity; }
+  NS::UInteger indexCapacity() const { return _index.capacity; }
+
+private:
+  struct BufferInfo {
+    MTL::Buffer *buffer = nullptr;
+    NS::UInteger capacity = 0;
+    MTL::ResourceOptions options = MTL::ResourceStorageModePrivate;
+    MTL::ResourceUsage usage = MTL::ResourceUsage(0);
+  };
+
+  void releaseBuffer(BufferInfo &info);
+  BufferInfo &bufferInfo(BufferKind kind);
+  NS::UInteger alignForHeap(NS::UInteger size) const;
+  void recreateHeap(NS::UInteger newSize);
+
+  MTL::Device *_device = nullptr;
+  MTL::Heap *_heap = nullptr;
+  BufferInfo _vertex;
+  BufferInfo _index;
+  NS::UInteger _heapSize = 0;
+  NS::UInteger _defaultHeapSize = 0;
+  MTL::StorageMode _storageMode = MTL::StorageMode::StorageModePrivate;
+  MTL::HazardTrackingMode _hazardMode = MTL::HazardTrackingModeTracked;
+};
+
+} // namespace MetalCppPathTracer
+

--- a/MetalCpp Path Tracer/Renderer/GpuHeapResources.mm
+++ b/MetalCpp Path Tracer/Renderer/GpuHeapResources.mm
@@ -1,0 +1,171 @@
+#include "GpuHeapResources.h"
+
+#include <Foundation/Foundation.hpp>
+#include <algorithm>
+
+namespace MetalCppPathTracer {
+
+namespace {
+constexpr NS::UInteger kDefaultHeapSizeBytes = 4 * 1024 * 1024; // 4 MB
+constexpr NS::UInteger kHeapAlignment = 256;
+
+NS::UInteger alignUp(NS::UInteger value, NS::UInteger alignment) {
+  if (alignment == 0)
+    return value;
+  return (value + alignment - 1) & ~(alignment - 1);
+}
+
+} // namespace
+
+GpuHeapResources::~GpuHeapResources() { destroy(); }
+
+void GpuHeapResources::initialize(MTL::Device *device, NS::UInteger heapSize,
+                                  MTL::StorageMode storageMode,
+                                  MTL::HazardTrackingMode hazardMode) {
+  if (!device)
+    return;
+
+  if (_device && _device != device) {
+    destroy();
+  }
+
+  if (!_device) {
+    _device = device->retain();
+  }
+
+  _storageMode = storageMode;
+  _hazardMode = hazardMode;
+  _defaultHeapSize = heapSize == 0 ? kDefaultHeapSizeBytes : heapSize;
+
+  if (_heap)
+    return;
+
+  recreateHeap(_defaultHeapSize);
+}
+
+void GpuHeapResources::destroy() {
+  releaseBuffer(_vertex);
+  releaseBuffer(_index);
+
+  if (_heap) {
+    _heap->release();
+    _heap = nullptr;
+  }
+
+  if (_device) {
+    _device->release();
+    _device = nullptr;
+  }
+
+  _heapSize = 0;
+  _defaultHeapSize = 0;
+}
+
+MTL::Buffer *GpuHeapResources::ensureOnHeapBuffer(BufferKind kind,
+                                                  NS::UInteger requiredBytes,
+                                                  MTL::ResourceOptions options,
+                                                  MTL::ResourceUsage usage,
+                                                  const char *label) {
+  if (!_device)
+    return nullptr;
+
+  if (!_heap) {
+    recreateHeap(std::max(_defaultHeapSize, alignForHeap(requiredBytes)));
+  }
+
+  BufferInfo &info = bufferInfo(kind);
+
+  if (info.buffer && requiredBytes <= info.capacity && info.options == options &&
+      info.usage == usage) {
+    return info.buffer;
+  }
+
+  NS::UInteger requiredCapacity = alignForHeap(requiredBytes);
+  if (requiredCapacity > _heapSize) {
+    NS::UInteger newSize = std::max(requiredCapacity, _heapSize);
+    if (newSize == 0)
+      newSize = _defaultHeapSize == 0 ? kDefaultHeapSizeBytes : _defaultHeapSize;
+
+    while (newSize < requiredCapacity) {
+      newSize *= 2;
+    }
+
+    recreateHeap(newSize);
+  }
+
+  releaseBuffer(info);
+
+  if (!_heap)
+    return nullptr;
+
+  MTL::Buffer *buffer = _heap->newBuffer(requiredCapacity, options);
+  if (!buffer)
+    return nullptr;
+
+  if (label) {
+    using NS::StringEncoding::UTF8StringEncoding;
+    buffer->setLabel(NS::String::string(label, UTF8StringEncoding));
+  }
+
+  info.buffer = buffer;
+  info.capacity = requiredCapacity;
+  info.options = options;
+  info.usage = usage;
+
+  return buffer;
+}
+
+void GpuHeapResources::releaseBuffer(BufferInfo &info) {
+  if (info.buffer) {
+    info.buffer->release();
+    info.buffer = nullptr;
+  }
+  info.capacity = 0;
+  info.options = MTL::ResourceStorageModePrivate;
+  info.usage = MTL::ResourceUsage(0);
+}
+
+GpuHeapResources::BufferInfo &GpuHeapResources::bufferInfo(BufferKind kind) {
+  switch (kind) {
+  case BufferKind::Vertex:
+    return _vertex;
+  case BufferKind::Index:
+    return _index;
+  }
+  return _vertex;
+}
+
+NS::UInteger GpuHeapResources::alignForHeap(NS::UInteger size) const {
+  if (size == 0)
+    return alignUp(_defaultHeapSize == 0 ? kDefaultHeapSizeBytes : _defaultHeapSize,
+                   kHeapAlignment);
+  return alignUp(size, kHeapAlignment);
+}
+
+void GpuHeapResources::recreateHeap(NS::UInteger newSize) {
+  releaseBuffer(_vertex);
+  releaseBuffer(_index);
+
+  if (_heap) {
+    _heap->release();
+    _heap = nullptr;
+  }
+
+  if (!_device) {
+    _heapSize = 0;
+    return;
+  }
+
+  MTL::HeapDescriptor *desc = MTL::HeapDescriptor::alloc()->init();
+  desc->setSize(newSize);
+  desc->setStorageMode(_storageMode);
+  desc->setHazardTrackingMode(_hazardMode);
+
+  _heap = _device->newHeap(desc);
+  desc->release();
+
+  _heapSize = _heap ? _heap->size() : 0;
+}
+
+} // namespace MetalCppPathTracer
+

--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -411,6 +411,11 @@ Renderer::~Renderer() {
   if (_pAdaptiveSamplingPSO)
     _pAdaptiveSamplingPSO->release();
 
+  for (auto &resident : _residentObjectGpuResources) {
+    resident.resources.destroy();
+  }
+  _residentObjectGpuResources.clear();
+
   if (_pPSO)
     _pPSO->release();
   if (_pCommandQueue)
@@ -659,6 +664,15 @@ void Renderer::updateVisibleScene() {
   _objectBounds.resize(objectCount);
   _objectActive.assign(objectCount, false);
   _objectCooldown.assign(objectCount, 0);
+  _residentObjectGpuResources.resize(objectCount);
+
+  for (size_t objectIndex = 0; objectIndex < objectCount; ++objectIndex) {
+    auto &resident = _residentObjectGpuResources[objectIndex];
+    resident.byteSize = 0;
+    resident.purgeable = false;
+    resident.resident = false;
+    resident.resources.initialize(_pDevice);
+  }
 
   for (size_t objectIndex = 0; objectIndex < objectCount; ++objectIndex) {
     const SceneObject &obj = _allSceneObjects[objectIndex];

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -8,6 +8,7 @@
 #include <simd/simd.h>
 #include <vector>
 
+#include "GpuHeapResources.h"
 #include "Scene.h"
 
 namespace MetalCppPathTracer {
@@ -17,6 +18,13 @@ struct BlasInstanceRecord {
   uint32_t primitiveBase;
   uint32_t primitiveCount;
   uint32_t primitiveIndexBase;
+};
+
+struct ResidentObjectGpuResources {
+  GpuHeapResources resources;
+  size_t byteSize = 0;
+  bool purgeable = false;
+  bool resident = false;
 };
 
 class Renderer {
@@ -157,6 +165,8 @@ private:
   std::vector<uint32_t> _residentRemap;
   std::vector<size_t> _recentlyActivated;
   std::vector<size_t> _recentlyDeactivated;
+
+  std::vector<ResidentObjectGpuResources> _residentObjectGpuResources;
 
   uint32_t _rayHitRebuildCooldown = 0;
 


### PR DESCRIPTION
## Summary
- add a reusable `GpuHeapResources` helper that owns a Metal heap and heap-backed buffers
- extend renderer residency tracking with per-object GPU heap slots ready for future allocations
- ensure the per-object resources are initialized when the scene loads and cleaned up during shutdown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd13955748832da4c1c7e194f17d58