### PR TITLE
Fix fillBuffer overload usage in Renderer

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1313,7 +1313,8 @@ void Renderer::updateTopLevelAccelerationStructure(
       instanceDesc->release();
       return;
     }
-    enc->fillBuffer(instanceBuffer, 0, instanceBuffer->length(), 0);
+    enc->fillBuffer(instanceBuffer,
+                    NS::Range::Make(0, instanceBuffer->length()), 0);
   }
 
   if (blit)


### PR DESCRIPTION
## Summary
- switch the instance buffer clear in Renderer::rebuildResidentResources to the NS::Range-based fillBuffer overload

## Testing
- xcodebuild -list -project 'MetalCpp Path Tracer.xcodeproj' *(fails: xcodebuild not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2c0f56b4832d9b586abb8f76c3fc