### PR TITLE
Add geometry handle buffer population for TLAS instances

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -472,6 +472,8 @@ Renderer::~Renderer() {
     _pLightCdfBuffer->release();
   if (_pInstanceBuffer)
     _pInstanceBuffer->release();
+  if (_pGeometryHandleBuffer)
+    _pGeometryHandleBuffer->release();
 
   _cachedInstanceDescriptors.clear();
   _cachedInstancedAccelerationStructures.clear();
@@ -2129,6 +2131,9 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       sceneObjects.size());
   std::vector<MTL::AccelerationStructure *> instancedStructures(
       sceneObjects.size(), nullptr);
+  std::vector<GeometryHandle> geometryHandles(sceneObjects.size() + 1);
+  if (!geometryHandles.empty())
+    geometryHandles[0] = GeometryHandle{};
   MTL::PackedFloat4x3 identityMatrix;
   identityMatrix[0] = MTL::PackedFloat3(1.0f, 0.0f, 0.0f);
   identityMatrix[1] = MTL::PackedFloat3(0.0f, 1.0f, 0.0f);
@@ -2160,6 +2165,29 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     }
 
     desc.mask = resident ? 0xFFu : 0u;
+
+    GeometryHandle handle{};
+    if (resident && objectIndex < _residentObjectGpuResources.size()) {
+      const auto &gpuResident = _residentObjectGpuResources[objectIndex];
+      if (gpuResident.geometryValid) {
+        MTL::Buffer *vertexBuffer = gpuResident.resources.vertexBuffer();
+        MTL::Buffer *indexBuffer = gpuResident.resources.indexBuffer();
+        if (vertexBuffer && indexBuffer) {
+          handle.vertexBufferAddress =
+              vertexBuffer->gpuAddress() + gpuResident.vertexBufferOffset;
+          handle.indexBufferAddress =
+              indexBuffer->gpuAddress() + gpuResident.indexBufferOffset;
+          handle.vertexStride = static_cast<uint32_t>(sizeof(simd::float3));
+          handle.indexStride = static_cast<uint32_t>(sizeof(uint32_t));
+          handle.vertexCount =
+              static_cast<uint32_t>(gpuResident.vertexCount);
+          handle.indexCount =
+              static_cast<uint32_t>(gpuResident.triangleCount * 3);
+          handle.instanceSlot = static_cast<uint32_t>(objectIndex + 1);
+        }
+      }
+    }
+    geometryHandles[objectIndex + 1] = handle;
   }
 
   updateTopLevelAccelerationStructure(instanceDescriptors, instancedStructures);
@@ -2333,6 +2361,25 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         dst[_instanceRecords.size()] = BlasInstanceRecord{};
     }
     markBufferModified(_pInstanceBuffer, NS::Range::Make(0, instanceBytes));
+  }
+
+  size_t geometryHandleCount = geometryHandles.size();
+  size_t geometryHandleBytes =
+      std::max<size_t>(geometryHandleCount, size_t(1)) *
+      sizeof(GeometryHandle);
+  ensureBufferCapacity(_pGeometryHandleBuffer, geometryHandleBytes,
+                       _geometryHandleBufferCapacity, allowShrink);
+  if (_pGeometryHandleBuffer) {
+    auto *dst = static_cast<GeometryHandle *>(
+        _pGeometryHandleBuffer->contents());
+    if (!geometryHandles.empty()) {
+      std::memcpy(dst, geometryHandles.data(),
+                  geometryHandles.size() * sizeof(GeometryHandle));
+    } else {
+      *dst = GeometryHandle{};
+    }
+    markBufferModified(_pGeometryHandleBuffer,
+                       NS::Range::Make(0, geometryHandleBytes));
   }
 
   size_t activeMaskCount =

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -20,6 +20,17 @@ struct BlasInstanceRecord {
   uint32_t primitiveIndexBase;
 };
 
+struct GeometryHandle {
+  uint64_t vertexBufferAddress = 0;
+  uint64_t indexBufferAddress = 0;
+  uint32_t vertexStride = 0;
+  uint32_t indexStride = 0;
+  uint32_t vertexCount = 0;
+  uint32_t indexCount = 0;
+  uint32_t instanceSlot = 0;
+  uint32_t padding = 0;
+};
+
 class Renderer;
 
 struct ResidentObjectGpuResources {
@@ -145,6 +156,7 @@ private:
   MTL::Buffer *_pLightCdfBuffer = nullptr;
   MTL::Buffer *_pInstanceBuffer = nullptr;
   MTL::Buffer *_pTlasInstanceDescriptorBuffer = nullptr;
+  MTL::Buffer *_pGeometryHandleBuffer = nullptr;
   size_t _blasNodeCount = 0;
   size_t _tlasNodeCount = 0;
   size_t _activeNodeCount = 0;
@@ -249,6 +261,7 @@ private:
   size_t _primitiveRemapBufferCapacity = 0;
   size_t _primitiveHitBufferCapacity = 0;
   size_t _instanceBufferCapacity = 0;
+  size_t _geometryHandleBufferCapacity = 0;
   size_t _primitiveHitReadbackCapacity = 0;
 
   std::chrono::high_resolution_clock::time_point _cpuStart;

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -30,6 +30,18 @@ struct InstanceRecord
     uint primitiveIndexBase;
 };
 
+struct GeometryHandle
+{
+    uint64_t vertexBufferAddress = 0;
+    uint64_t indexBufferAddress = 0;
+    uint vertexStride = 0;
+    uint indexStride = 0;
+    uint vertexCount = 0;
+    uint indexCount = 0;
+    uint instanceSlot = 0;
+    uint padding = 0;
+};
+
 
 struct UniformsData
 {


### PR DESCRIPTION
## Summary
- add a GeometryHandle struct shared with shaders to describe per-object geometry buffers
- allocate and maintain a geometry-handle buffer alongside TLAS instance descriptors, including a dummy slot for the null instance

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd47d165a4832daddd75defb67e4b4