### PR TITLE
Fix Metal handle address space

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -137,7 +137,8 @@ struct RayQueryResult {
   float2 barycentrics = float2(0.0f);
 };
 
-inline bool loadTriangleFromHandle(const GeometryHandle &handle, uint primitiveLocal,
+inline bool loadTriangleFromHandle(thread const GeometryHandle &handle,
+                                   uint primitiveLocal,
                                    thread float3 &v0, thread float3 &v1,
                                    thread float3 &v2) {
   if (handle.vertexBufferAddress == 0 || handle.indexBufferAddress == 0)


### PR DESCRIPTION
## Summary
- update loadTriangleFromHandle to pass geometry handle through the thread address space to satisfy Metal rules

## Testing
- xcrun metal *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dda3d64b64832d8746d33d664b4607