### PR TITLE
Fix Metal shader namespace usage

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -4,6 +4,9 @@
 #include <metal_stdlib>
 #include <metal_raytracing>
 
+using namespace metal;
+using namespace metal::raytracing;
+
 struct v2f
 {
     float4 position [[position]];


### PR DESCRIPTION
## Summary
- add using directives for metal and metal::raytracing in the shader structs header so `acceleration_structure` resolves consistently

## Testing
- ⚠️ `xcodebuild -project 'MetalCpp Path Tracer.xcodeproj'` *(fails in container: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3417a198832db40b341b93a2e1db