### PR TITLE
Add geometry metadata tracking to resident GPU resources

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -49,6 +49,11 @@ void ResidentObjectGpuResources::transitionToCold(
   resources.makeResourcesPurgeable();
   resources.releaseAllAllocations();
   byteSize = 0;
+  triangleCount = 0;
+  vertexCount = 0;
+  vertexBufferOffset = 0;
+  indexBufferOffset = 0;
+  geometryValid = false;
   state = ResidencyState::Cold;
   lastStateChange = std::chrono::steady_clock::now();
   instanceRecord.primitiveBase = 0;
@@ -863,6 +868,11 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
   if (triangleCount == 0) {
     resident.resources.ensureAccelerationStructure(0, nullptr);
     resident.byteSize = 0;
+    resident.triangleCount = 0;
+    resident.vertexCount = 0;
+    resident.vertexBufferOffset = 0;
+    resident.indexBufferOffset = 0;
+    resident.geometryValid = false;
     cleanupPool();
     return true;
   }
@@ -1091,6 +1101,11 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
   accelDesc->release();
 
   resident.byteSize = totalHeapBytes;
+  resident.triangleCount = triangleCount;
+  resident.vertexCount = vertices.size();
+  resident.vertexBufferOffset = 0;
+  resident.indexBufferOffset = 0;
+  resident.geometryValid = true;
 
   cleanupPool();
   return true;

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -36,6 +36,11 @@ struct ResidentObjectGpuResources {
 
   GpuHeapResources resources;
   size_t byteSize = 0;
+  size_t triangleCount = 0;
+  size_t vertexCount = 0;
+  size_t vertexBufferOffset = 0;
+  size_t indexBufferOffset = 0;
+  bool geometryValid = false;
   ResidencyState state = ResidencyState::Cold;
   std::chrono::steady_clock::time_point lastStateChange{};
   MTL::CommandBuffer *pendingCommand = nullptr;


### PR DESCRIPTION
## Summary
- extend resident object GPU resources with geometry metadata and validity flag
- populate and clear the new metadata when building or evicting BLAS objects

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd46fdb2b4832d8a751a1b30eab0db