### PR TITLE
Fix sphere extent initialization

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -928,7 +928,7 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
     }
     case PrimitiveType::Sphere: {
       simd::float3 center = p.sphere.center;
-      simd::float3 extent(p.sphere.radius, p.sphere.radius, p.sphere.radius);
+      simd::float3 extent = {p.sphere.radius, p.sphere.radius, p.sphere.radius};
       appendProceduralBounds(center - extent, center + extent);
       break;
     }


### PR DESCRIPTION
## Summary
- replace the sphere extent initialization with an aggregate initializer to avoid function-style initialization

## Testing
- g++ -std=c++17 -fsyntax-only 'MetalCpp Path Tracer/Renderer/Renderer.cpp' *(fails: Metal/Metal.hpp missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddcdd1d0e0832db13ebd8004ae9f10