### PR TITLE
Fix Metal headers and resource usage enums

### DIFF
--- a/MetalCpp Path Tracer/Renderer/GpuHeapResources.h
+++ b/MetalCpp Path Tracer/Renderer/GpuHeapResources.h
@@ -32,11 +32,11 @@ public:
   MTL::Buffer *ensureVertexBuffer(
       NS::UInteger requiredBytes, const char *label = nullptr,
       MTL::ResourceOptions options = MTL::ResourceStorageModePrivate,
-      MTL::ResourceUsage usage = MTL::ResourceUsage::ResourceUsageRead);
+      MTL::ResourceUsage usage = MTL::ResourceUsageRead);
   MTL::Buffer *ensureIndexBuffer(
       NS::UInteger requiredBytes, const char *label = nullptr,
       MTL::ResourceOptions options = MTL::ResourceStorageModePrivate,
-      MTL::ResourceUsage usage = MTL::ResourceUsage::ResourceUsageRead);
+      MTL::ResourceUsage usage = MTL::ResourceUsageRead);
   MTL::AccelerationStructure *ensureAccelerationStructure(
       NS::UInteger requiredSize, const char *label = nullptr);
 
@@ -59,7 +59,7 @@ private:
     MTL::Buffer *buffer = nullptr;
     NS::UInteger capacity = 0;
     MTL::ResourceOptions options = MTL::ResourceStorageModePrivate;
-    MTL::ResourceUsage usage = MTL::ResourceUsage(0);
+    MTL::ResourceUsage usage = static_cast<MTL::ResourceUsage>(0);
   };
 
   void releaseBuffer(BufferInfo &info);

--- a/MetalCpp Path Tracer/Renderer/GpuHeapResources.mm
+++ b/MetalCpp Path Tracer/Renderer/GpuHeapResources.mm
@@ -196,7 +196,7 @@ void GpuHeapResources::releaseBuffer(BufferInfo &info) {
   }
   info.capacity = 0;
   info.options = MTL::ResourceStorageModePrivate;
-  info.usage = MTL::ResourceUsage(0);
+  info.usage = static_cast<MTL::ResourceUsage>(0);
 }
 
 void GpuHeapResources::releaseAccelerationStructure() {

--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -7,7 +7,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <CoreFoundation/CoreFoundation.hpp>
+#include <CoreFoundation/CoreFoundation.h>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
## Summary
- replace the unavailable CoreFoundation C++ header include with the standard C header
- update Metal resource usage defaults to use the unscoped option constants
- ensure default resource usage flags are initialized with explicit casts

## Testing
- not run (platform-specific build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd188465f8832d9da8c2fa4c834895