### PR TITLE
Ensure residency fallback keeps objects visible

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -3195,9 +3195,23 @@ bool Renderer::updateLODByDistance(bool forceAllToggles) {
     if (active)
       ++activeCount;
 
-  if (activeCount == 0 && !_activePrimitive.empty()) {
-    // Ensure at least one primitive remains visible to avoid a blank scene
-    if (setPrimitiveActive(0, true))
+  if (activeCount == 0 && !_allSceneObjects.empty()) {
+    // Ensure at least one nearby object remains visible to avoid a blank
+    // scene. Prefer the closest object and fall back to a primitive toggle if
+    // object activation fails for any reason.
+    size_t fallbackObject = !sortedIndices.empty() ? sortedIndices.front()
+                                                   : size_t(0);
+    bool activated = false;
+    if (fallbackObject < _allSceneObjects.size()) {
+      size_t toggled = setObjectActive(fallbackObject, true);
+      if (toggled > 0)
+        activated = true;
+    }
+    if (!activated && !_activePrimitive.empty()) {
+      if (setPrimitiveActive(0, true))
+        activated = true;
+    }
+    if (activated)
       changed = true;
   }
 
@@ -3294,7 +3308,20 @@ bool Renderer::updateEnergyImportance(bool forceAllToggles) {
   if (activeCount == 0 && !_activePrimitive.empty()) {
     size_t fallback = !_energySortedIndices.empty() ? _energySortedIndices.front()
                                                     : size_t(0);
-    if (setPrimitiveActive(fallback, true))
+    bool activated = false;
+    if (fallback < _primitiveToObject.size()) {
+      size_t fallbackObject = _primitiveToObject[fallback];
+      if (fallbackObject < _allSceneObjects.size()) {
+        size_t toggled = setObjectActive(fallbackObject, true);
+        if (toggled > 0)
+          activated = true;
+      }
+    }
+    if (!activated) {
+      if (setPrimitiveActive(fallback, true))
+        activated = true;
+    }
+    if (activated)
       changed = true;
   }
 
@@ -3391,7 +3418,20 @@ bool Renderer::updateRayHitBudget(bool forceAllToggles) {
   if (activeCount == 0 && !_activePrimitive.empty()) {
     size_t fallback = !_rayHitSortedIndices.empty() ? _rayHitSortedIndices.front()
                                                     : size_t(0);
-    if (setPrimitiveActive(fallback, true))
+    bool activated = false;
+    if (fallback < _primitiveToObject.size()) {
+      size_t fallbackObject = _primitiveToObject[fallback];
+      if (fallbackObject < _allSceneObjects.size()) {
+        size_t toggled = setObjectActive(fallbackObject, true);
+        if (toggled > 0)
+          activated = true;
+      }
+    }
+    if (!activated) {
+      if (setPrimitiveActive(fallback, true))
+        activated = true;
+    }
+    if (activated)
       changed = true;
   }
 
@@ -3526,7 +3566,20 @@ bool Renderer::updateScreenSpaceFootprint(bool forceAllToggles) {
     size_t fallback = !_screenCoverageSortedIndices.empty()
                           ? _screenCoverageSortedIndices.front()
                           : size_t(0);
-    if (setPrimitiveActive(fallback, true))
+    bool activated = false;
+    if (fallback < _primitiveToObject.size()) {
+      size_t fallbackObject = _primitiveToObject[fallback];
+      if (fallbackObject < _allSceneObjects.size()) {
+        size_t toggled = setObjectActive(fallbackObject, true);
+        if (toggled > 0)
+          activated = true;
+      }
+    }
+    if (!activated) {
+      if (setPrimitiveActive(fallback, true))
+        activated = true;
+    }
+    if (activated)
       changed = true;
   }
 


### PR DESCRIPTION
## Summary
- keep distance LOD fallback activating the nearest object rather than a single primitive when all primitives were disabled
- apply the same object-based fallback for energy, ray-hit, and screen-footprint residency strategies so the scene never collapses to an invisible triangle

## Testing
- not run (platform-specific renderer)

------
https://chatgpt.com/codex/tasks/task_e_68e389a97bdc832d8ce2e7bdf3c89384