### PR TITLE
Switch TLAS template tag to supported instancing alias

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -2,11 +2,12 @@
 #include <metal_stdlib>
 
 using namespace metal;
+using namespace metal::raytracing;
 
 #include "PathTracing.h"
 
 kernel void pathTraceKernel(
-    acceleration_structure<instance_acceleration_structure> sceneAS [[buffer(0)]],
+    acceleration_structure<instancing> sceneAS [[buffer(0)]],
     device const GeometryHandle *geometryHandles [[buffer(1)]],
     device const float4 *primitives [[buffer(2)]],
     device const float4 *materials [[buffer(3)]],


### PR DESCRIPTION
## Summary
- update the path tracing kernel TLAS parameter to use the instancing tag supported by the current Metal toolchain
- import the metal::raytracing namespace so the new acceleration_structure tag resolves cleanly

## Testing
- `xcrun -sdk macosx metal 'MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal'` *(fails: toolchain unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7f1f6030832d8cc773d2136209d9