### PR TITLE
Track triangle/procedural ranges per BLAS instance

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -67,6 +67,12 @@ void ResidentObjectGpuResources::transitionToCold(
   instanceRecord.primitiveIndexBase = 0;
   instanceRecord.blasRootIndex = -1;
   instanceRecord.primitiveCount = 0;
+  instanceRecord.triangleBase = 0;
+  instanceRecord.triangleCount = 0;
+  instanceRecord.proceduralBase = 0;
+  instanceRecord.proceduralCount = 0;
+  triangleBase = 0;
+  proceduralBase = 0;
 }
 
 bool ResidentObjectGpuResources::ensureResident(
@@ -87,6 +93,11 @@ bool ResidentObjectGpuResources::ensureResident(
   clearPendingCommand();
   state = ResidencyState::Resident;
   lastStateChange = std::chrono::steady_clock::now();
+  instanceRecord.triangleBase = static_cast<uint32_t>(triangleBase);
+  instanceRecord.triangleCount = static_cast<uint32_t>(triangleCount);
+  instanceRecord.proceduralBase = static_cast<uint32_t>(proceduralBase);
+  instanceRecord.proceduralCount =
+      static_cast<uint32_t>(boundingBoxCount);
   return true;
 }
 
@@ -1894,6 +1905,9 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   std::vector<simd::float3> compactTriangleVertices;
   std::vector<simd::uint3> compactTriangleIndices;
 
+  size_t triangleLeafCursor = 0;
+  size_t proceduralLeafCursor = 0;
+
   const std::vector<simd::float4> *primitiveSource = &_cachedPrimitiveData;
   const std::vector<simd::float4> *materialSource = &_cachedMaterialData;
   const std::vector<int> *primitiveIndexSource = &_cachedPrimitiveIndices;
@@ -1923,19 +1937,29 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       record.primitiveBase = static_cast<uint32_t>(obj.firstPrimitive);
       record.primitiveCount = static_cast<uint32_t>(obj.primitiveCount);
       record.primitiveIndexBase = static_cast<uint32_t>(obj.firstPrimitive);
+      record.triangleBase = static_cast<uint32_t>(triangleLeafCursor);
+      record.proceduralBase = static_cast<uint32_t>(proceduralLeafCursor);
       bool anyActive = false;
       size_t first = obj.firstPrimitive;
       size_t last = first + obj.primitiveCount;
-      for (size_t prim = first;
-           prim < last && prim < _activePrimitive.size(); ++prim) {
-        if (_activePrimitive[prim]) {
+      size_t objectTriangleCount = 0;
+      size_t objectProceduralCount = 0;
+      for (size_t prim = first; prim < last && prim < _allPrimitives.size(); ++prim) {
+        const Primitive &p = _allPrimitives[prim];
+        if (p.type == PrimitiveType::Triangle)
+          ++objectTriangleCount;
+        else
+          ++objectProceduralCount;
+        if (prim < _activePrimitive.size() && _activePrimitive[prim])
           anyActive = true;
-          break;
-        }
       }
+      record.triangleCount = static_cast<uint32_t>(objectTriangleCount);
+      record.proceduralCount = static_cast<uint32_t>(objectProceduralCount);
       record.blasRootIndex = anyActive ? obj.blasRootIndex : -1;
       objectShouldBeResident[objectIndex] = anyActive;
       _instanceRecords[objectIndex] = record;
+      triangleLeafCursor += objectTriangleCount;
+      proceduralLeafCursor += objectProceduralCount;
     }
   } else {
     remapUpload.clear();
@@ -1970,6 +1994,10 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       record.primitiveBase = static_cast<uint32_t>(remapUpload.size());
       record.primitiveIndexBase =
           static_cast<uint32_t>(compactPrimitiveIndices.size());
+      record.triangleBase = static_cast<uint32_t>(triangleLeafCursor);
+      record.proceduralBase = static_cast<uint32_t>(proceduralLeafCursor);
+      size_t objectTriangleCount = 0;
+      size_t objectProceduralCount = 0;
 
       bool hasCache = !obj.cachedBlasNodes.empty() &&
                       !obj.cachedPrimitiveIndices.empty() &&
@@ -2017,6 +2045,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
             prim1 = simd::make_float4(
                 simd::make_float3(p.sphere.radius, 0.0f, 0.0f), 0.0f);
             prim2 = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+            ++objectProceduralCount;
             break;
           }
           case PrimitiveType::Rectangle: {
@@ -2024,6 +2053,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
                                       static_cast<float>(p.type));
             prim1 = simd::make_float4(p.rectangle.u, 0.0f);
             prim2 = simd::make_float4(p.rectangle.v, 0.0f);
+            ++objectProceduralCount;
             break;
           }
           case PrimitiveType::Triangle: {
@@ -2039,6 +2069,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
                 static_cast<uint32_t>(baseVertex),
                 static_cast<uint32_t>(baseVertex + 1),
                 static_cast<uint32_t>(baseVertex + 2)));
+            ++objectTriangleCount;
             break;
           }
           }
@@ -2060,12 +2091,16 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         }
 
         record.primitiveCount = static_cast<uint32_t>(activeCount);
+        record.triangleCount = static_cast<uint32_t>(objectTriangleCount);
+        record.proceduralCount = static_cast<uint32_t>(objectProceduralCount);
         if (activeCount == 0) {
           for (const auto &edit : residentIndexEdits)
             if (edit.first < _primitiveToResidentIndex.size())
               _primitiveToResidentIndex[edit.first] = edit.second;
           objectShouldBeResident[objectIndex] = false;
           _instanceRecords[objectIndex] = record;
+          objectTriangleCount = 0;
+          objectProceduralCount = 0;
           ++blasCacheSkipped;
           continue;
         }
@@ -2127,6 +2162,8 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
                                  rebuiltNodes.end());
           objectShouldBeResident[objectIndex] = true;
           _instanceRecords[objectIndex] = record;
+          triangleLeafCursor += objectTriangleCount;
+          proceduralLeafCursor += objectProceduralCount;
           ++blasCacheReused;
           assert(!encounteredEmptyLeaf &&
                  "Cached BLAS leaf with zero primitives reached upload");
@@ -2149,6 +2186,10 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
             _primitiveToResidentIndex[edit.first] = edit.second;
 
         record.blasRootIndex = -1;
+        objectTriangleCount = 0;
+        objectProceduralCount = 0;
+        record.triangleCount = 0;
+        record.proceduralCount = 0;
       }
 
       activeLocalPrims.reserve(obj.primitiveCount);
@@ -2165,6 +2206,8 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       if (activeLocalPrims.empty()) {
         objectShouldBeResident[objectIndex] = false;
         _instanceRecords[objectIndex] = record;
+        record.triangleCount = 0;
+        record.proceduralCount = 0;
         continue;
       }
 
@@ -2209,12 +2252,14 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
           prim1 = simd::make_float4(
               simd::make_float3(p.sphere.radius, 0.0f, 0.0f), 0.0f);
           prim2 = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+          ++objectProceduralCount;
           break;
         }
         case PrimitiveType::Rectangle: {
           prim0 = simd::make_float4(p.rectangle.center, static_cast<float>(p.type));
           prim1 = simd::make_float4(p.rectangle.u, 0.0f);
           prim2 = simd::make_float4(p.rectangle.v, 0.0f);
+          ++objectProceduralCount;
           break;
         }
         case PrimitiveType::Triangle: {
@@ -2229,6 +2274,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
               static_cast<uint32_t>(baseVertex),
               static_cast<uint32_t>(baseVertex + 1),
               static_cast<uint32_t>(baseVertex + 2)));
+          ++objectTriangleCount;
           break;
         }
         }
@@ -2272,8 +2318,14 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       }
 
       record.blasRootIndex = static_cast<int32_t>(nodeBase);
+      record.triangleCount = static_cast<uint32_t>(objectTriangleCount);
+      record.proceduralCount = static_cast<uint32_t>(objectProceduralCount);
       objectShouldBeResident[objectIndex] = record.primitiveCount > 0;
       _instanceRecords[objectIndex] = record;
+      if (record.primitiveCount > 0) {
+        triangleLeafCursor += objectTriangleCount;
+        proceduralLeafCursor += objectProceduralCount;
+      }
     }
 
     printf("BLAS cache stats: reused %zu, rebuilt %zu, skipped %zu\n",
@@ -2309,6 +2361,9 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     bool shouldBeResident = objectShouldBeResident[objectIndex];
     auto &gpuResident = _residentObjectGpuResources[objectIndex];
     auto &instanceRecord = _instanceRecords[objectIndex];
+
+    gpuResident.triangleBase = instanceRecord.triangleBase;
+    gpuResident.proceduralBase = instanceRecord.proceduralBase;
 
     if (shouldBeResident) {
       bool built = gpuResident.ensureResident(
@@ -2367,6 +2422,19 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     GeometryHandle handle{};
     if (resident && objectIndex < _residentObjectGpuResources.size()) {
       const auto &gpuResident = _residentObjectGpuResources[objectIndex];
+      if (gpuResident.boundingBoxCount > 0)
+        desc.intersectionFunctionTableOffset =
+            _instanceRecords[objectIndex].proceduralBase;
+      else
+        desc.intersectionFunctionTableOffset = 0;
+      handle.triangleBase = _instanceRecords[objectIndex].triangleBase;
+      handle.triangleCount = _instanceRecords[objectIndex].triangleCount;
+      handle.proceduralBase = _instanceRecords[objectIndex].proceduralBase;
+      handle.proceduralCount = _instanceRecords[objectIndex].proceduralCount;
+      handle.boundingBoxCount =
+          static_cast<uint32_t>(gpuResident.boundingBoxCount);
+      handle.boundingBoxStride =
+          static_cast<uint32_t>(sizeof(MTL::AxisAlignedBoundingBox));
       if (gpuResident.geometryValid) {
         MTL::Buffer *vertexBuffer = gpuResident.resources.vertexBuffer();
         MTL::Buffer *indexBuffer = gpuResident.resources.indexBuffer();
@@ -2375,6 +2443,11 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
               vertexBuffer->gpuAddress() + gpuResident.vertexBufferOffset;
           handle.indexBufferAddress =
               indexBuffer->gpuAddress() + gpuResident.indexBufferOffset;
+          if (gpuResident.boundingBoxBuffer) {
+            handle.boundingBoxBufferAddress =
+                gpuResident.boundingBoxBuffer->gpuAddress() +
+                gpuResident.boundingBoxBufferOffset;
+          }
           handle.vertexStride = static_cast<uint32_t>(sizeof(simd::float3));
           handle.indexStride = static_cast<uint32_t>(sizeof(uint32_t));
           handle.vertexCount =

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -18,17 +18,30 @@ struct BlasInstanceRecord {
   uint32_t primitiveBase;
   uint32_t primitiveCount;
   uint32_t primitiveIndexBase;
+  uint32_t triangleBase;
+  uint32_t triangleCount;
+  uint32_t proceduralBase;
+  uint32_t proceduralCount;
 };
 
 struct GeometryHandle {
   uint64_t vertexBufferAddress = 0;
   uint64_t indexBufferAddress = 0;
+  uint64_t boundingBoxBufferAddress = 0;
   uint32_t vertexStride = 0;
   uint32_t indexStride = 0;
+  uint32_t boundingBoxStride = 0;
   uint32_t vertexCount = 0;
   uint32_t indexCount = 0;
+  uint32_t boundingBoxCount = 0;
+  uint32_t triangleBase = 0;
+  uint32_t triangleCount = 0;
+  uint32_t proceduralBase = 0;
+  uint32_t proceduralCount = 0;
   uint32_t instanceSlot = 0;
-  uint32_t padding = 0;
+  uint32_t padding0 = 0;
+  uint32_t padding1 = 0;
+  uint32_t padding2 = 0;
 };
 
 class Renderer;
@@ -55,6 +68,8 @@ struct ResidentObjectGpuResources {
   size_t boundingBoxBufferCapacity = 0;
   size_t boundingBoxBufferOffset = 0;
   size_t boundingBoxCount = 0;
+  size_t triangleBase = 0;
+  size_t proceduralBase = 0;
   bool geometryValid = false;
   ResidencyState state = ResidencyState::Cold;
   std::chrono::steady_clock::time_point lastStateChange{};

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -28,18 +28,31 @@ struct InstanceRecord
     uint primitiveBase;
     uint primitiveCount;
     uint primitiveIndexBase;
+    uint triangleBase;
+    uint triangleCount;
+    uint proceduralBase;
+    uint proceduralCount;
 };
 
 struct GeometryHandle
 {
     uint64_t vertexBufferAddress = 0;
     uint64_t indexBufferAddress = 0;
+    uint64_t boundingBoxBufferAddress = 0;
     uint vertexStride = 0;
     uint indexStride = 0;
+    uint boundingBoxStride = 0;
     uint vertexCount = 0;
     uint indexCount = 0;
+    uint boundingBoxCount = 0;
+    uint triangleBase = 0;
+    uint triangleCount = 0;
+    uint proceduralBase = 0;
+    uint proceduralCount = 0;
     uint instanceSlot = 0;
-    uint padding = 0;
+    uint padding0 = 0;
+    uint padding1 = 0;
+    uint padding2 = 0;
 };
 
 


### PR DESCRIPTION
## Summary
- extend BLAS instance records to track triangle/procedural ranges and propagate them when residency changes
- keep running triangle/procedural offsets while rebuilding resident resources and set intersection function offsets for procedural geometry
- upload expanded geometry handles with bounding-box buffer metadata aligned to instance IDs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddcec12aa8832da34c3f10ecf4eab1