### PR TITLE
Update path trace kernel AS parameter

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -7,7 +7,7 @@ using namespace metal::raytracing;
 #include "PathTracing.h"
 
 kernel void pathTraceKernel(
-    instance_acceleration_structure sceneAS [[buffer(0)]],
+    acceleration_structure<instance_acceleration_structure> sceneAS [[buffer(0)]],
     device const GeometryHandle *geometryHandles [[buffer(1)]],
     device const float4 *primitives [[buffer(2)]],
     device const float4 *materials [[buffer(3)]],


### PR DESCRIPTION
## Summary
- switch the path tracing kernel's scene acceleration structure argument to the templated acceleration_structure type so TLAS binding is explicit

## Testing
- not run (Metal tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd876db2d8832d90c9fdbf46777ab5