### PR TITLE
Add full-scene residency strategy

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -642,6 +642,13 @@ void Renderer::updateVisibleScene() {
   printf("Texture residency memory cap: %.1f MB\n",
          _textureResidencyMemoryCapMB);
   _residentCompacted = _pScene->getStartCompacted();
+  bool fullSceneResidency =
+      _pScene->getResidencyStrategy() == ResidencyStrategy::FullScene;
+  if (fullSceneResidency && _residentCompacted) {
+    printf("Full-scene residency requires all geometry to remain uploaded; "
+           "disabling initial compaction.\n");
+    _residentCompacted = false;
+  }
   _compactionCooldown = 0;
 
   printf("LOD activation threshold: %.1f, deactivation threshold: %.1f (cooldown "
@@ -660,6 +667,9 @@ void Renderer::updateVisibleScene() {
     break;
   case ResidencyStrategy::ScreenSpaceFootprint:
     strategyName = "Screen-space footprint";
+    break;
+  case ResidencyStrategy::FullScene:
+    strategyName = "Full-scene residency";
     break;
   case ResidencyStrategy::DistanceLOD:
   default:
@@ -1569,6 +1579,10 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
 
   if (forceFullRebuild) {
     bool startCompacted = _pScene ? _pScene->getStartCompacted() : false;
+    if (_pScene &&
+        _pScene->getResidencyStrategy() == ResidencyStrategy::FullScene) {
+      startCompacted = false;
+    }
     _residentCompacted = startCompacted;
     _compactionCooldown = 0;
   }
@@ -3151,6 +3165,9 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   case ResidencyStrategy::ScreenSpaceFootprint:
     changed = updateScreenSpaceFootprint(forceAllToggles);
     break;
+  case ResidencyStrategy::FullScene:
+    changed = activateFullSceneResidency();
+    break;
   case ResidencyStrategy::DistanceLOD:
   default:
     changed = updateLODByDistance(forceAllToggles);
@@ -3159,6 +3176,43 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
 
   if (changed || forceFullRebuild)
     flushResidencyChanges(forceFullRebuild);
+}
+
+bool Renderer::activateFullSceneResidency() {
+  bool changed = false;
+  const size_t primCount = _activePrimitive.size();
+  for (size_t i = 0; i < primCount; ++i) {
+    if (!_activePrimitive[i]) {
+      if (setPrimitiveActive(i, true))
+        changed = true;
+    }
+  }
+
+  if (_objectActive.size() < _allSceneObjects.size())
+    _objectActive.resize(_allSceneObjects.size(), false);
+  if (_objectCooldown.size() < _allSceneObjects.size())
+    _objectCooldown.resize(_allSceneObjects.size(), 0);
+
+  for (size_t objectIndex = 0; objectIndex < _allSceneObjects.size();
+       ++objectIndex) {
+    const SceneObject &obj = _allSceneObjects[objectIndex];
+    size_t first = obj.firstPrimitive;
+    size_t last = first + obj.primitiveCount;
+    bool anyActive = false;
+    for (size_t prim = first; prim < last && prim < primCount; ++prim) {
+      if (_activePrimitive[prim]) {
+        anyActive = true;
+        break;
+      }
+    }
+    if (_objectActive[objectIndex] != anyActive) {
+      _objectActive[objectIndex] = anyActive;
+      _objectCooldown[objectIndex] = _residencyConfig.stateCooldownFrames;
+      changed = true;
+    }
+  }
+
+  return changed;
 }
 
 bool Renderer::updateLODByDistance(bool forceAllToggles) {

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -118,6 +118,7 @@ private:
   bool updateEnergyImportance(bool forceAllToggles);
   bool updateRayHitBudget(bool forceAllToggles);
   bool updateScreenSpaceFootprint(bool forceAllToggles);
+  bool activateFullSceneResidency();
   void flushResidencyChanges(bool forceFullRebuild);
   void beginFrameMetrics();
   void completeFrameMetrics(MTL::CommandBuffer *pCmd);

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -14,6 +14,7 @@ enum class ResidencyStrategy {
   EnergyImportance = 1,
   RayHitBudget = 2,
   ScreenSpaceFootprint = 3,
+  FullScene = 4,
 };
 
 struct SceneObject {

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -277,6 +277,9 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
                    value == "screen_space_footprint" || value == "footprint" ||
                    value == "screenspace") {
             scene->setResidencyStrategy(ResidencyStrategy::ScreenSpaceFootprint);
+        } else if (value == "none" || value == "all" || value == "fullscene" ||
+                   value == "full_scene" || value == "full") {
+            scene->setResidencyStrategy(ResidencyStrategy::FullScene);
         } else {
             printf("Unknown residency strategy '%s', defaulting to distance LOD.\n",
                    residencyAttr);


### PR DESCRIPTION
## Summary
- extend the residency strategy enum with a full-scene option and keep the default unchanged
- map scene XML values such as none/all/fullScene to the new strategy and label it in the renderer
- ensure the renderer forces all primitives resident, disables compaction, and rebuilds resources when the full-scene strategy is active

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3beea627c832d92ed66ef99ed77fa