### PR TITLE
Grant ResidentObjectGpuResources access to buildObjectBlas

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -42,6 +42,8 @@ struct ResidentObjectGpuResources {
 };
 
 class Renderer {
+  friend struct ResidentObjectGpuResources;
+
 public:
   Renderer(MTL::Device *pDevice);
   ~Renderer();


### PR DESCRIPTION
## Summary
- expose Renderer::buildObjectBlas to ResidentObjectGpuResources by declaring the struct as a friend

## Testing
- xcodebuild -project 'MetalCpp Path Tracer.xcodeproj' *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd20037d0c832d80636f324c822df8