### PR TITLE
Move path tracing into compute pipeline

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -485,6 +485,8 @@ Renderer::~Renderer() {
   if (_pTextureClearBuffer)
     _pTextureClearBuffer->release();
 
+  if (_pPathTracePSO)
+    _pPathTracePSO->release();
   if (_pAdaptiveSamplingPSO)
     _pAdaptiveSamplingPSO->release();
 
@@ -519,6 +521,10 @@ void Renderer::buildShaders() {
     _pPSO->release();
     _pPSO = nullptr;
   }
+  if (_pPathTracePSO) {
+    _pPathTracePSO->release();
+    _pPathTracePSO = nullptr;
+  }
   if (_pAdaptiveSamplingPSO) {
     _pAdaptiveSamplingPSO->release();
     _pAdaptiveSamplingPSO = nullptr;
@@ -535,7 +541,7 @@ void Renderer::buildShaders() {
   MTL::Function *pVertexFn = pLibrary->newFunction(
       NS::String::string("vertexMain", UTF8StringEncoding));
   MTL::Function *pFragFn = pLibrary->newFunction(
-      NS::String::string("fragmentMain", UTF8StringEncoding));
+      NS::String::string("presentMain", UTF8StringEncoding));
 
   MTL::RenderPipelineDescriptor *pDesc =
       MTL::RenderPipelineDescriptor::alloc()->init();
@@ -548,6 +554,17 @@ void Renderer::buildShaders() {
   if (!_pPSO) {
     __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
     assert(false);
+  }
+
+  pError = nullptr;
+  MTL::Function *pPathTraceFn = pLibrary->newFunction(
+      NS::String::string("pathTraceKernel", UTF8StringEncoding));
+  if (pPathTraceFn) {
+    _pPathTracePSO = _pDevice->newComputePipelineState(pPathTraceFn, &pError);
+    if (!_pPathTracePSO && pError) {
+      __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
+    }
+    pPathTraceFn->release();
   }
 
   pError = nullptr;
@@ -2913,31 +2930,52 @@ void Renderer::draw(MTK::View *pView) {
 
   updateAdaptiveSamplingMaps(pCmd);
 
+  if (_pPathTracePSO && haveAllTextures) {
+    MTL::ComputeCommandEncoder *pCompute = pCmd->computeCommandEncoder();
+    if (pCompute) {
+      pCompute->setComputePipelineState(_pPathTracePSO);
+      pCompute->setBuffer(_pBVHBuffer, 0, 0);
+      pCompute->setBuffer(_pSphereBuffer, 0, 1);
+      pCompute->setBuffer(_pSphereMaterialBuffer, 0, 2);
+      pCompute->setBuffer(_pUniformsBuffer, 0, 3);
+      pCompute->setBuffer(_pTriangleVertexBuffer, 0, 4);
+      pCompute->setBuffer(_pTriangleIndexBuffer, 0, 5);
+      pCompute->setBuffer(_pPrimitiveIndexBuffer, 0, 6);
+      pCompute->setBuffer(_pTLASBuffer, 0, 7);
+      pCompute->setBuffer(_pActiveBuffer, 0, 8);
+      pCompute->setBuffer(_pLightIndexBuffer, 0, 9);
+      pCompute->setBuffer(_pLightCdfBuffer, 0, 10);
+      pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
+      pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
+      pCompute->setBuffer(_pInstanceBuffer, 0, 13);
+      pCompute->setTexture(accum0, 0);
+      pCompute->setTexture(accum1, 1);
+      pCompute->setTexture(sampleCount, 2);
+      pCompute->setTexture(sampleImportance, 3);
+
+      NS::UInteger width = accum1 ? accum1->width() : 0;
+      NS::UInteger height = accum1 ? accum1->height() : 0;
+      if (width > 0 && height > 0) {
+        NS::UInteger tgWidth = std::max<NS::UInteger>(1, _pPathTracePSO->threadExecutionWidth());
+        NS::UInteger maxThreads = std::max<NS::UInteger>(tgWidth,
+            _pPathTracePSO->maxTotalThreadsPerThreadgroup());
+        NS::UInteger tgHeight = std::max<NS::UInteger>(1, maxThreads / tgWidth);
+        MTL::Size threadsPerThreadgroup = MTL::Size::Make(tgWidth, tgHeight, 1);
+        MTL::Size threadgroups = MTL::Size::Make(
+            (width + threadsPerThreadgroup.width - 1) / threadsPerThreadgroup.width,
+            (height + threadsPerThreadgroup.height - 1) / threadsPerThreadgroup.height, 1);
+        pCompute->dispatchThreadgroups(threadgroups, threadsPerThreadgroup);
+      }
+
+      pCompute->endEncoding();
+    }
+  }
+
   MTL::RenderPassDescriptor *pRpd = pView->currentRenderPassDescriptor();
   MTL::RenderCommandEncoder *pEnc = pCmd->renderCommandEncoder(pRpd);
 
   pEnc->setRenderPipelineState(_pPSO);
-
-  // Always bind something for each slot
-  pEnc->setFragmentBuffer(_pBVHBuffer, 0, 0); // New!
-  pEnc->setFragmentBuffer(_pSphereBuffer, 0, 1);
-  pEnc->setFragmentBuffer(_pSphereMaterialBuffer, 0, 2);
-  pEnc->setFragmentBuffer(_pUniformsBuffer, 0, 3);
-  pEnc->setFragmentBuffer(_pTriangleVertexBuffer, 0, 4);
-  pEnc->setFragmentBuffer(_pTriangleIndexBuffer, 0, 5);
-  pEnc->setFragmentBuffer(_pPrimitiveIndexBuffer, 0, 6);
-  pEnc->setFragmentBuffer(_pTLASBuffer, 0, 7);
-  pEnc->setFragmentBuffer(_pActiveBuffer, 0, 8);
-  pEnc->setFragmentBuffer(_pLightIndexBuffer, 0, 9);
-  pEnc->setFragmentBuffer(_pLightCdfBuffer, 0, 10);
-  pEnc->setFragmentBuffer(_pPrimitiveRemapBuffer, 0, 11);
-  pEnc->setFragmentBuffer(_pPrimitiveHitBufferGPU, 0, 12);
-  pEnc->setFragmentBuffer(_pInstanceBuffer, 0, 13);
-
-  pEnc->setFragmentTexture(accum0, 0);
-  pEnc->setFragmentTexture(accum1, 1);
-  pEnc->setFragmentTexture(sampleCount, 2);
-  pEnc->setFragmentTexture(sampleImportance, 3);
+  pEnc->setFragmentTexture(accum1, 0);
 
   pEnc->drawPrimitives(MTL::PrimitiveType::PrimitiveTypeTriangle,
                        NS::UInteger(0), NS::UInteger(6));

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -117,6 +117,7 @@ private:
   MTL::Device *_pDevice = nullptr;
   MTL::CommandQueue *_pCommandQueue = nullptr;
   MTL::RenderPipelineState *_pPSO = nullptr;
+  MTL::ComputePipelineState *_pPathTracePSO = nullptr;
   MTL::ComputePipelineState *_pAdaptiveSamplingPSO = nullptr;
 
   // Core scene and geometry data

--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -1,109 +1,11 @@
 #include <metal_stdlib>
-#include <metal_raytracing>
+
 using namespace metal;
-using metal::raytracing::ray;
 
-#include "PathTracing.h"
+#include "Structs.h"
 
-float4 fragment fragmentMain(
-    v2f in [[stage_in]],
-    device const float4* bvhNodes [[buffer(0)]],          // <--- ADD THIS LINE
-    device const float4* primitives [[buffer(1)]],
-    device const float4* materials [[buffer(2)]],
-    device const UniformsData* uniforms [[buffer(3)]],
-    device const float3* vertexBuffer [[buffer(4)]],
-    device const uint3* indexBuffer [[buffer(5)]],
-    device const int* primitiveIndices [[buffer(6)]],
-    device const float4* tlasNodes [[buffer(7)]],
-    device const uchar* activeMask [[buffer(8)]],
-    device const uint* lightIndices [[buffer(9)]],
-    device const float* lightCdf [[buffer(10)]],
-    device const uint* primitiveRemap [[buffer(11)]],
-    device atomic_uint* primitiveHitCounts [[buffer(12)]],
-    device const InstanceRecord* instanceRecords [[buffer(13)]],
-    texture2d<half, access::read_write> lastFrame [[texture(0)]],
-    texture2d<half, access::read_write> currentFrame [[texture(1)]],
-    texture2d<half, access::read_write> sampleCount [[texture(2)]],
-    texture2d<half, access::read> sampleImportance [[texture(3)]])
-
-{
-    const device UniformsData& u = *uniforms;
-
-    uint32_t seed = random(in.uv, u.randomSeed.xyz) * ((uint32_t)-1);
-
-    uint2 coord = uint2(in.uv * u.screenSize);
-
-    float desiredSamples = float(sampleImportance.read(coord).x);
-    if (!isfinite(desiredSamples))
-    {
-        desiredSamples = float(u.minSamplesPerPixel);
-    }
-
-    uint samplesThisFrame = uint(round(desiredSamples));
-    samplesThisFrame = clamp(samplesThisFrame, u.minSamplesPerPixel, u.maxSamplesPerPixel);
-    samplesThisFrame = max(samplesThisFrame, 1u);
-
-    float previousSampleCount = float(sampleCount.read(coord).x);
-    float4 previousColor = float4(lastFrame.read(coord));
-
-    float4 accumulatedColor = float4(0.0);
-
-    float3 rayDx = u.rayDx;
-    float3 rayDy = u.rayDy;
-
-    for (uint sample = 0; sample < samplesThisFrame; ++sample)
-    {
-        float xOff = (randomFloat(seed) - 0.5) / u.screenSize.x;
-        seed = random(seed);
-        float yOff = (randomFloat(seed) - 0.5) / u.screenSize.y;
-        seed = random(seed);
-
-        float3 rayDir = (
-            u.firstPixelPosition +
-            (in.uv.x + xOff) * u.viewportU +
-            (in.uv.y + yOff) * u.viewportV
-        ) - u.cameraPosition;
-
-        ray r{u.cameraPosition, normalize(rayDir)};
-        r.min_distance = 0.0001;
-        r.max_distance = INFINITY;
-
-        accumulatedColor += rayColor(
-            r,
-            rayDx,
-            rayDy,
-            tlasNodes,
-            u.tlasNodeCount,
-            bvhNodes,
-            primitives,
-            materials,
-            u.primitiveCount,
-            primitiveIndices,
-            activeMask,
-            instanceRecords,
-            lightIndices,
-            lightCdf,
-            primitiveRemap,
-            primitiveHitCounts,
-            seed,
-            u.maxRayDepth,
-            u.debugAS,
-            u.blasNodeCount,
-            u.lightCount,
-            u.lightTotalWeight,
-            static_cast<uint>(u.totalPrimitiveCount)
-        );
-    }
-
-    float totalSamples = previousSampleCount + float(samplesThisFrame);
-    float3 previousSum = previousColor.xyz * previousSampleCount;
-    float3 combinedSum = previousSum + accumulatedColor.xyz;
-    float3 averaged = (totalSamples > 0.0f) ? combinedSum / totalSamples : float3(0.0);
-    averaged = clamp(averaged, 0.0, 1.0);
-
-    float4 result = float4(averaged, 1.0);
-    currentFrame.write(half4(result), coord);
-    sampleCount.write(half4(totalSamples, half(0.0), half(0.0), half(0.0)), coord);
-
-    return result;
+fragment float4 presentMain(v2f in [[stage_in]],
+                             texture2d<half, access::sample> accumulation [[texture(0)]]) {
+  constexpr sampler linearSampler(filter::linear, address::clamp_to_edge);
+  return float4(accumulation.sample(linearSampler, in.uv));
 }

--- a/MetalCpp Path Tracer/Renderer/Shaders/Intersect.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Intersect.h
@@ -7,7 +7,7 @@ using namespace metal;
 #include "Structs.h"
 
 // Sphere intersection (your original function)
-inline float sphereIntersection(thread const ray &ray, device const float4 &sphere)
+inline float sphereIntersection(thread const Ray &ray, device const float4 &sphere)
 {
     const float3 sphereCenter = sphere.xyz;
     const float r = sphere.w;
@@ -25,10 +25,10 @@ inline float sphereIntersection(thread const ray &ray, device const float4 &sphe
 
     float root = (h - sqrtDiscriminant) / a;
 
-    if (ray.min_distance > root || ray.max_distance < root)
+    if (ray.minDistance > root || ray.maxDistance < root)
     {
         root = (h + sqrtDiscriminant) / a;
-        if (ray.max_distance < root || ray.min_distance > root)
+        if (ray.maxDistance < root || ray.minDistance > root)
         {
             return INFINITY;
         }
@@ -40,7 +40,7 @@ inline float sphereIntersection(thread const ray &ray, device const float4 &sphe
 
 // Triangle intersection (Möller–Trumbore)
 inline bool triangleIntersection(
-    thread const ray &ray,
+    thread const Ray &ray,
     float3 v0,
     float3 v1,
     float3 v2,
@@ -73,7 +73,7 @@ inline bool triangleIntersection(
 
     float t = f * dot(edge2, q);
 
-    if (t < ray.min_distance || t > ray.max_distance)
+    if (t < ray.minDistance || t > ray.maxDistance)
         return false;
 
     // Valid intersection
@@ -84,7 +84,7 @@ inline bool triangleIntersection(
 
 // Rectangle intersection
 inline bool rectangleIntersection(
-    thread const ray &ray,
+    thread const Ray &ray,
     float3 center,
     float3 e1,
     float3 e2,
@@ -97,7 +97,7 @@ inline bool rectangleIntersection(
         return false;
 
     float t = dot(center - ray.origin, normal) / denom;
-    if (t < ray.min_distance || t > ray.max_distance)
+    if (t < ray.minDistance || t > ray.maxDistance)
         return false;
 
     float3 pHit = ray.origin + t * ray.direction;

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -1,0 +1,97 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+#include "PathTracing.h"
+
+kernel void pathTraceKernel(
+    device const float4 *bvhNodes [[buffer(0)]],
+    device const float4 *primitives [[buffer(1)]],
+    device const float4 *materials [[buffer(2)]],
+    device const UniformsData *uniforms [[buffer(3)]],
+    device const float3 *vertexBuffer [[buffer(4)]],
+    device const uint3 *indexBuffer [[buffer(5)]],
+    device const int *primitiveIndices [[buffer(6)]],
+    device const float4 *tlasNodes [[buffer(7)]],
+    device const uchar *activeMask [[buffer(8)]],
+    device const uint *lightIndices [[buffer(9)]],
+    device const float *lightCdf [[buffer(10)]],
+    device const uint *primitiveRemap [[buffer(11)]],
+    device atomic_uint *primitiveHitCounts [[buffer(12)]],
+    device const InstanceRecord *instanceRecords [[buffer(13)]],
+    texture2d<half, access::read> lastFrame [[texture(0)]],
+    texture2d<half, access::write> currentFrame [[texture(1)]],
+    texture2d<half, access::read_write> sampleCount [[texture(2)]],
+    texture2d<half, access::read> sampleImportance [[texture(3)]],
+    uint2 gid [[thread_position_in_grid]]) {
+  if (!uniforms)
+    return;
+
+  if (vertexBuffer) {
+  }
+  if (indexBuffer) {
+  }
+
+  uint width = currentFrame.get_width();
+  uint height = currentFrame.get_height();
+  if (gid.x >= width || gid.y >= height)
+    return;
+
+  const device UniformsData &u = *uniforms;
+  float2 screenSize = float2(u.screenSize);
+  if (screenSize.x <= 0.0f || screenSize.y <= 0.0f)
+    return;
+
+  float2 uv = (float2(gid) + 0.5f) / screenSize;
+  uint32_t seed = random(uv, u.randomSeed.xyz) * ((uint32_t)-1);
+
+  float desiredSamples = float(sampleImportance.read(gid).x);
+  if (!isfinite(desiredSamples))
+    desiredSamples = float(u.minSamplesPerPixel);
+
+  uint samplesThisFrame = uint(round(desiredSamples));
+  samplesThisFrame = clamp(samplesThisFrame, u.minSamplesPerPixel, u.maxSamplesPerPixel);
+  samplesThisFrame = max(samplesThisFrame, 1u);
+
+  float previousSampleCount = float(sampleCount.read(gid).x);
+  float4 previousColor = float4(lastFrame.read(gid));
+
+  float4 accumulatedColor = float4(0.0);
+
+  float3 rayDx = u.rayDx;
+  float3 rayDy = u.rayDy;
+
+  for (uint sample = 0; sample < samplesThisFrame; ++sample) {
+    float xOff = (randomFloat(seed) - 0.5f) / screenSize.x;
+    seed = random(seed);
+    float yOff = (randomFloat(seed) - 0.5f) / screenSize.y;
+    seed = random(seed);
+
+    float3 rayDir = (u.firstPixelPosition + (uv.x + xOff) * u.viewportU +
+                     (uv.y + yOff) * u.viewportV) -
+                    u.cameraPosition;
+
+    Ray r;
+    r.origin = u.cameraPosition;
+    r.direction = normalize(rayDir);
+    r.minDistance = 0.0001f;
+    r.maxDistance = INFINITY;
+
+    accumulatedColor += rayColor(r, rayDx, rayDy, tlasNodes, u.tlasNodeCount, bvhNodes,
+                                 primitives, materials, u.primitiveCount, primitiveIndices,
+                                 activeMask, instanceRecords, lightIndices, lightCdf,
+                                 primitiveRemap, primitiveHitCounts, seed, u.maxRayDepth,
+                                 u.debugAS, u.blasNodeCount, u.lightCount,
+                                 u.lightTotalWeight, static_cast<uint>(u.totalPrimitiveCount));
+  }
+
+  float totalSamples = previousSampleCount + float(samplesThisFrame);
+  float3 previousSum = previousColor.xyz * previousSampleCount;
+  float3 combinedSum = previousSum + accumulatedColor.xyz;
+  float3 averaged = (totalSamples > 0.0f) ? combinedSum / totalSamples : float3(0.0f);
+  averaged = clamp(averaged, 0.0f, 1.0f);
+
+  float4 result = float4(averaged, 1.0f);
+  currentFrame.write(half4(result), gid);
+  sampleCount.write(half4(totalSamples, half(0.0f), half(0.0f), half(0.0f)), gid);
+}

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -2,17 +2,23 @@
 #define PATH_TRACING_H
 
 #include <metal_atomic>
-#include <metal_raytracing>
 #include <metal_stdlib>
 
 #define M_PI 3.14159265358979323846
+
+using namespace metal;
+
+struct Ray {
+  float3 origin;
+  float3 direction;
+  float minDistance = 0.0f;
+  float maxDistance = 0.0f;
+};
 
 #include "Intersect.h"
 #include "Random.h"
 #include "Scatter.h"
 #include "Structs.h"
-
-using namespace metal;
 
 template <typename T> inline void swap(thread T &a, thread T &b) {
   T tmp = a;
@@ -121,7 +127,7 @@ inline bool sampleLightPoint(int primitiveType, float4 p0, float4 p1, float4 p2,
 }
 
 // BVH intersection helper
-inline bool intersectAABB(thread const ray &r, float3 bmin, float3 bmax,
+inline bool intersectAABB(thread const Ray &r, float3 bmin, float3 bmax,
                           float tMin, float tMax) {
   for (int i = 0; i < 3; ++i) {
     float invD = 1.0 / r.direction[i];
@@ -139,7 +145,7 @@ inline bool intersectAABB(thread const ray &r, float3 bmin, float3 bmax,
 }
 
 // BVH traversal version of firstHit
-inline intersection firstHitBVH(thread const ray &r,
+inline intersection firstHitBVH(thread const Ray &r,
                                 device const float4 *bvhNodes,
                                 device const float4 *primitives,
                                 device const int *primitiveIndices,
@@ -290,7 +296,7 @@ inline intersection firstHitBVH(thread const ray &r,
 }
 
 inline intersection firstHitTLAS(
-    thread const ray &r, device const float4 *tlasNodes, uint tlasNodeCount,
+    thread const Ray &r, device const float4 *tlasNodes, uint tlasNodeCount,
     device const float4 *bvhNodes, device const float4 *primitives,
     device const int *primitiveIndices, device const uchar *activeMask,
     device const InstanceRecord *instanceRecords) {
@@ -375,7 +381,7 @@ inline intersection firstHitTLAS(
   return bestHit;
 }
 
-inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
+inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
                        device const float4 *tlasNodes,
                        uint tlasNodeCount, device const float4 *bvhNodes,
                        device const float4 *primitives,
@@ -494,9 +500,13 @@ inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
                   float pdfSolid = pdfArea * dist2 / cosLight;
                   float totalPdf = lightPdf * pdfSolid;
                   if (totalPdf > 0.0f) {
-                    ray shadowRay;
+                    Ray shadowRay;
                     shadowRay.origin = bestHit.point + 0.0005f * offsetNormal;
                     shadowRay.direction = wi;
+                    shadowRay.minDistance = 0.0001f;
+                    shadowRay.maxDistance = dist - 0.0001f;
+                    if (shadowRay.maxDistance < shadowRay.minDistance)
+                      shadowRay.maxDistance = shadowRay.minDistance;
                     intersection shadowHit = firstHitTLAS(
                         shadowRay, tlasNodes, tlasNodeCount, bvhNodes,
                         primitives, primitiveIndices, activeMask, instanceRecords);
@@ -528,6 +538,8 @@ inline float4 rayColor(ray r, float3 rayDx, float3 rayDy,
     }
 
     r.origin = bestHit.point + 0.0001 * offsetNormal;
+    r.minDistance = 0.0001f;
+    r.maxDistance = INFINITY;
     scatter(r, bestHit, materialType, seed);
     seed = random(seed);
     absorption *= float4(albedo, 1.0);

--- a/MetalCpp Path Tracer/Renderer/Shaders/Scatter.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Scatter.h
@@ -2,7 +2,6 @@
 #define SCATTER_H
 
 #include <metal_stdlib>
-#include <metal_raytracing>
 
 #include "Random.h"
 #include "Structs.h"
@@ -19,7 +18,8 @@ inline bool mirrorAngle(float refractionIndex, thread const float3 &normal, thre
     return ((refractionIndex * sinTheta > 1.0) || (reflectance > randomFloat(seed)));
 }
 
-inline void scatter(thread ray &r, thread const intersection &i, float materialType, thread uint32_t &seed)
+inline void scatter(thread Ray &r, thread const intersection &i, float materialType,
+                    thread uint32_t &seed)
 {
     if(!materialType)
     {

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -4,7 +4,6 @@
 #include <metal_stdlib>
 
 using namespace metal;
-using namespace metal::raytracing;
 
 struct v2f
 {


### PR DESCRIPTION
## Summary
- introduce a compute kernel that performs per-pixel path tracing using the shared Ray helpers and accumulation textures
- compile and dispatch the compute pipeline before a lightweight presentation pass that samples the accumulation result
- replace uses of metal::raytracing::ray with a custom Ray struct across shader helpers

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dd404491b8832d96639e7ab87b2b63