### PR TITLE
Refine acceleration structure argument detection

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -594,7 +594,11 @@ void Renderer::buildShaders() {
           if (!argument)
             continue;
           if (argument->type() ==
-                  MTL::ArgumentType::ArgumentTypeInstanceAccelerationStructure ||
+              MTL::ArgumentType::ArgumentTypeInstanceAccelerationStructure) {
+            _useAccelerationStructureBindings = true;
+            break;
+          }
+          if (argument->type() == MTL::ArgumentType::ArgumentTypeBuffer &&
               argument->bufferDataType() ==
                   MTL::DataType::DataTypeInstanceAccelerationStructure) {
             _useAccelerationStructureBindings = true;


### PR DESCRIPTION
## Summary
- guard bufferDataType inspection with a buffer-type check in the shader argument loop
- retain acceleration-structure detection for both dedicated arguments and buffer-backed data

## Testing
- not run (Metal build environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd76bd3334832db5218702cd0421b7