### PR TITLE
Refocus path tracing on triangle mesh data

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -56,10 +56,6 @@ void ResidentObjectGpuResources::transitionToCold(
   vertexCount = 0;
   vertexBufferOffset = 0;
   indexBufferOffset = 0;
-  boundingBoxBuffer = nullptr;
-  boundingBoxBufferCapacity = 0;
-  boundingBoxBufferOffset = 0;
-  boundingBoxCount = 0;
   geometryValid = false;
   state = ResidencyState::Cold;
   lastStateChange = std::chrono::steady_clock::now();
@@ -69,10 +65,7 @@ void ResidentObjectGpuResources::transitionToCold(
   instanceRecord.primitiveCount = 0;
   instanceRecord.triangleBase = 0;
   instanceRecord.triangleCount = 0;
-  instanceRecord.proceduralBase = 0;
-  instanceRecord.proceduralCount = 0;
   triangleBase = 0;
-  proceduralBase = 0;
 }
 
 bool ResidentObjectGpuResources::ensureResident(
@@ -95,9 +88,6 @@ bool ResidentObjectGpuResources::ensureResident(
   lastStateChange = std::chrono::steady_clock::now();
   instanceRecord.triangleBase = static_cast<uint32_t>(triangleBase);
   instanceRecord.triangleCount = static_cast<uint32_t>(triangleCount);
-  instanceRecord.proceduralBase = static_cast<uint32_t>(proceduralBase);
-  instanceRecord.proceduralCount =
-      static_cast<uint32_t>(boundingBoxCount);
   return true;
 }
 
@@ -422,10 +412,10 @@ Renderer::Renderer(MTL::Device *pDevice)
 }
 
 Renderer::~Renderer() {
-  if (_pSphereBuffer)
-    _pSphereBuffer->release();
-  if (_pSphereMaterialBuffer)
-    _pSphereMaterialBuffer->release();
+  if (_pPrimitiveBuffer)
+    _pPrimitiveBuffer->release();
+  if (_pMaterialBuffer)
+    _pMaterialBuffer->release();
   if (_pTriangleVertexBuffer)
     _pTriangleVertexBuffer->release();
   if (_pTriangleIndexBuffer)
@@ -851,10 +841,8 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
 
   std::vector<simd::float3> vertices;
   std::vector<uint32_t> indices;
-  std::vector<MTL::AxisAlignedBoundingBox> proceduralBoundingBoxes;
   vertices.reserve((last - first) * 3);
   indices.reserve((last - first) * 3);
-  proceduralBoundingBoxes.reserve(0);
 
   for (size_t prim = first; prim < last; ++prim) {
     if (prim >= _allPrimitives.size())
@@ -878,19 +866,13 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
   }
 
   size_t triangleCount = indices.size() / 3;
-  size_t proceduralCount = proceduralBoundingBoxes.size();
-  if (triangleCount == 0 && proceduralCount == 0) {
+  if (triangleCount == 0) {
     resident.resources.ensureAccelerationStructure(0, nullptr);
-    resident.resources.ensureBoundingBoxBuffer(0, nullptr);
     resident.byteSize = 0;
     resident.triangleCount = 0;
     resident.vertexCount = 0;
     resident.vertexBufferOffset = 0;
     resident.indexBufferOffset = 0;
-    resident.boundingBoxBuffer = nullptr;
-    resident.boundingBoxBufferCapacity = 0;
-    resident.boundingBoxBufferOffset = 0;
-    resident.boundingBoxCount = 0;
     resident.geometryValid = false;
     cleanupPool();
     return true;
@@ -900,8 +882,6 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
       static_cast<NS::UInteger>(vertices.size() * sizeof(simd::float3));
   NS::UInteger indexBytes =
       static_cast<NS::UInteger>(indices.size() * sizeof(uint32_t));
-  NS::UInteger boundingBoxBytes = static_cast<NS::UInteger>(
-      proceduralBoundingBoxes.size() * sizeof(MTL::AxisAlignedBoundingBox));
   MTL::AccelerationStructureTriangleGeometryDescriptor *geometryDesc =
       triangleCount > 0
           ? MTL::AccelerationStructureTriangleGeometryDescriptor::alloc()
@@ -910,37 +890,20 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
   if (geometryDesc)
     geometryDesc->setOpaque(true);
 
-  MTL::AccelerationStructureBoundingBoxGeometryDescriptor *boundingDesc =
-      proceduralCount > 0
-          ? MTL::AccelerationStructureBoundingBoxGeometryDescriptor::alloc()
-                ->init()
-          : nullptr;
-  if (boundingDesc) {
-    boundingDesc->setAllowDuplicateIntersectionFunctionInvocation(true);
-  }
-
   std::string blasLabel = "ObjectBLAS_" + std::to_string(objectIndex);
   std::string vertexLabel = "ObjectVertices_" + std::to_string(objectIndex);
   std::string indexLabel = "ObjectIndices_" + std::to_string(objectIndex);
-  std::string boundingLabel =
-      "ObjectBounds_" + std::to_string(objectIndex);
 
   auto releaseGeometryDescriptors = [&]() {
     if (geometryDesc) {
       geometryDesc->release();
       geometryDesc = nullptr;
     }
-    if (boundingDesc) {
-      boundingDesc->release();
-      boundingDesc = nullptr;
-    }
   };
 
   std::vector<NS::Object *> descriptorObjects;
   if (geometryDesc)
     descriptorObjects.push_back(geometryDesc);
-  if (boundingDesc)
-    descriptorObjects.push_back(boundingDesc);
 
   if (descriptorObjects.empty()) {
     releaseGeometryDescriptors();
@@ -959,18 +922,11 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
       vertexBytes > 0 ? resident.resources.alignedHeapSize(vertexBytes) : 0;
   NS::UInteger alignedIndexSize =
       indexBytes > 0 ? resident.resources.alignedHeapSize(indexBytes) : 0;
-  NS::UInteger alignedBoundingBoxSize = boundingBoxBytes > 0
-                                            ? resident.resources.alignedHeapSize(
-                                                  boundingBoxBytes)
-                                            : 0;
-
   MTL::Buffer *vertexBuffer = nullptr;
   MTL::Buffer *indexBuffer = nullptr;
-  MTL::Buffer *boundingBoxBuffer = nullptr;
 
   auto requestGeometryBuffers = [&]() -> bool {
-    NS::UInteger initialHeapBytes =
-        alignedVertexSize + alignedIndexSize + alignedBoundingBoxSize;
+    NS::UInteger initialHeapBytes = alignedVertexSize + alignedIndexSize;
     if (initialHeapBytes > 0)
       resident.resources.ensureHeapCapacity(initialHeapBytes);
 
@@ -990,16 +946,6 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
         return false;
     } else {
       indexBuffer = nullptr;
-    }
-
-    if (boundingBoxBytes > 0) {
-      boundingBoxBuffer = resident.resources.ensureBoundingBoxBuffer(
-          boundingBoxBytes, boundingLabel.c_str());
-      if (!boundingBoxBuffer)
-        return false;
-    } else {
-      boundingBoxBuffer = nullptr;
-      resident.resources.ensureBoundingBoxBuffer(0, nullptr);
     }
 
     return true;
@@ -1026,14 +972,6 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
       geometryDesc->setIndexType(MTL::IndexType::IndexTypeUInt32);
       geometryDesc->setTriangleCount(triangleCount);
     }
-    if (boundingDesc) {
-      boundingDesc->setBoundingBoxBuffer(boundingBoxBuffer);
-      boundingDesc->setBoundingBoxBufferOffset(0);
-      boundingDesc->setBoundingBoxStride(
-          sizeof(MTL::AxisAlignedBoundingBox));
-      boundingDesc->setBoundingBoxCount(
-          static_cast<NS::UInteger>(proceduralCount));
-    }
   };
 
   NS::UInteger totalHeapBytes = 0;
@@ -1053,8 +991,8 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
     alignedAccelerationSize =
         resident.resources.alignedHeapSize(alignedAccelerationSize);
 
-    NS::UInteger requiredTotal = alignedAccelerationSize + alignedVertexSize +
-                                 alignedIndexSize + alignedBoundingBoxSize;
+    NS::UInteger requiredTotal =
+        alignedAccelerationSize + alignedVertexSize + alignedIndexSize;
 
     if (requiredTotal > totalHeapBytes) {
       totalHeapBytes = requiredTotal;
@@ -1092,7 +1030,6 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
 
   MTL::Buffer *vertexStaging = nullptr;
   MTL::Buffer *indexStaging = nullptr;
-  MTL::Buffer *boundingBoxStaging = nullptr;
   if (vertexBytes > 0) {
     vertexStaging =
         _pDevice->newBuffer(vertexBytes, MTL::ResourceStorageModeShared);
@@ -1109,27 +1046,12 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
       markBufferModified(indexStaging, NS::Range::Make(0, indexBytes));
     }
   }
-  if (boundingBoxBytes > 0) {
-    boundingBoxStaging = _pDevice->newBuffer(boundingBoxBytes,
-                                             MTL::ResourceStorageModeShared);
-    if (boundingBoxStaging) {
-      std::memcpy(boundingBoxStaging->contents(),
-                  proceduralBoundingBoxes.data(),
-                  boundingBoxBytes);
-      markBufferModified(boundingBoxStaging,
-                         NS::Range::Make(0, boundingBoxBytes));
-    }
-  }
-
   if ((vertexBytes > 0 && !vertexStaging) ||
-      (indexBytes > 0 && !indexStaging) ||
-      (boundingBoxBytes > 0 && !boundingBoxStaging)) {
+      (indexBytes > 0 && !indexStaging)) {
     if (indexStaging)
       indexStaging->release();
     if (vertexStaging)
       vertexStaging->release();
-    if (boundingBoxStaging)
-      boundingBoxStaging->release();
     if (geometryArray)
       geometryArray->release();
     releaseGeometryDescriptors();
@@ -1152,8 +1074,6 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
       indexStaging->release();
     if (vertexStaging)
       vertexStaging->release();
-    if (boundingBoxStaging)
-      boundingBoxStaging->release();
     if (geometryArray)
       geometryArray->release();
     releaseGeometryDescriptors();
@@ -1175,11 +1095,6 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
   if (indexStaging && indexBytes > 0)
     ensureBlitEncoder()->copyFromBuffer(indexStaging, 0, indexBuffer, 0,
                                         indexBytes);
-  if (boundingBoxStaging && boundingBoxBytes > 0 && boundingBoxBuffer)
-    ensureBlitEncoder()->copyFromBuffer(boundingBoxStaging, 0,
-                                        boundingBoxBuffer, 0,
-                                        boundingBoxBytes);
-
   if (blitEncoder)
     blitEncoder->endEncoding();
 
@@ -1192,8 +1107,6 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
       indexStaging->release();
     if (vertexStaging)
       vertexStaging->release();
-    if (boundingBoxStaging)
-      boundingBoxStaging->release();
     if (geometryArray)
       geometryArray->release();
     releaseGeometryDescriptors();
@@ -1215,8 +1128,6 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
     indexStaging->release();
   if (vertexStaging)
     vertexStaging->release();
-  if (boundingBoxStaging)
-    boundingBoxStaging->release();
   if (geometryArray)
     geometryArray->release();
   releaseGeometryDescriptors();
@@ -1227,11 +1138,6 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
   resident.vertexCount = vertices.size();
   resident.vertexBufferOffset = 0;
   resident.indexBufferOffset = 0;
-  resident.boundingBoxBuffer = resident.resources.boundingBoxBuffer();
-  resident.boundingBoxBufferCapacity =
-      resident.resources.boundingBoxCapacity();
-  resident.boundingBoxBufferOffset = 0;
-  resident.boundingBoxCount = proceduralBoundingBoxes.size();
   resident.geometryValid = true;
 
   cleanupPool();
@@ -1801,7 +1707,6 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   std::vector<simd::uint3> compactTriangleIndices;
 
   size_t triangleLeafCursor = 0;
-  size_t proceduralLeafCursor = 0;
 
   const std::vector<simd::float4> *primitiveSource = &_cachedPrimitiveData;
   const std::vector<simd::float4> *materialSource = &_cachedMaterialData;
@@ -1833,24 +1738,20 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       record.primitiveCount = static_cast<uint32_t>(obj.primitiveCount);
       record.primitiveIndexBase = static_cast<uint32_t>(obj.firstPrimitive);
       record.triangleBase = static_cast<uint32_t>(triangleLeafCursor);
-      record.proceduralBase = static_cast<uint32_t>(proceduralLeafCursor);
       bool anyActive = false;
       size_t first = obj.firstPrimitive;
       size_t last = first + obj.primitiveCount;
       size_t objectTriangleCount = 0;
-      size_t objectProceduralCount = 0;
       for (size_t prim = first; prim < last && prim < _allPrimitives.size(); ++prim) {
         ++objectTriangleCount;
         if (prim < _activePrimitive.size() && _activePrimitive[prim])
           anyActive = true;
       }
       record.triangleCount = static_cast<uint32_t>(objectTriangleCount);
-      record.proceduralCount = static_cast<uint32_t>(objectProceduralCount);
       record.blasRootIndex = anyActive ? obj.blasRootIndex : -1;
       objectShouldBeResident[objectIndex] = anyActive;
       _instanceRecords[objectIndex] = record;
       triangleLeafCursor += objectTriangleCount;
-      proceduralLeafCursor += objectProceduralCount;
     }
   } else {
     remapUpload.clear();
@@ -1886,9 +1787,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       record.primitiveIndexBase =
           static_cast<uint32_t>(compactPrimitiveIndices.size());
       record.triangleBase = static_cast<uint32_t>(triangleLeafCursor);
-      record.proceduralBase = static_cast<uint32_t>(proceduralLeafCursor);
       size_t objectTriangleCount = 0;
-      size_t objectProceduralCount = 0;
 
       bool hasCache = !obj.cachedBlasNodes.empty() &&
                       !obj.cachedPrimitiveIndices.empty() &&
@@ -1958,7 +1857,6 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
 
         record.primitiveCount = static_cast<uint32_t>(activeCount);
         record.triangleCount = static_cast<uint32_t>(objectTriangleCount);
-        record.proceduralCount = static_cast<uint32_t>(objectProceduralCount);
         if (activeCount == 0) {
           for (const auto &edit : residentIndexEdits)
             if (edit.first < _primitiveToResidentIndex.size())
@@ -1966,7 +1864,6 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
           objectShouldBeResident[objectIndex] = false;
           _instanceRecords[objectIndex] = record;
           objectTriangleCount = 0;
-          objectProceduralCount = 0;
           ++blasCacheSkipped;
           continue;
         }
@@ -2029,7 +1926,6 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
           objectShouldBeResident[objectIndex] = true;
           _instanceRecords[objectIndex] = record;
           triangleLeafCursor += objectTriangleCount;
-          proceduralLeafCursor += objectProceduralCount;
           ++blasCacheReused;
           assert(!encounteredEmptyLeaf &&
                  "Cached BLAS leaf with zero primitives reached upload");
@@ -2053,9 +1949,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
 
         record.blasRootIndex = -1;
         objectTriangleCount = 0;
-        objectProceduralCount = 0;
         record.triangleCount = 0;
-        record.proceduralCount = 0;
       }
 
       activeLocalPrims.reserve(obj.primitiveCount);
@@ -2073,7 +1967,6 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         objectShouldBeResident[objectIndex] = false;
         _instanceRecords[objectIndex] = record;
         record.triangleCount = 0;
-        record.proceduralCount = 0;
         continue;
       }
 
@@ -2163,12 +2056,10 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
 
       record.blasRootIndex = static_cast<int32_t>(nodeBase);
       record.triangleCount = static_cast<uint32_t>(objectTriangleCount);
-      record.proceduralCount = static_cast<uint32_t>(objectProceduralCount);
       objectShouldBeResident[objectIndex] = record.primitiveCount > 0;
       _instanceRecords[objectIndex] = record;
       if (record.primitiveCount > 0) {
         triangleLeafCursor += objectTriangleCount;
-        proceduralLeafCursor += objectProceduralCount;
       }
     }
 
@@ -2207,7 +2098,6 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     auto &instanceRecord = _instanceRecords[objectIndex];
 
     gpuResident.triangleBase = instanceRecord.triangleBase;
-    gpuResident.proceduralBase = instanceRecord.proceduralBase;
 
     if (shouldBeResident) {
       bool built = gpuResident.ensureResident(
@@ -2266,19 +2156,9 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     GeometryHandle handle{};
     if (resident && objectIndex < _residentObjectGpuResources.size()) {
       const auto &gpuResident = _residentObjectGpuResources[objectIndex];
-      if (gpuResident.boundingBoxCount > 0)
-        desc.intersectionFunctionTableOffset =
-            _instanceRecords[objectIndex].proceduralBase;
-      else
-        desc.intersectionFunctionTableOffset = 0;
+      desc.intersectionFunctionTableOffset = 0;
       handle.triangleBase = _instanceRecords[objectIndex].triangleBase;
       handle.triangleCount = _instanceRecords[objectIndex].triangleCount;
-      handle.proceduralBase = _instanceRecords[objectIndex].proceduralBase;
-      handle.proceduralCount = _instanceRecords[objectIndex].proceduralCount;
-      handle.boundingBoxCount =
-          static_cast<uint32_t>(gpuResident.boundingBoxCount);
-      handle.boundingBoxStride =
-          static_cast<uint32_t>(sizeof(MTL::AxisAlignedBoundingBox));
       if (gpuResident.geometryValid) {
         MTL::Buffer *vertexBuffer = gpuResident.resources.vertexBuffer();
         MTL::Buffer *indexBuffer = gpuResident.resources.indexBuffer();
@@ -2287,11 +2167,6 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
               vertexBuffer->gpuAddress() + gpuResident.vertexBufferOffset;
           handle.indexBufferAddress =
               indexBuffer->gpuAddress() + gpuResident.indexBufferOffset;
-          if (gpuResident.boundingBoxBuffer) {
-            handle.boundingBoxBufferAddress =
-                gpuResident.boundingBoxBuffer->gpuAddress() +
-                gpuResident.boundingBoxBufferOffset;
-          }
           handle.vertexStride = static_cast<uint32_t>(sizeof(simd::float3));
           handle.indexStride = static_cast<uint32_t>(sizeof(uint32_t));
           handle.vertexCount =
@@ -2317,28 +2192,29 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     size_t primitiveBytes =
         std::max<size_t>(primitiveFloat4Count, size_t(1)) *
         sizeof(simd::float4);
-    ensureBufferCapacity(_pSphereBuffer, primitiveBytes, _sphereBufferCapacity,
-                         allowShrink);
-    if (_pSphereBuffer) {
+    ensureBufferCapacity(_pPrimitiveBuffer, primitiveBytes,
+                         _primitiveBufferCapacity, allowShrink);
+    if (_pPrimitiveBuffer) {
       simd::float4 *dst =
-          static_cast<simd::float4 *>(_pSphereBuffer->contents());
+          static_cast<simd::float4 *>(_pPrimitiveBuffer->contents());
       if (primitiveFloat4Count > 0)
         std::memcpy(dst, primitiveSource->data(),
                     primitiveFloat4Count * sizeof(simd::float4));
       else
         dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-      markBufferModified(_pSphereBuffer, NS::Range::Make(0, primitiveBytes));
+      markBufferModified(_pPrimitiveBuffer,
+                         NS::Range::Make(0, primitiveBytes));
     }
 
     size_t materialFloat4Count = materialSource->size();
     size_t materialBytes =
         std::max<size_t>(materialFloat4Count, size_t(1)) *
         sizeof(simd::float4);
-    ensureBufferCapacity(_pSphereMaterialBuffer, materialBytes,
-                         _sphereMaterialBufferCapacity, allowShrink);
-    if (_pSphereMaterialBuffer) {
-      simd::float4 *dst = static_cast<simd::float4 *>(
-          _pSphereMaterialBuffer->contents());
+    ensureBufferCapacity(_pMaterialBuffer, materialBytes,
+                         _materialBufferCapacity, allowShrink);
+    if (_pMaterialBuffer) {
+      simd::float4 *dst =
+          static_cast<simd::float4 *>(_pMaterialBuffer->contents());
       if (materialFloat4Count > 0)
         std::memcpy(dst, materialSource->data(),
                     materialFloat4Count * sizeof(simd::float4));
@@ -2347,7 +2223,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         if (materialBytes >= 2 * sizeof(simd::float4))
           dst[1] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
       }
-      markBufferModified(_pSphereMaterialBuffer,
+      markBufferModified(_pMaterialBuffer,
                          NS::Range::Make(0, materialBytes));
     }
 
@@ -3148,8 +3024,8 @@ void Renderer::draw(MTK::View *pView) {
       pCompute->setBuffer(useAccelerationStructureLayout ? _pGeometryHandleBuffer
                                                          : nullptr,
                           0, 1);
-      pCompute->setBuffer(_pSphereBuffer, 0, 2);
-      pCompute->setBuffer(_pSphereMaterialBuffer, 0, 3);
+      pCompute->setBuffer(_pPrimitiveBuffer, 0, 2);
+      pCompute->setBuffer(_pMaterialBuffer, 0, 3);
       pCompute->setBuffer(_pUniformsBuffer, 0, 4);
       pCompute->setBuffer(_pActiveBuffer, 0, 5);
       pCompute->setBuffer(_pLightIndexBuffer, 0, 6);

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -20,28 +20,18 @@ struct BlasInstanceRecord {
   uint32_t primitiveIndexBase;
   uint32_t triangleBase;
   uint32_t triangleCount;
-  uint32_t proceduralBase;
-  uint32_t proceduralCount;
 };
 
 struct GeometryHandle {
   uint64_t vertexBufferAddress = 0;
   uint64_t indexBufferAddress = 0;
-  uint64_t boundingBoxBufferAddress = 0;
   uint32_t vertexStride = 0;
   uint32_t indexStride = 0;
-  uint32_t boundingBoxStride = 0;
   uint32_t vertexCount = 0;
   uint32_t indexCount = 0;
-  uint32_t boundingBoxCount = 0;
   uint32_t triangleBase = 0;
   uint32_t triangleCount = 0;
-  uint32_t proceduralBase = 0;
-  uint32_t proceduralCount = 0;
   uint32_t instanceSlot = 0;
-  uint32_t padding0 = 0;
-  uint32_t padding1 = 0;
-  uint32_t padding2 = 0;
 };
 
 class Renderer;
@@ -64,12 +54,7 @@ struct ResidentObjectGpuResources {
   size_t vertexCount = 0;
   size_t vertexBufferOffset = 0;
   size_t indexBufferOffset = 0;
-  MTL::Buffer *boundingBoxBuffer = nullptr;
-  size_t boundingBoxBufferCapacity = 0;
-  size_t boundingBoxBufferOffset = 0;
-  size_t boundingBoxCount = 0;
   size_t triangleBase = 0;
-  size_t proceduralBase = 0;
   bool geometryValid = false;
   ResidencyState state = ResidencyState::Cold;
   std::chrono::steady_clock::time_point lastStateChange{};
@@ -157,8 +142,8 @@ private:
   Scene *_pScene = nullptr;
 
   // Buffers
-  MTL::Buffer *_pSphereBuffer = nullptr;
-  MTL::Buffer *_pSphereMaterialBuffer = nullptr;
+  MTL::Buffer *_pPrimitiveBuffer = nullptr;
+  MTL::Buffer *_pMaterialBuffer = nullptr;
   MTL::Buffer *_pTriangleVertexBuffer = nullptr;
   MTL::Buffer *_pTriangleIndexBuffer = nullptr;
   MTL::Buffer *_pUniformsBuffer = nullptr;
@@ -266,8 +251,8 @@ private:
   size_t _maxBlasNodeCount = 0;
   size_t _maxTlasNodeCount = 0;
 
-  size_t _sphereBufferCapacity = 0;
-  size_t _sphereMaterialBufferCapacity = 0;
+  size_t _primitiveBufferCapacity = 0;
+  size_t _materialBufferCapacity = 0;
   size_t _triangleVertexBufferCapacity = 0;
   size_t _triangleIndexBufferCapacity = 0;
   size_t _bvhBufferCapacity = 0;

--- a/MetalCpp Path Tracer/Renderer/Shaders/Intersect.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Intersect.h
@@ -6,38 +6,6 @@ using namespace metal;
 
 #include "Structs.h"
 
-// Sphere intersection (your original function)
-inline float sphereIntersection(thread const Ray &ray, device const float4 &sphere)
-{
-    const float3 sphereCenter = sphere.xyz;
-    const float r = sphere.w;
-
-    float3 originToCenter = sphereCenter - ray.origin;
-    float a = length_squared(ray.direction);
-    float h = dot(ray.direction, originToCenter);
-    float c = length_squared(originToCenter) - r*r;
-
-    float discriminant = h*h - a*c;
-
-    if (discriminant < 0) return INFINITY;
-
-    float sqrtDiscriminant = sqrt(discriminant);
-
-    float root = (h - sqrtDiscriminant) / a;
-
-    if (ray.minDistance > root || ray.maxDistance < root)
-    {
-        root = (h + sqrtDiscriminant) / a;
-        if (ray.maxDistance < root || ray.minDistance > root)
-        {
-            return INFINITY;
-        }
-    }
-
-    return root;
-}
-
-
 // Triangle intersection (Möller–Trumbore)
 inline bool triangleIntersection(
     thread const Ray &ray,
@@ -79,35 +47,6 @@ inline bool triangleIntersection(
     // Valid intersection
     tHit = t;
     barycentric = float3(1.0 - u - v, u, v);
-    return true;
-}
-
-// Rectangle intersection
-inline bool rectangleIntersection(
-    thread const Ray &ray,
-    float3 center,
-    float3 e1,
-    float3 e2,
-    thread float &tHit,
-    thread float3 &normal)
-{
-    normal = normalize(cross(e1, e2));
-    float denom = dot(normal, ray.direction);
-    if (fabs(denom) < 1e-6)
-        return false;
-
-    float t = dot(center - ray.origin, normal) / denom;
-    if (t < ray.minDistance || t > ray.maxDistance)
-        return false;
-
-    float3 pHit = ray.origin + t * ray.direction;
-    float3 rel = pHit - center;
-    float u = dot(rel, e1) / dot(e1, e1);
-    float v = dot(rel, e2) / dot(e2, e2);
-    if (fabs(u) > 1.0 || fabs(v) > 1.0)
-        return false;
-
-    tHit = t;
     return true;
 }
 

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -64,67 +64,30 @@ inline uint selectLightOffset(float xi, device const float *lightCdf,
   return min(low, lightCount - 1);
 }
 
-inline bool sampleLightPoint(int primitiveType, float4 p0, float4 p1, float4 p2,
+inline bool sampleLightPoint(float4 p0, float4 p1, float4 p2,
                              thread uint32_t &seed, thread float3 &position,
                              thread float3 &normal, thread float &area) {
-  if (primitiveType == 0) {
-    float radius = p1.x;
-    if (radius <= 0.0f)
-      return false;
-    float u1 = randomFloat(seed);
-    seed = random(seed);
-    float u2 = randomFloat(seed);
-    seed = random(seed);
-    float z = 2.0 * u1 - 1.0;
-    float phi = 2.0 * M_PI * u2;
-    float r = sqrt(max(0.0f, 1.0f - z * z));
-    float3 dir = float3(r * cos(phi), r * sin(phi), z);
-    position = p0.xyz + radius * dir;
-    normal = dir;
-    area = 4.0f * M_PI * radius * radius;
-    return area > 0.0f;
-  } else if (primitiveType == 1) {
-    float u1 = randomFloat(seed);
-    seed = random(seed);
-    float u2 = randomFloat(seed);
-    seed = random(seed);
-    float su1 = sqrt(u1);
-    float b0 = 1.0 - su1;
-    float b1 = su1 * (1.0 - u2);
-    float b2 = su1 * u2;
-    float3 v0 = p0.xyz;
-    float3 v1 = p1.xyz;
-    float3 v2 = p2.xyz;
-    position = b0 * v0 + b1 * v1 + b2 * v2;
-    float3 e1 = v1 - v0;
-    float3 e2 = v2 - v0;
-    float3 n = cross(e1, e2);
-    float lenN = length(n);
-    if (lenN <= 0.0f)
-      return false;
-    normal = n / lenN;
-    area = 0.5f * lenN;
-    return area > 0.0f;
-  } else if (primitiveType == 2) {
-    float u1 = randomFloat(seed);
-    seed = random(seed);
-    float u2 = randomFloat(seed);
-    seed = random(seed);
-    float su = u1 * 2.0 - 1.0;
-    float sv = u2 * 2.0 - 1.0;
-    float3 center = p0.xyz;
-    float3 e1 = p1.xyz;
-    float3 e2 = p2.xyz;
-    position = center + su * e1 + sv * e2;
-    float3 n = cross(e1, e2);
-    float lenN = length(n);
-    if (lenN <= 0.0f)
-      return false;
-    normal = n / lenN;
-    area = 4.0f * lenN;
-    return area > 0.0f;
-  }
-  return false;
+  float u1 = randomFloat(seed);
+  seed = random(seed);
+  float u2 = randomFloat(seed);
+  seed = random(seed);
+  float su1 = sqrt(u1);
+  float b0 = 1.0 - su1;
+  float b1 = su1 * (1.0 - u2);
+  float b2 = su1 * u2;
+  float3 v0 = p0.xyz;
+  float3 v1 = p1.xyz;
+  float3 v2 = p2.xyz;
+  position = b0 * v0 + b1 * v1 + b2 * v2;
+  float3 e1 = v1 - v0;
+  float3 e2 = v2 - v0;
+  float3 n = cross(e1, e2);
+  float lenN = length(n);
+  if (lenN <= 0.0f)
+    return false;
+  normal = n / lenN;
+  area = 0.5f * lenN;
+  return area > 0.0f;
 }
 
 namespace mtlrt = metal::raytracing;
@@ -345,8 +308,8 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
           float3 lightPoint;
           float3 lightNormal;
           float area = 0.0f;
-          if (sampleLightPoint(int(lp0.w), lp0, lp1, lp2, seed, lightPoint,
-                               lightNormal, area) && area > 0.0f) {
+          if (sampleLightPoint(lp0, lp1, lp2, seed, lightPoint, lightNormal,
+                               area) && area > 0.0f) {
             float3 toLight = lightPoint - hit.hit.point;
             float dist2 = dot(toLight, toLight);
             if (dist2 > 1e-6f) {

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -30,29 +30,19 @@ struct InstanceRecord
     uint primitiveIndexBase;
     uint triangleBase;
     uint triangleCount;
-    uint proceduralBase;
-    uint proceduralCount;
 };
 
 struct GeometryHandle
 {
     uint64_t vertexBufferAddress = 0;
     uint64_t indexBufferAddress = 0;
-    uint64_t boundingBoxBufferAddress = 0;
     uint vertexStride = 0;
     uint indexStride = 0;
-    uint boundingBoxStride = 0;
     uint vertexCount = 0;
     uint indexCount = 0;
-    uint boundingBoxCount = 0;
     uint triangleBase = 0;
     uint triangleCount = 0;
-    uint proceduralBase = 0;
-    uint proceduralCount = 0;
     uint instanceSlot = 0;
-    uint padding0 = 0;
-    uint padding1 = 0;
-    uint padding2 = 0;
 };
 
 


### PR DESCRIPTION
## Summary
- remove sphere/procedural buffer handling from the renderer and rename GPU bindings for triangle data
- rebuild BLAS, geometry handles, and instance records assuming triangle-only content
- update shaders to drop sphere/rectangle helpers and sample lights directly from triangle geometry

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de7411d960832da2b140ac3a781d37