### PR TITLE
Use Metal builtin pointer conversion for path tracing

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -46,7 +46,13 @@ inline float3 randomInUnitSphere(thread uint32_t &seed) {
 }
 
 inline device const uchar *addressAsPointer(uint64_t address) {
-  return as_type<device const uchar *>(address);
+  if (address == 0)
+    return nullptr;
+#if defined(__METAL_VERSION__)
+  return static_cast<device const uchar *>(__builtin_int_to_ptr(address));
+#else
+  return reinterpret_cast<device const uchar *>(address);
+#endif
 }
 
 inline bool fetchTriangleFromHandle(const device GeometryHandle &handle,
@@ -65,6 +71,8 @@ inline bool fetchTriangleFromHandle(const device GeometryHandle &handle,
                                               : static_cast<uint>(sizeof(uint));
 
   device const uchar *indexBytes = addressAsPointer(handle.indexBufferAddress);
+  if (!indexBytes)
+    return false;
   uint baseIndex = triangleIndex * 3u;
   uint i0 = 0;
   uint i1 = 0;
@@ -95,6 +103,8 @@ inline bool fetchTriangleFromHandle(const device GeometryHandle &handle,
     return false;
 
   device const uchar *vertexBytes = addressAsPointer(handle.vertexBufferAddress);
+  if (!vertexBytes)
+    return false;
   auto loadVertex = [&](uint index) -> float3 {
     device const float3 *ptr =
         reinterpret_cast<device const float3 *>(vertexBytes + index * vertexStride);


### PR DESCRIPTION
## Summary
- replace the generic `as_type` cast with Metal's integer-to-pointer conversion builtin
- guard downstream pointer usage when buffer addresses are missing

## Testing
- `xcrun -sdk macosx metal 'MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal'` *(fails: `xcrun` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7debbc40832d995e26abc8ca673c