### PR TITLE
Fix Metal resource usage defaults and NS array handling

### DIFF
--- a/MetalCpp Path Tracer/Renderer/GpuHeapResources.h
+++ b/MetalCpp Path Tracer/Renderer/GpuHeapResources.h
@@ -32,11 +32,13 @@ public:
   MTL::Buffer *ensureVertexBuffer(
       NS::UInteger requiredBytes, const char *label = nullptr,
       MTL::ResourceOptions options = MTL::ResourceStorageModePrivate,
-      MTL::ResourceUsage usage = MTL::ResourceUsageRead);
+      MTL::ResourceUsage usage =
+          static_cast<MTL::ResourceUsage>(MTL::ResourceUsageRead));
   MTL::Buffer *ensureIndexBuffer(
       NS::UInteger requiredBytes, const char *label = nullptr,
       MTL::ResourceOptions options = MTL::ResourceStorageModePrivate,
-      MTL::ResourceUsage usage = MTL::ResourceUsageRead);
+      MTL::ResourceUsage usage =
+          static_cast<MTL::ResourceUsage>(MTL::ResourceUsageRead));
   MTL::AccelerationStructure *ensureAccelerationStructure(
       NS::UInteger requiredSize, const char *label = nullptr);
 

--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -787,9 +787,9 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
   std::string vertexLabel = "ObjectVertices_" + std::to_string(objectIndex);
   std::string indexLabel = "ObjectIndices_" + std::to_string(objectIndex);
 
-  CFTypeRef descriptorRefs[] = {reinterpret_cast<CFTypeRef>(geometryDesc)};
-  NS::Array *geometryArray = static_cast<NS::Array *>(CFArrayCreate(
-      kCFAllocatorDefault, descriptorRefs, 1, &kCFTypeArrayCallBacks));
+  NS::Object *descriptorObjects[] = {geometryDesc};
+  NS::Array *geometryArray =
+      NS::Array::alloc()->init(descriptorObjects, 1);
 
   MTL::PrimitiveAccelerationStructureDescriptor *accelDesc =
       MTL::PrimitiveAccelerationStructureDescriptor::alloc()->init();
@@ -824,7 +824,7 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
 
   if (!accelerationStructure || !vertexBuffer || !indexBuffer) {
     if (geometryArray)
-      CFRelease(geometryArray);
+      geometryArray->release();
     geometryDesc->release();
     accelDesc->release();
     cleanupPool();
@@ -866,7 +866,7 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
     if (vertexStaging)
       vertexStaging->release();
     if (geometryArray)
-      CFRelease(geometryArray);
+      geometryArray->release();
     geometryDesc->release();
     accelDesc->release();
     cleanupPool();
@@ -888,7 +888,7 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
     if (vertexStaging)
       vertexStaging->release();
     if (geometryArray)
-      CFRelease(geometryArray);
+      geometryArray->release();
     geometryDesc->release();
     accelDesc->release();
     cleanupPool();
@@ -922,7 +922,7 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
     if (vertexStaging)
       vertexStaging->release();
     if (geometryArray)
-      CFRelease(geometryArray);
+      geometryArray->release();
     geometryDesc->release();
     accelDesc->release();
     cleanupPool();
@@ -943,7 +943,7 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
   if (vertexStaging)
     vertexStaging->release();
   if (geometryArray)
-    CFRelease(geometryArray);
+    geometryArray->release();
   geometryDesc->release();
   accelDesc->release();
 


### PR DESCRIPTION
## Summary
- fix default Metal resource usage arguments by explicitly casting the read usage flag
- replace Core Foundation array creation with native NS::Array allocation and release logic

## Testing
- not run (platform-specific build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd192e17b0832d9c478d92c3a68d9f