### PR TITLE
Align uniforms struct with shader definition

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -104,6 +104,8 @@ struct UniformsData {
 
   uint64_t primitiveCount;
   uint64_t triangleCount;
+  uint64_t geometryHandleCount;
+  uint64_t instanceCount;
   uint64_t frameCount = 0;
   uint64_t totalPrimitiveCount;
   uint64_t tlasNodeCount;


### PR DESCRIPTION
## Summary
- add the geometryHandleCount and instanceCount fields to Renderer.cpp's UniformsData so it mirrors the shader header

## Testing
- xcodebuild -project 'MetalCpp Path Tracer.xcodeproj' -scheme MetalCpp -configuration Release build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7e8dd3c8832db7e6f1af2b31435b