### PR TITLE
Fix bounding box descriptor duplicate intersection flag

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -989,7 +989,7 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
                 ->init()
           : nullptr;
   if (boundingDesc) {
-    boundingDesc->setAllowsDuplicateIntersectionFunctionInvocation(true);
+    boundingDesc->setAllowDuplicateIntersectionFunctionInvocation(true);
   }
 
   std::string blasLabel = "ObjectBLAS_" + std::to_string(objectIndex);


### PR DESCRIPTION
## Summary
- update bounding box geometry descriptor configuration to call the correct Metal API for duplicate intersection function invocation

## Testing
- xcodebuild -project 'MetalCpp Path Tracer.xcodeproj' *(fails: command not found in Linux CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddce32e668832d949aeaae44359343