### PR TITLE
Handle analytic primitives in BLAS and TLAS

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -55,6 +55,9 @@ void ResidentObjectGpuResources::transitionToCold(
   vertexCount = 0;
   vertexBufferOffset = 0;
   indexBufferOffset = 0;
+  boundingBoxCount = 0;
+  boundingBoxBufferOffset = 0;
+  boundingBoxBufferSize = 0;
   geometryValid = false;
   state = ResidencyState::Cold;
   lastStateChange = std::chrono::steady_clock::now();
@@ -432,7 +435,6 @@ Renderer::Renderer(MTL::Device *pDevice)
     : _pDevice(pDevice->retain()), _pScene(new Scene()) {
   _pCommandQueue = _pDevice->newCommandQueue();
   _tlasHeap.initialize(_pDevice);
-  _dummyBlasResources.initialize(_pDevice);
 
   Camera::reset();
 
@@ -481,10 +483,8 @@ Renderer::~Renderer() {
   _cachedInstancedAccelerationStructures.clear();
   _pTlasInstanceDescriptorBuffer = nullptr;
   _pTlasStructure = nullptr;
-  _pDummyBlas = nullptr;
 
   _tlasHeap.destroy();
-  _dummyBlasResources.destroy();
 
   for (auto &slot : _accumulationSlots)
     releaseTextureSlot(slot);
@@ -880,57 +880,184 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
   size_t first = object.firstPrimitive;
   size_t last = std::min(first + object.primitiveCount, _allPrimitives.size());
 
+  struct BoundingBox {
+    simd::float3 min;
+    simd::float3 max;
+  };
+
+  enum class GeometryKind { Triangles, BoundingBox };
+
+  struct GeometryEntry {
+    GeometryKind kind;
+    size_t localIndex = 0;
+    size_t primitiveCount = 0;
+    size_t vertexStart = 0;
+    size_t indexStart = 0;
+    size_t boundingBoxStart = 0;
+  };
+
   std::vector<simd::float3> vertices;
   std::vector<uint32_t> indices;
+  std::vector<BoundingBox> boundingBoxes;
+  std::vector<GeometryEntry> geometryEntries;
   vertices.reserve((last - first) * 3);
   indices.reserve((last - first) * 3);
+  boundingBoxes.reserve(last - first);
+  geometryEntries.reserve(last - first);
 
-  for (size_t prim = first; prim < last; ++prim) {
+  bool triangleRunActive = false;
+  GeometryEntry currentTriangleRun{};
+
+  auto flushTriangleRun = [&]() {
+    if (!triangleRunActive)
+      return;
+    geometryEntries.push_back(currentTriangleRun);
+    triangleRunActive = false;
+  };
+
+  size_t localIndex = 0;
+  for (size_t prim = first; prim < last; ++prim, ++localIndex) {
     if (prim >= _allPrimitives.size())
       break;
     const Primitive &p = _allPrimitives[prim];
-    if (p.type != PrimitiveType::Triangle)
-      continue;
 
-    uint32_t baseIndex = static_cast<uint32_t>(vertices.size());
-    vertices.push_back(p.triangle.v0);
-    vertices.push_back(p.triangle.v1);
-    vertices.push_back(p.triangle.v2);
-    indices.push_back(baseIndex + 0);
-    indices.push_back(baseIndex + 1);
-    indices.push_back(baseIndex + 2);
+    switch (p.type) {
+    case PrimitiveType::Triangle: {
+      if (!triangleRunActive) {
+        currentTriangleRun.kind = GeometryKind::Triangles;
+        currentTriangleRun.localIndex = localIndex;
+        currentTriangleRun.primitiveCount = 0;
+        currentTriangleRun.vertexStart = vertices.size();
+        currentTriangleRun.indexStart = indices.size();
+      }
+      triangleRunActive = true;
+
+      uint32_t baseIndex = static_cast<uint32_t>(vertices.size());
+      vertices.push_back(p.triangle.v0);
+      vertices.push_back(p.triangle.v1);
+      vertices.push_back(p.triangle.v2);
+      indices.push_back(baseIndex + 0);
+      indices.push_back(baseIndex + 1);
+      indices.push_back(baseIndex + 2);
+      ++currentTriangleRun.primitiveCount;
+      break;
+    }
+    case PrimitiveType::Sphere: {
+      flushTriangleRun();
+      simd::float3 center = p.sphere.center;
+      float radius = p.sphere.radius;
+      simd::float3 extent(radius, radius, radius);
+      BoundingBox box{center - extent, center + extent};
+      GeometryEntry entry{};
+      entry.kind = GeometryKind::BoundingBox;
+      entry.localIndex = localIndex;
+      entry.primitiveCount = 1;
+      entry.boundingBoxStart = boundingBoxes.size();
+      boundingBoxes.push_back(box);
+      geometryEntries.push_back(entry);
+      break;
+    }
+    case PrimitiveType::Rectangle: {
+      flushTriangleRun();
+      simd::float3 center = p.rectangle.center;
+      simd::float3 u = p.rectangle.u;
+      simd::float3 v = p.rectangle.v;
+      simd::float3 corner0 = center + u + v;
+      simd::float3 corner1 = center + u - v;
+      simd::float3 corner2 = center - u + v;
+      simd::float3 corner3 = center - u - v;
+      BoundingBox box{};
+      box.min = simd::min(simd::min(corner0, corner1), simd::min(corner2, corner3));
+      box.max = simd::max(simd::max(corner0, corner1), simd::max(corner2, corner3));
+      GeometryEntry entry{};
+      entry.kind = GeometryKind::BoundingBox;
+      entry.localIndex = localIndex;
+      entry.primitiveCount = 1;
+      entry.boundingBoxStart = boundingBoxes.size();
+      boundingBoxes.push_back(box);
+      geometryEntries.push_back(entry);
+      break;
+    }
+    }
   }
 
-  size_t triangleCount = indices.size() / 3;
+  flushTriangleRun();
 
-  if (triangleCount == 0) {
+  if (geometryEntries.empty()) {
     resident.resources.ensureAccelerationStructure(0, nullptr);
     resident.byteSize = 0;
     resident.triangleCount = 0;
     resident.vertexCount = 0;
     resident.vertexBufferOffset = 0;
     resident.indexBufferOffset = 0;
+    resident.boundingBoxCount = 0;
+    resident.boundingBoxBufferOffset = 0;
+    resident.boundingBoxBufferSize = 0;
     resident.geometryValid = false;
     cleanupPool();
     return true;
   }
 
-  NS::UInteger vertexBytes =
-      static_cast<NS::UInteger>(vertices.size() * sizeof(simd::float3));
-  NS::UInteger indexBytes =
-      static_cast<NS::UInteger>(indices.size() * sizeof(uint32_t));
+  size_t triangleCount = indices.size() / 3;
+  size_t boundingBoxCount = boundingBoxes.size();
 
-  MTL::AccelerationStructureTriangleGeometryDescriptor *geometryDesc =
-      MTL::AccelerationStructureTriangleGeometryDescriptor::alloc()->init();
-  geometryDesc->setOpaque(true);
+  size_t vertexSectionBytes = vertices.size() * sizeof(simd::float3);
+  size_t indexSectionBytes = indices.size() * sizeof(uint32_t);
+  size_t boundingBoxBytes = boundingBoxes.size() * sizeof(BoundingBox);
+  size_t boundingBoxOffset =
+      boundingBoxBytes > 0 ? alignTo(vertexSectionBytes, sizeof(simd::float4)) : 0;
+  size_t vertexBufferBytes =
+      boundingBoxBytes > 0 ? (boundingBoxOffset + boundingBoxBytes)
+                            : vertexSectionBytes;
+
+  NS::UInteger vertexBytes = static_cast<NS::UInteger>(vertexBufferBytes);
+  NS::UInteger indexBytes = static_cast<NS::UInteger>(indexSectionBytes);
+
+  resident.boundingBoxBufferOffset =
+      boundingBoxBytes > 0 ? boundingBoxOffset : 0;
+  resident.boundingBoxBufferSize = boundingBoxBytes;
 
   std::string blasLabel = "ObjectBLAS_" + std::to_string(objectIndex);
   std::string vertexLabel = "ObjectVertices_" + std::to_string(objectIndex);
   std::string indexLabel = "ObjectIndices_" + std::to_string(objectIndex);
 
-  NS::Object *descriptorObjects[] = {geometryDesc};
-  NS::Array *geometryArray =
-      NS::Array::alloc()->init(descriptorObjects, 1);
+  std::vector<MTL::AccelerationStructureGeometryDescriptor *> geometryDescriptors;
+  geometryDescriptors.reserve(geometryEntries.size());
+  for (const auto &entry : geometryEntries) {
+    if (entry.kind == GeometryKind::Triangles) {
+      auto *triDesc =
+          MTL::AccelerationStructureTriangleGeometryDescriptor::alloc()->init();
+      triDesc->setOpaque(true);
+      triDesc->setVertexStride(sizeof(simd::float3));
+      triDesc->setVertexFormat(MTL::AttributeFormat::AttributeFormatFloat3);
+      triDesc->setIndexType(MTL::IndexType::IndexTypeUInt32);
+      triDesc->setTriangleCount(static_cast<NS::UInteger>(entry.primitiveCount));
+      geometryDescriptors.push_back(triDesc);
+    } else {
+      auto *boxDesc =
+          MTL::AccelerationStructureBoundingBoxGeometryDescriptor::alloc()->init();
+      boxDesc->setBoundingBoxStride(sizeof(BoundingBox));
+      boxDesc->setBoundingBoxCount(
+          static_cast<NS::UInteger>(entry.primitiveCount));
+      geometryDescriptors.push_back(boxDesc);
+    }
+  }
+
+  std::vector<NS::Object *> descriptorObjects;
+  descriptorObjects.reserve(geometryDescriptors.size());
+  for (auto *desc : geometryDescriptors)
+    descriptorObjects.push_back(desc);
+
+  auto releaseGeometryDescriptors = [&]() {
+    for (auto *desc : geometryDescriptors) {
+      if (desc)
+        desc->release();
+    }
+    geometryDescriptors.clear();
+  };
+
+  NS::Array *geometryArray = NS::Array::alloc()->init(
+      descriptorObjects.data(), descriptorObjects.size());
 
   MTL::PrimitiveAccelerationStructureDescriptor *accelDesc =
       MTL::PrimitiveAccelerationStructureDescriptor::alloc()->init();
@@ -949,32 +1076,67 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
     if (initialHeapBytes > 0)
       resident.resources.ensureHeapCapacity(initialHeapBytes);
 
-    vertexBuffer = resident.resources.ensureVertexBuffer(vertexBytes,
-                                                        vertexLabel.c_str());
-    indexBuffer = resident.resources.ensureIndexBuffer(indexBytes,
-                                                      indexLabel.c_str());
-    return vertexBuffer && indexBuffer;
+    vertexBuffer = nullptr;
+    indexBuffer = nullptr;
+
+    if (vertexBytes > 0) {
+      vertexBuffer = resident.resources.ensureVertexBuffer(
+          vertexBytes, vertexLabel.c_str());
+      if (!vertexBuffer)
+        return false;
+    }
+
+    if (indexBytes > 0) {
+      indexBuffer = resident.resources.ensureIndexBuffer(indexBytes,
+                                                        indexLabel.c_str());
+      if (!indexBuffer)
+        return false;
+    }
+
+    return true;
   };
 
   if (!requestGeometryBuffers()) {
     if (geometryArray)
       geometryArray->release();
-    geometryDesc->release();
+    releaseGeometryDescriptors();
     accelDesc->release();
     cleanupPool();
     return false;
   }
 
-  auto configureGeometryDescriptor = [&]() {
-    geometryDesc->setVertexBuffer(vertexBuffer);
-    geometryDesc->setVertexBufferOffset(0);
-    geometryDesc->setVertexStride(sizeof(simd::float3));
-    geometryDesc->setVertexFormat(
-        MTL::AttributeFormat::AttributeFormatFloat3);
-    geometryDesc->setIndexBuffer(indexBuffer);
-    geometryDesc->setIndexBufferOffset(0);
-    geometryDesc->setIndexType(MTL::IndexType::IndexTypeUInt32);
-    geometryDesc->setTriangleCount(triangleCount);
+  auto configureGeometryDescriptors = [&]() {
+    for (size_t i = 0; i < geometryEntries.size(); ++i) {
+      const GeometryEntry &entry = geometryEntries[i];
+      auto *desc = geometryDescriptors[i];
+      if (entry.kind == GeometryKind::Triangles) {
+        auto *triDesc =
+            static_cast<MTL::AccelerationStructureTriangleGeometryDescriptor *>(
+                desc);
+        triDesc->setVertexBuffer(vertexBuffer);
+        triDesc->setVertexBufferOffset(static_cast<NS::UInteger>(
+            entry.vertexStart * sizeof(simd::float3)));
+        triDesc->setVertexStride(sizeof(simd::float3));
+        triDesc->setVertexFormat(
+            MTL::AttributeFormat::AttributeFormatFloat3);
+        triDesc->setIndexBuffer(indexBuffer);
+        triDesc->setIndexBufferOffset(static_cast<NS::UInteger>(
+            entry.indexStart * sizeof(uint32_t)));
+        triDesc->setIndexType(MTL::IndexType::IndexTypeUInt32);
+        triDesc->setTriangleCount(
+            static_cast<NS::UInteger>(entry.primitiveCount));
+      } else {
+        auto *boxDesc = static_cast<
+            MTL::AccelerationStructureBoundingBoxGeometryDescriptor *>(desc);
+        boxDesc->setBoundingBoxBuffer(vertexBuffer);
+        boxDesc->setBoundingBoxBufferOffset(static_cast<NS::UInteger>(
+            resident.boundingBoxBufferOffset +
+            entry.boundingBoxStart * sizeof(BoundingBox)));
+        boxDesc->setBoundingBoxStride(sizeof(BoundingBox));
+        boxDesc->setBoundingBoxCount(
+            static_cast<NS::UInteger>(entry.primitiveCount));
+      }
+    }
   };
 
   NS::UInteger totalHeapBytes = 0;
@@ -983,7 +1145,7 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
   MTL::SizeAndAlign heapAlign{};
 
   while (true) {
-    configureGeometryDescriptor();
+    configureGeometryDescriptors();
 
     sizes = _pDevice->accelerationStructureSizes(accelDesc);
     heapAlign = _pDevice->heapAccelerationStructureSizeAndAlign(accelDesc);
@@ -1004,7 +1166,7 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
       if (!requestGeometryBuffers()) {
         if (geometryArray)
           geometryArray->release();
-        geometryDesc->release();
+        releaseGeometryDescriptors();
         accelDesc->release();
         cleanupPool();
         return false;
@@ -1016,7 +1178,7 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
     break;
   }
 
-  configureGeometryDescriptor();
+  configureGeometryDescriptors();
 
   MTL::AccelerationStructure *accelerationStructure =
       resident.resources.ensureAccelerationStructure(
@@ -1025,7 +1187,7 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
   if (!accelerationStructure) {
     if (geometryArray)
       geometryArray->release();
-    geometryDesc->release();
+    releaseGeometryDescriptors();
     accelDesc->release();
     cleanupPool();
     return false;
@@ -1033,32 +1195,52 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
 
   MTL::Buffer *vertexStaging = nullptr;
   MTL::Buffer *indexStaging = nullptr;
-  if (vertexBytes > 0) {
-    vertexStaging =
-        _pDevice->newBuffer(vertexBytes, MTL::ResourceStorageModeShared);
+  MTL::Buffer *boundingBoxStaging = nullptr;
+  if (vertexSectionBytes > 0) {
+    vertexStaging = _pDevice->newBuffer(
+        static_cast<NS::UInteger>(vertexSectionBytes),
+        MTL::ResourceStorageModeShared);
     if (vertexStaging) {
-      std::memcpy(vertexStaging->contents(), vertices.data(), vertexBytes);
-      markBufferModified(vertexStaging, NS::Range::Make(0, vertexBytes));
+      std::memcpy(vertexStaging->contents(), vertices.data(),
+                  vertexSectionBytes);
+      markBufferModified(vertexStaging,
+                         NS::Range::Make(0, vertexSectionBytes));
     }
   }
-  if (indexBytes > 0) {
+  if (indexSectionBytes > 0) {
     indexStaging =
-        _pDevice->newBuffer(indexBytes, MTL::ResourceStorageModeShared);
+        _pDevice->newBuffer(static_cast<NS::UInteger>(indexSectionBytes),
+                             MTL::ResourceStorageModeShared);
     if (indexStaging) {
-      std::memcpy(indexStaging->contents(), indices.data(), indexBytes);
-      markBufferModified(indexStaging, NS::Range::Make(0, indexBytes));
+      std::memcpy(indexStaging->contents(), indices.data(), indexSectionBytes);
+      markBufferModified(indexStaging,
+                         NS::Range::Make(0, indexSectionBytes));
+    }
+  }
+  if (boundingBoxBytes > 0) {
+    boundingBoxStaging = _pDevice->newBuffer(
+        static_cast<NS::UInteger>(boundingBoxBytes),
+        MTL::ResourceStorageModeShared);
+    if (boundingBoxStaging) {
+      std::memcpy(boundingBoxStaging->contents(), boundingBoxes.data(),
+                  boundingBoxBytes);
+      markBufferModified(boundingBoxStaging,
+                         NS::Range::Make(0, boundingBoxBytes));
     }
   }
 
-  if ((vertexBytes > 0 && !vertexStaging) ||
-      (indexBytes > 0 && !indexStaging)) {
+  if ((vertexSectionBytes > 0 && !vertexStaging) ||
+      (indexSectionBytes > 0 && !indexStaging) ||
+      (boundingBoxBytes > 0 && !boundingBoxStaging)) {
+    if (boundingBoxStaging)
+      boundingBoxStaging->release();
     if (indexStaging)
       indexStaging->release();
     if (vertexStaging)
       vertexStaging->release();
     if (geometryArray)
       geometryArray->release();
-    geometryDesc->release();
+    releaseGeometryDescriptors();
     accelDesc->release();
     cleanupPool();
     return false;
@@ -1074,13 +1256,15 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
   if (!commandBuffer) {
     if (scratchBuffer)
       scratchBuffer->release();
+    if (boundingBoxStaging)
+      boundingBoxStaging->release();
     if (indexStaging)
       indexStaging->release();
     if (vertexStaging)
       vertexStaging->release();
     if (geometryArray)
       geometryArray->release();
-    geometryDesc->release();
+    releaseGeometryDescriptors();
     accelDesc->release();
     cleanupPool();
     return false;
@@ -1093,12 +1277,17 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
     return blitEncoder;
   };
 
-  if (vertexStaging && vertexBytes > 0)
+  if (vertexStaging && vertexSectionBytes > 0)
     ensureBlitEncoder()->copyFromBuffer(vertexStaging, 0, vertexBuffer, 0,
-                                        vertexBytes);
-  if (indexStaging && indexBytes > 0)
+                                        vertexSectionBytes);
+  if (boundingBoxStaging && boundingBoxBytes > 0)
+    ensureBlitEncoder()->copyFromBuffer(
+        boundingBoxStaging, 0, vertexBuffer,
+        static_cast<NS::UInteger>(resident.boundingBoxBufferOffset),
+        boundingBoxBytes);
+  if (indexStaging && indexSectionBytes > 0)
     ensureBlitEncoder()->copyFromBuffer(indexStaging, 0, indexBuffer, 0,
-                                        indexBytes);
+                                        indexSectionBytes);
 
   if (blitEncoder)
     blitEncoder->endEncoding();
@@ -1108,13 +1297,15 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
   if (!asEncoder) {
     if (scratchBuffer)
       scratchBuffer->release();
+    if (boundingBoxStaging)
+      boundingBoxStaging->release();
     if (indexStaging)
       indexStaging->release();
     if (vertexStaging)
       vertexStaging->release();
     if (geometryArray)
       geometryArray->release();
-    geometryDesc->release();
+    releaseGeometryDescriptors();
     accelDesc->release();
     cleanupPool();
     return false;
@@ -1129,13 +1320,15 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
 
   if (scratchBuffer)
     scratchBuffer->release();
+  if (boundingBoxStaging)
+    boundingBoxStaging->release();
   if (indexStaging)
     indexStaging->release();
   if (vertexStaging)
     vertexStaging->release();
   if (geometryArray)
     geometryArray->release();
-  geometryDesc->release();
+  releaseGeometryDescriptors();
   accelDesc->release();
 
   resident.byteSize = totalHeapBytes;
@@ -1143,194 +1336,10 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
   resident.vertexCount = vertices.size();
   resident.vertexBufferOffset = 0;
   resident.indexBufferOffset = 0;
-  resident.geometryValid = true;
+  resident.boundingBoxCount = boundingBoxCount;
+  resident.geometryValid = (triangleCount + boundingBoxCount) > 0;
 
   cleanupPool();
-  return true;
-}
-
-bool Renderer::ensureDummyBlas() {
-  if (_pDummyBlas)
-    return true;
-
-  if (!_pDevice || !_pCommandQueue)
-    return false;
-
-  _dummyBlasResources.initialize(_pDevice);
-
-  MTL::AccelerationStructureTriangleGeometryDescriptor *geometryDesc =
-      MTL::AccelerationStructureTriangleGeometryDescriptor::alloc()->init();
-  geometryDesc->setOpaque(true);
-  const NS::UInteger dummyVertexSize =
-      static_cast<NS::UInteger>(sizeof(simd::float3) * 3);
-  const NS::UInteger dummyIndexSize =
-      static_cast<NS::UInteger>(sizeof(uint32_t) * 3);
-  MTL::Buffer *dummyVertexBuffer = _dummyBlasResources.ensureVertexBuffer(
-      dummyVertexSize, "DummyBLASVertices");
-  MTL::Buffer *dummyIndexBuffer = _dummyBlasResources.ensureIndexBuffer(
-      dummyIndexSize, "DummyBLASIndices");
-  if (!dummyVertexBuffer || !dummyIndexBuffer) {
-    geometryDesc->release();
-    return false;
-  }
-  geometryDesc->setVertexStride(sizeof(simd::float3));
-  geometryDesc->setVertexFormat(MTL::AttributeFormat::AttributeFormatFloat3);
-  geometryDesc->setIndexType(MTL::IndexType::IndexTypeUInt32);
-  geometryDesc->setTriangleCount(0);
-  geometryDesc->setVertexBuffer(dummyVertexBuffer);
-  geometryDesc->setVertexBufferOffset(0);
-  geometryDesc->setIndexBuffer(dummyIndexBuffer);
-  geometryDesc->setIndexBufferOffset(0);
-
-  struct ZeroRequest {
-    MTL::Buffer *target = nullptr;
-    MTL::Buffer *staging = nullptr;
-    NS::UInteger size = 0;
-  };
-
-  ZeroRequest vertexZeroRequest;
-  ZeroRequest indexZeroRequest;
-
-  auto prepareZeroRequest = [&](MTL::Buffer *buffer, NS::UInteger size,
-                                ZeroRequest &request) -> bool {
-    if (!buffer || size == 0)
-      return true;
-
-    MTL::StorageMode storageMode = buffer->storageMode();
-    if (storageMode == MTL::StorageMode::StorageModeShared ||
-        storageMode == MTL::StorageMode::StorageModeManaged) {
-      if (void *contents = buffer->contents())
-        std::memset(contents, 0, size);
-      return true;
-    }
-
-    MTL::Buffer *staging =
-        _pDevice->newBuffer(size, MTL::ResourceStorageModeShared);
-    if (!staging)
-      return false;
-    if (void *contents = staging->contents())
-      std::memset(contents, 0, size);
-    request.target = buffer;
-    request.staging = staging;
-    request.size = size;
-    return true;
-  };
-
-  if (!prepareZeroRequest(dummyVertexBuffer, dummyVertexSize,
-                          vertexZeroRequest) ||
-      !prepareZeroRequest(dummyIndexBuffer, dummyIndexSize, indexZeroRequest)) {
-    if (vertexZeroRequest.staging)
-      vertexZeroRequest.staging->release();
-    if (indexZeroRequest.staging)
-      indexZeroRequest.staging->release();
-    geometryDesc->release();
-    return false;
-  }
-
-  NS::Object *geometryObjects[] = {geometryDesc};
-  NS::Array *geometryArray = NS::Array::alloc()->init(geometryObjects, 1);
-
-  MTL::PrimitiveAccelerationStructureDescriptor *accelDesc =
-      MTL::PrimitiveAccelerationStructureDescriptor::alloc()->init();
-  accelDesc->setGeometryDescriptors(geometryArray);
-
-  MTL::AccelerationStructureSizes sizes =
-      _pDevice->accelerationStructureSizes(accelDesc);
-
-  MTL::AccelerationStructure *structure =
-      _dummyBlasResources.ensureAccelerationStructure(
-          sizes.accelerationStructureSize, "DummyBLAS");
-
-  if (!structure) {
-    if (vertexZeroRequest.staging)
-      vertexZeroRequest.staging->release();
-    if (indexZeroRequest.staging)
-      indexZeroRequest.staging->release();
-    geometryArray->release();
-    geometryDesc->release();
-    accelDesc->release();
-    return false;
-  }
-
-  NS::UInteger scratchSize = sizes.buildScratchBufferSize;
-  MTL::Buffer *scratchBuffer = nullptr;
-  if (scratchSize > 0)
-    scratchBuffer =
-        _pDevice->newBuffer(scratchSize, MTL::ResourceStorageModePrivate);
-
-  MTL::CommandBuffer *commandBuffer = _pCommandQueue->commandBuffer();
-  if (!commandBuffer) {
-    if (scratchBuffer)
-      scratchBuffer->release();
-    if (vertexZeroRequest.staging)
-      vertexZeroRequest.staging->release();
-    if (indexZeroRequest.staging)
-      indexZeroRequest.staging->release();
-    geometryArray->release();
-    geometryDesc->release();
-    accelDesc->release();
-    return false;
-  }
-
-  if (vertexZeroRequest.staging || indexZeroRequest.staging) {
-    MTL::BlitCommandEncoder *blitEncoder = commandBuffer->blitCommandEncoder();
-    if (!blitEncoder) {
-      if (scratchBuffer)
-        scratchBuffer->release();
-      if (vertexZeroRequest.staging)
-        vertexZeroRequest.staging->release();
-      if (indexZeroRequest.staging)
-        indexZeroRequest.staging->release();
-      geometryArray->release();
-      geometryDesc->release();
-      accelDesc->release();
-      return false;
-    }
-    if (vertexZeroRequest.staging) {
-      blitEncoder->copyFromBuffer(vertexZeroRequest.staging, 0,
-                                  vertexZeroRequest.target, 0,
-                                  vertexZeroRequest.size);
-    }
-    if (indexZeroRequest.staging) {
-      blitEncoder->copyFromBuffer(indexZeroRequest.staging, 0,
-                                  indexZeroRequest.target, 0,
-                                  indexZeroRequest.size);
-    }
-    blitEncoder->endEncoding();
-  }
-
-  MTL::AccelerationStructureCommandEncoder *encoder =
-      commandBuffer->accelerationStructureCommandEncoder();
-  if (!encoder) {
-    if (scratchBuffer)
-      scratchBuffer->release();
-    if (vertexZeroRequest.staging)
-      vertexZeroRequest.staging->release();
-    if (indexZeroRequest.staging)
-      indexZeroRequest.staging->release();
-    geometryArray->release();
-    geometryDesc->release();
-    accelDesc->release();
-    return false;
-  }
-
-  encoder->buildAccelerationStructure(structure, accelDesc, scratchBuffer, 0);
-  encoder->endEncoding();
-
-  commandBuffer->commit();
-  commandBuffer->waitUntilCompleted();
-
-  if (vertexZeroRequest.staging)
-    vertexZeroRequest.staging->release();
-  if (indexZeroRequest.staging)
-    indexZeroRequest.staging->release();
-  if (scratchBuffer)
-    scratchBuffer->release();
-  geometryArray->release();
-  geometryDesc->release();
-  accelDesc->release();
-
-  _pDummyBlas = structure;
   return true;
 }
 
@@ -1340,17 +1349,9 @@ void Renderer::updateTopLevelAccelerationStructure(
   if (!_pDevice || !_pCommandQueue)
     return;
 
-  if (!ensureDummyBlas())
-    return;
-
   _tlasHeap.initialize(_pDevice);
 
-  std::vector<MTL::AccelerationStructure *> instancedStructures;
-  instancedStructures.reserve(structures.size() + 1);
-  instancedStructures.push_back(_pDummyBlas);
-  for (MTL::AccelerationStructure *structure : structures) {
-    instancedStructures.push_back(structure ? structure : _pDummyBlas);
-  }
+  std::vector<MTL::AccelerationStructure *> instancedStructures = structures;
 
   bool structureListChanged =
       instancedStructures.size() != _cachedInstancedAccelerationStructures.size();
@@ -2163,13 +2164,14 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     }
   }
 
-  std::vector<MTL::AccelerationStructureInstanceDescriptor> instanceDescriptors(
-      sceneObjects.size());
-  std::vector<MTL::AccelerationStructure *> instancedStructures(
-      sceneObjects.size(), nullptr);
-  std::vector<GeometryHandle> geometryHandles(sceneObjects.size() + 1);
-  if (!geometryHandles.empty())
-    geometryHandles[0] = GeometryHandle{};
+  std::vector<MTL::AccelerationStructureInstanceDescriptor> instanceDescriptors;
+  std::vector<MTL::AccelerationStructure *> instancedStructures;
+  std::vector<GeometryHandle> geometryHandles;
+  std::vector<BlasInstanceRecord> gpuInstanceRecords;
+  instanceDescriptors.reserve(sceneObjects.size());
+  instancedStructures.reserve(sceneObjects.size());
+  geometryHandles.reserve(sceneObjects.size());
+  gpuInstanceRecords.reserve(sceneObjects.size());
   MTL::PackedFloat4x3 identityMatrix;
   identityMatrix[0] = MTL::PackedFloat3(1.0f, 0.0f, 0.0f);
   identityMatrix[1] = MTL::PackedFloat3(0.0f, 1.0f, 0.0f);
@@ -2178,52 +2180,58 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
 
   for (size_t objectIndex = 0; objectIndex < sceneObjects.size();
        ++objectIndex) {
-    auto &desc = instanceDescriptors[objectIndex];
+    bool resident = false;
+    MTL::AccelerationStructure *structure = nullptr;
+    const auto *gpuResidentPtr =
+        (objectIndex < _residentObjectGpuResources.size())
+            ? &_residentObjectGpuResources[objectIndex]
+            : nullptr;
+    if (gpuResidentPtr) {
+      resident = gpuResidentPtr->isResident() &&
+                 objectShouldBeResident[objectIndex];
+      if (resident)
+        structure = gpuResidentPtr->resources.accelerationStructure();
+    }
+
+    const BlasInstanceRecord &record =
+        (objectIndex < _instanceRecords.size()) ? _instanceRecords[objectIndex]
+                                                : BlasInstanceRecord{};
+    if (!resident || !structure || record.primitiveCount == 0)
+      continue;
+
+    uint32_t structureIndex = static_cast<uint32_t>(instancedStructures.size());
+
+    MTL::AccelerationStructureInstanceDescriptor desc{};
     desc.transformationMatrix = identityMatrix;
     desc.options = MTL::AccelerationStructureInstanceOptionNone;
     desc.intersectionFunctionTableOffset = 0;
-    desc.accelerationStructureIndex =
-        static_cast<uint32_t>(objectIndex + 1);
+    desc.accelerationStructureIndex = structureIndex;
+    desc.mask = 0xFFu;
 
-    bool resident = false;
-    if (objectIndex < _residentObjectGpuResources.size()) {
-      const auto &gpuResident = _residentObjectGpuResources[objectIndex];
-      resident = gpuResident.isResident() && objectShouldBeResident[objectIndex];
-      if (resident) {
-        MTL::AccelerationStructure *structure =
-            gpuResident.resources.accelerationStructure();
-        if (structure) {
-          instancedStructures[objectIndex] = structure;
-        } else {
-          resident = false;
-        }
-      }
-    }
-
-    desc.mask = resident ? 0xFFu : 0u;
+    instancedStructures.push_back(structure);
+    instanceDescriptors.push_back(desc);
 
     GeometryHandle handle{};
-    if (resident && objectIndex < _residentObjectGpuResources.size()) {
-      const auto &gpuResident = _residentObjectGpuResources[objectIndex];
-      if (gpuResident.geometryValid) {
-        MTL::Buffer *vertexBuffer = gpuResident.resources.vertexBuffer();
-        MTL::Buffer *indexBuffer = gpuResident.resources.indexBuffer();
-        if (vertexBuffer && indexBuffer) {
-          handle.vertexBufferAddress =
-              vertexBuffer->gpuAddress() + gpuResident.vertexBufferOffset;
-          handle.indexBufferAddress =
-              indexBuffer->gpuAddress() + gpuResident.indexBufferOffset;
-          handle.vertexStride = static_cast<uint32_t>(sizeof(simd::float3));
-          handle.indexStride = static_cast<uint32_t>(sizeof(uint32_t));
-          handle.vertexCount =
-              static_cast<uint32_t>(gpuResident.vertexCount);
-          handle.indexCount =
-              static_cast<uint32_t>(gpuResident.triangleCount * 3);
-          handle.instanceSlot = static_cast<uint32_t>(objectIndex + 1);
-        }
+    if (gpuResidentPtr && gpuResidentPtr->geometryValid) {
+      MTL::Buffer *vertexBuffer = gpuResidentPtr->resources.vertexBuffer();
+      MTL::Buffer *indexBuffer = gpuResidentPtr->resources.indexBuffer();
+      if (vertexBuffer) {
+        handle.vertexBufferAddress =
+            vertexBuffer->gpuAddress() + gpuResidentPtr->vertexBufferOffset;
+        handle.vertexStride = static_cast<uint32_t>(sizeof(simd::float3));
+        handle.vertexCount = static_cast<uint32_t>(gpuResidentPtr->vertexCount);
       }
+      if (indexBuffer) {
+        handle.indexBufferAddress =
+            indexBuffer->gpuAddress() + gpuResidentPtr->indexBufferOffset;
+        handle.indexStride = static_cast<uint32_t>(sizeof(uint32_t));
+        handle.indexCount =
+            static_cast<uint32_t>(gpuResidentPtr->triangleCount * 3);
+      }
+      handle.instanceSlot = structureIndex;
     }
-    geometryHandles[objectIndex + 1] = handle;
+    geometryHandles.push_back(handle);
+    gpuInstanceRecords.push_back(record);
   }
 
   updateTopLevelAccelerationStructure(instanceDescriptors, instancedStructures);
@@ -2381,20 +2389,20 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     _residentBuffersInitialized = true;
   }
 
-  size_t instanceCount = std::max<size_t>(_instanceRecords.size(), size_t(1));
+  size_t instanceCount = std::max<size_t>(gpuInstanceRecords.size(), size_t(1));
   size_t instanceBytes = instanceCount * sizeof(BlasInstanceRecord);
   ensureBufferCapacity(_pInstanceBuffer, instanceBytes, _instanceBufferCapacity,
                        allowShrink);
   if (_pInstanceBuffer) {
     auto *dst = static_cast<BlasInstanceRecord *>(
         _pInstanceBuffer->contents());
-    if (_instanceRecords.empty()) {
+    if (gpuInstanceRecords.empty()) {
       dst[0] = BlasInstanceRecord{};
     } else {
-      std::memcpy(dst, _instanceRecords.data(),
-                  _instanceRecords.size() * sizeof(BlasInstanceRecord));
-      if (_instanceRecords.size() < instanceCount)
-        dst[_instanceRecords.size()] = BlasInstanceRecord{};
+      std::memcpy(dst, gpuInstanceRecords.data(),
+                  gpuInstanceRecords.size() * sizeof(BlasInstanceRecord));
+      if (gpuInstanceRecords.size() < instanceCount)
+        dst[gpuInstanceRecords.size()] = BlasInstanceRecord{};
     }
     markBufferModified(_pInstanceBuffer, NS::Range::Make(0, instanceBytes));
   }

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -51,6 +51,9 @@ struct ResidentObjectGpuResources {
   size_t vertexCount = 0;
   size_t vertexBufferOffset = 0;
   size_t indexBufferOffset = 0;
+  size_t boundingBoxCount = 0;
+  size_t boundingBoxBufferOffset = 0;
+  size_t boundingBoxBufferSize = 0;
   bool geometryValid = false;
   ResidencyState state = ResidencyState::Cold;
   std::chrono::steady_clock::time_point lastStateChange{};
@@ -122,7 +125,6 @@ private:
   void processRayHitCounters();
   bool buildObjectBlas(size_t objectIndex, const SceneObject &object,
                        ResidentObjectGpuResources &residentResources);
-  bool ensureDummyBlas();
   void updateTopLevelAccelerationStructure(
       const std::vector<MTL::AccelerationStructureInstanceDescriptor>
           &descriptors,
@@ -211,9 +213,7 @@ private:
   std::vector<ResidentObjectGpuResources> _residentObjectGpuResources;
 
   GpuHeapResources _tlasHeap;
-  GpuHeapResources _dummyBlasResources;
   MTL::AccelerationStructure *_pTlasStructure = nullptr;
-  MTL::AccelerationStructure *_pDummyBlas = nullptr;
   std::vector<MTL::AccelerationStructureInstanceDescriptor>
       _cachedInstanceDescriptors;
   std::vector<MTL::AccelerationStructure *> _cachedInstancedAccelerationStructures;

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -176,6 +176,7 @@ inline RayQueryResult traceRay(mtlrt::instance_acceleration_structure tlas,
                                device const GeometryHandle *geometryHandles,
                                device const InstanceRecord *instanceRecords,
                                device const uchar *activeMask,
+                               device const float4 *primitives,
                                uint primitiveCount, thread const Ray &r) {
   RayQueryResult result;
   result.hit.t = INFINITY;
@@ -197,54 +198,159 @@ inline RayQueryResult traceRay(mtlrt::instance_acceleration_structure tlas,
   float distance = hit.distance;
   float2 bary = hit.triangle_barycentric_coord;
 
-  if (!instanceRecords)
-    return result;
+  const float epsilon = 1e-4f;
 
-  InstanceRecord record = instanceRecords[instanceId];
-  if (record.primitiveCount == 0 || primitiveLocal >= record.primitiveCount)
-    return result;
+  float currentMin = r.minDistance;
+  float maxDistance = r.maxDistance;
 
-  uint primitiveIndex = record.primitiveBase + primitiveLocal;
-  if (primitiveIndex >= primitiveCount)
-    return result;
+  mtlrt::intersector<mtlrt::triangle_data, mtlrt::bounding_box_data,
+                     mtlrt::instancing>
+      intersector;
+  intersector.assume_geometry_type(mtlrt::geometry_type::triangle);
+  intersector.force_opacity(mtlrt::opacity::opaque);
 
-  if (activeMask && !activeMask[primitiveIndex])
-    return result;
+  while (currentMin <= maxDistance) {
+    mtlrt::ray queryRay(r.origin, r.direction, currentMin, maxDistance);
+    auto hit = intersector.intersect(queryRay, tlas);
+    if (hit.type == mtlrt::intersection_type::none)
+      break;
 
-  uint geometryIndex = instanceId + 1u;
-  GeometryHandle handle =
-      geometryHandles ? geometryHandles[geometryIndex] : GeometryHandle{};
-  float3 v0, v1, v2;
-  if (!loadTriangleFromHandle(handle, primitiveLocal, v0, v1, v2))
-    return result;
+    uint instanceId = hit.instance_id;
+    uint primitiveLocal = hit.primitive_id;
+    float hitDistance = hit.distance;
 
-  float3 edge1 = v1 - v0;
-  float3 edge2 = v2 - v0;
-  float3 normal = cross(edge1, edge2);
-  float normalLen = length(normal);
-  if (normalLen <= 0.0f)
-    return result;
-  normal /= normalLen;
+    if (!instanceRecords) {
+      currentMin = fmax(hitDistance + epsilon, currentMin + epsilon);
+      continue;
+    }
 
-  float b0 = 1.0f - bary.x - bary.y;
-  float b1 = bary.x;
-  float b2 = bary.y;
-  float3 point = b0 * v0 + b1 * v1 + b2 * v2;
+    InstanceRecord record = instanceRecords[instanceId];
+    if (record.primitiveCount == 0 || primitiveLocal >= record.primitiveCount) {
+      currentMin = fmax(hitDistance + epsilon, currentMin + epsilon);
+      continue;
+    }
 
-  bool frontFace = dot(normal, r.direction) < 0.0f;
-  float3 orientedNormal = frontFace ? normal : -normal;
+    uint primitiveIndex = record.primitiveBase + primitiveLocal;
+    if (primitiveIndex >= primitiveCount) {
+      currentMin = fmax(hitDistance + epsilon, currentMin + epsilon);
+      continue;
+    }
 
-  result.valid = true;
-  result.instanceId = instanceId;
-  result.primitiveLocal = primitiveLocal;
-  result.barycentrics = bary;
-  result.hit.t = distance;
-  result.hit.point = point;
-  result.hit.normal = orientedNormal;
-  result.hit.frontFace = frontFace;
-  result.hit.primitiveId = static_cast<int>(primitiveIndex);
-  result.hit.isTriangle = 1;
-  result.hit.nodeIndex = static_cast<int>(primitiveLocal);
+    if (activeMask && !activeMask[primitiveIndex]) {
+      currentMin = fmax(hitDistance + epsilon, currentMin + epsilon);
+      continue;
+    }
+
+    if (hit.type == mtlrt::intersection_type::triangle) {
+      uint geometryIndex = instanceId;
+      GeometryHandle handle =
+          geometryHandles ? geometryHandles[geometryIndex] : GeometryHandle{};
+      float3 v0, v1, v2;
+      if (!loadTriangleFromHandle(handle, primitiveLocal, v0, v1, v2)) {
+        currentMin = fmax(hitDistance + epsilon, currentMin + epsilon);
+        continue;
+      }
+
+      float2 bary = hit.triangle_barycentric_coord;
+      float3 edge1 = v1 - v0;
+      float3 edge2 = v2 - v0;
+      float3 normal = cross(edge1, edge2);
+      float normalLen = length(normal);
+      if (normalLen <= 0.0f) {
+        currentMin = fmax(hitDistance + epsilon, currentMin + epsilon);
+        continue;
+      }
+      normal /= normalLen;
+
+      float b0 = 1.0f - bary.x - bary.y;
+      float b1 = bary.x;
+      float b2 = bary.y;
+      float3 point = b0 * v0 + b1 * v1 + b2 * v2;
+
+      bool frontFace = dot(normal, r.direction) < 0.0f;
+      float3 orientedNormal = frontFace ? normal : -normal;
+
+      result.valid = true;
+      result.instanceId = instanceId;
+      result.primitiveLocal = primitiveLocal;
+      result.barycentrics = bary;
+      result.hit.t = hitDistance;
+      result.hit.point = point;
+      result.hit.normal = orientedNormal;
+      result.hit.frontFace = frontFace;
+      result.hit.primitiveId = static_cast<int>(primitiveIndex);
+      result.hit.isTriangle = 1;
+      result.hit.nodeIndex = static_cast<int>(primitiveLocal);
+      return result;
+    } else if (hit.type == mtlrt::intersection_type::bounding_box) {
+      if (!primitives) {
+        currentMin = fmax(hitDistance + epsilon, currentMin + epsilon);
+        continue;
+      }
+
+      uint base = primitiveIndex * 3u;
+      float4 prim0 = primitives[base + 0];
+      float4 prim1 = primitives[base + 1];
+      float4 prim2 = primitives[base + 2];
+      int primitiveType = static_cast<int>(prim0.w + 0.5f);
+
+      bool accepted = false;
+      float tHit = INFINITY;
+      float3 point = float3(0.0f);
+      float3 normal = float3(0.0f);
+      bool frontFace = false;
+
+      if (primitiveType == 0) {
+        float radius = prim1.x;
+        float4 sphereData = float4(prim0.xyz, radius);
+        float distance = sphereIntersection(r, sphereData);
+        if (isfinite(distance) && distance < INFINITY) {
+          point = r.origin + distance * r.direction;
+          float3 rawNormal = point - prim0.xyz;
+          float len = length(rawNormal);
+          if (len > 0.0f) {
+            normal = rawNormal / len;
+            frontFace = dot(normal, r.direction) < 0.0f;
+            if (!frontFace)
+              normal = -normal;
+            tHit = distance;
+            accepted = distance >= r.minDistance && distance <= r.maxDistance;
+          }
+        }
+      } else if (primitiveType == 2) {
+        float localTHit;
+        float3 rectNormal;
+        if (rectangleIntersection(r, prim0.xyz, prim1.xyz, prim2.xyz, localTHit,
+                                  rectNormal)) {
+          point = r.origin + localTHit * r.direction;
+          rectNormal = normalize(rectNormal);
+          frontFace = dot(rectNormal, r.direction) < 0.0f;
+          normal = frontFace ? rectNormal : -rectNormal;
+          tHit = localTHit;
+          accepted = true;
+        }
+      }
+
+      if (accepted && isfinite(tHit) && tHit >= r.minDistance &&
+          tHit <= r.maxDistance) {
+        result.valid = true;
+        result.instanceId = instanceId;
+        result.primitiveLocal = primitiveLocal;
+        result.barycentrics = float2(0.0f);
+        result.hit.t = tHit;
+        result.hit.point = point;
+        result.hit.normal = normal;
+        result.hit.frontFace = frontFace;
+        result.hit.primitiveId = static_cast<int>(primitiveIndex);
+        result.hit.isTriangle = 0;
+        result.hit.nodeIndex = static_cast<int>(primitiveLocal);
+        return result;
+      }
+    }
+
+    currentMin = fmax(hitDistance + epsilon, currentMin + epsilon);
+  }
+
   return result;
 }
 
@@ -268,7 +374,7 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
 
   if (debugAS == 1) {
     RayQueryResult debugHit = traceRay(tlas, geometryHandles, instanceRecords,
-                                       activeMask, primitiveCount, r);
+                                       activeMask, primitives, primitiveCount, r);
     if (debugHit.valid) {
       float denom = (tlasNodeCount > 1) ? float(tlasNodeCount - 1) : 1.0f;
       float t = denom > 0.0f ? clamp(float(debugHit.instanceId) / denom, 0.0f, 1.0f)
@@ -278,7 +384,7 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
     return float4(0.0, 0.0, 0.0, 1.0);
   } else if (debugAS == 2) {
     RayQueryResult debugHit = traceRay(tlas, geometryHandles, instanceRecords,
-                                       activeMask, primitiveCount, r);
+                                       activeMask, primitives, primitiveCount, r);
     if (debugHit.valid) {
       float denom = (blasNodeCount > 1) ? float(blasNodeCount - 1) : 1.0f;
       float key = denom > 0.0f
@@ -294,7 +400,7 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
 
   for (uint depth = 0; depth < maxRayDepth; ++depth) {
     RayQueryResult hit = traceRay(tlas, geometryHandles, instanceRecords,
-                                  activeMask, primitiveCount, r);
+                                  activeMask, primitives, primitiveCount, r);
 
     if (!hit.valid || hit.hit.primitiveId < 0) {
       float3 unitDir = normalize(r.direction);


### PR DESCRIPTION
## Summary
- generate bounding box geometry for spheres and rectangles when building BLASes and persist the associated buffers
- update the path tracing shader to resolve hardware bounding-box hits into analytic intersections
- remove the dummy BLAS path from TLAS construction and skip zero-primitive instances

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ddb61f0f1c832da487fdfb0b030181