### PR TITLE
Fix Metal pointer conversion and TLAS binding for ray tracing kernel

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -7,7 +7,7 @@ using namespace metal::raytracing;
 #include "PathTracing.h"
 
 kernel void pathTraceKernel(
-    acceleration_structure<instancing> sceneAS [[buffer(0)]],
+    acceleration_structure<raytracing::instance_acceleration_structure> sceneAS [[buffer(0)]],
     device const GeometryHandle *geometryHandles [[buffer(1)]],
     device const float4 *primitives [[buffer(2)]],
     device const float4 *materials [[buffer(3)]],

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -49,7 +49,7 @@ inline device const uchar *addressAsPointer(uint64_t address) {
   if (address == 0)
     return nullptr;
 #if defined(__METAL_VERSION__)
-  return static_cast<device const uchar *>(__builtin_int_to_ptr(address));
+  return reinterpret_cast<device const uchar *>(static_cast<ulong>(address));
 #else
   return reinterpret_cast<device const uchar *>(address);
 #endif


### PR DESCRIPTION
## Summary
- replace the shader pointer conversion helper with a Metal-compliant reinterpret cast
- tag the TLAS parameter of `pathTraceKernel` with `instance_acceleration_structure` to match the encoder binding

## Testing
- xcrun metal -c 'MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal' -o /tmp/PathTraceKernel.air *(fails: xcrun not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd80afa130832d9794fab8b4b79340