### PR TITLE
Align TLAS types with Metal raytracing namespace

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -3,10 +3,12 @@
 
 using namespace metal;
 
+namespace mtlrt = metal::raytracing;
+
 #include "PathTracing.h"
 
 kernel void pathTraceKernel(
-    instance_acceleration_structure tlas [[buffer(0)]],
+    mtlrt::instance_acceleration_structure tlas [[buffer(0)]],
     device const GeometryHandle *geometryHandles [[buffer(1)]],
     device const float4 *primitives [[buffer(2)]],
     device const float4 *materials [[buffer(3)]],

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -171,7 +171,7 @@ inline bool loadTriangleFromHandle(const GeometryHandle &handle, uint primitiveL
   return true;
 }
 
-inline RayQueryResult traceRay(instance_acceleration_structure tlas,
+inline RayQueryResult traceRay(mtlrt::instance_acceleration_structure tlas,
                                device const GeometryHandle *geometryHandles,
                                device const InstanceRecord *instanceRecords,
                                device const uchar *activeMask,
@@ -251,7 +251,7 @@ inline RayQueryResult traceRay(instance_acceleration_structure tlas,
 }
 
 inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
-                       instance_acceleration_structure tlas,
+                       mtlrt::instance_acceleration_structure tlas,
                        device const GeometryHandle *geometryHandles,
                        device const float4 *primitives,
                        device const float4 *materials, uint primitiveCount,


### PR DESCRIPTION
## Summary
- update the path tracing kernel to use the Metal raytracing instance acceleration structure type
- propagate the qualified TLAS type to traceRay and rayColor for signature consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda359f540832d81344d64dcff850c