### PR TITLE
Increase exit distance for distance LOD sweep scene

### DIFF
--- a/MetalCpp Path Tracer/scene_distance_lod_sweep.xml
+++ b/MetalCpp Path Tracer/scene_distance_lod_sweep.xml
@@ -1,6 +1,7 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="distance"
        textureResidencyMemoryCapMB="16"
-       lodEnterDistance="55" lodExitDistance="80" residencyCooldown="0" lodToggleBudget="12000">
+       lodEnterDistance="55" lodExitDistance="115" residencyCooldown="0" lodToggleBudget="12000">
+    <!-- Keep meshes resident through the full pullback so the grid stays visible at the last keyframe -->
     <CameraPath>
         <!-- Slow dolly backwards so distant clusters can be released from memory -->
         <Keyframe frame="0" position="0,12,20" lookAt="0,5,-60" />


### PR DESCRIPTION
## Summary
- raise the distance LOD exit threshold so the sweep keeps its mesh grid visible through the final pullback
- add a comment explaining the higher residency budget for the camera move

## Testing
- not run (data only change)


------
https://chatgpt.com/codex/tasks/task_e_68e38bc5f964832db0b004ab37a0a6ae