### PR TITLE
Avoid setting purgeable state on heap-managed resources

### DIFF
--- a/MetalCpp Path Tracer/Renderer/GpuHeapResources.mm
+++ b/MetalCpp Path Tracer/Renderer/GpuHeapResources.mm
@@ -96,6 +96,11 @@ void GpuHeapResources::releaseAllAllocations() {
 }
 
 void GpuHeapResources::makeResourcesPurgeable() {
+  if (_heap) {
+    _heap->setPurgeableState(MTL::PurgeableStateEmpty);
+    return;
+  }
+
   if (_vertex.buffer)
     _vertex.buffer->setPurgeableState(MTL::PurgeableStateEmpty);
   if (_index.buffer)


### PR DESCRIPTION
## Summary
- update makeResourcesPurgeable to mark the heap purgeable instead of heap-allocated buffers
- keep purgeable calls for rare non-heap allocations when no heap is present

## Testing
- not run (Metal renderer workflow requires macOS/Metal runtime)

------
https://chatgpt.com/codex/tasks/task_e_68dd210c0ae0832da179696a0bc39ab5