### PR TITLE
Add option to disable mesh partitioning from scene XML

### DIFF
--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -135,8 +135,14 @@ static void PartitionTrianglesRecursive(std::vector<Primitive>& prims,
 }
 
 static void EmitMeshPartitions(Scene* scene, std::vector<Primitive>& prims,
-                               size_t maxTriangles, float maxExtent) {
+                               size_t maxTriangles, float maxExtent,
+                               bool disablePartitioning) {
     if (prims.empty()) {
+        return;
+    }
+
+    if (disablePartitioning) {
+        scene->addObject(prims);
         return;
     }
 
@@ -325,6 +331,9 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
 
     scene->setResidencyParameters(params);
 
+    bool disableMeshPartitioning =
+        root->BoolAttribute("disableMeshPartitioning", false);
+
     bool startCompacted = root->BoolAttribute("startCompacted", scene->getStartCompacted());
     scene->setStartCompacted(startCompacted);
 
@@ -414,7 +423,7 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             }
 
             EmitMeshPartitions(scene, spherePrimitives, clusterMaxTriangles,
-                               clusterMaxExtent);
+                               clusterMaxExtent, disableMeshPartitioning);
         }
         else if (tag == "Rectangle") {
             simd::float3 center = parseVec3(e->Attribute("position"));
@@ -457,7 +466,7 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             rectPrimitives.push_back(t1);
 
             EmitMeshPartitions(scene, rectPrimitives, clusterMaxTriangles,
-                               clusterMaxExtent);
+                               clusterMaxExtent, disableMeshPartitioning);
         }
         else if (tag == "Mesh") {
             // Build full path to mesh file relative to the scene's directory
@@ -502,7 +511,7 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
                 meshPrimitives.push_back(p);
             }
             EmitMeshPartitions(scene, meshPrimitives, clusterMaxTriangles,
-                               clusterMaxExtent);
+                               clusterMaxExtent, disableMeshPartitioning);
         }
         else if (tag == "CameraPath") {
             for (auto* kf = e->FirstChildElement("Keyframe"); kf; kf = kf->NextSiblingElement("Keyframe")) {

--- a/MetalCpp Path Tracer/scene_distance_lod_sweep.xml
+++ b/MetalCpp Path Tracer/scene_distance_lod_sweep.xml
@@ -1,4 +1,5 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="distance"
+       disableMeshPartitioning="true"
        textureResidencyMemoryCapMB="16"
        lodEnterDistance="55" lodExitDistance="115" residencyCooldown="0" lodToggleBudget="12000">
     <!-- Keep meshes resident through the full pullback so the grid stays visible at the last keyframe -->


### PR DESCRIPTION
## Summary
- add a Scene-level `disableMeshPartitioning` flag that bypasses mesh splitting when loading geometry
- propagate the flag to all primitive emitters so objects are added without partitioning when requested
- configure the distance LOD sweep scene to start with mesh partitioning disabled

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3c1360708832d9675d23022123384