### PR TITLE
Add always-resident residency strategy

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -676,6 +676,9 @@ void Renderer::updateVisibleScene() {
   case ResidencyStrategy::ScreenSpaceFootprint:
     strategyName = "Screen-space footprint";
     break;
+  case ResidencyStrategy::AlwaysResident:
+    strategyName = "Always resident";
+    break;
   case ResidencyStrategy::DistanceLOD:
   default:
     strategyName = "Distance-based LOD";
@@ -3166,6 +3169,9 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   case ResidencyStrategy::ScreenSpaceFootprint:
     changed = updateScreenSpaceFootprint(forceAllToggles);
     break;
+  case ResidencyStrategy::AlwaysResident:
+    changed = updateAlwaysResident(forceAllToggles);
+    break;
   case ResidencyStrategy::DistanceLOD:
   default:
     changed = updateLODByDistance(forceAllToggles);
@@ -3174,6 +3180,51 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
 
   if (changed || forceFullRebuild)
     flushResidencyChanges(forceFullRebuild);
+}
+
+bool Renderer::updateAlwaysResident(bool /*forceAllToggles*/) {
+  bool changed = false;
+
+  for (size_t objectIndex = 0; objectIndex < _allSceneObjects.size(); ++objectIndex) {
+    size_t toggled = setObjectActive(objectIndex, true);
+    if (toggled > 0)
+      changed = true;
+  }
+
+  for (size_t primIndex = 0; primIndex < _activePrimitive.size(); ++primIndex) {
+    if (setPrimitiveActive(primIndex, true))
+      changed = true;
+  }
+
+  bool anyInactivePrimitive =
+      std::any_of(_activePrimitive.begin(), _activePrimitive.end(),
+                  [](bool active) { return !active; });
+  bool anyInactiveObject = false;
+  for (size_t objectIndex = 0; objectIndex < _allSceneObjects.size(); ++objectIndex) {
+    const SceneObject &obj = _allSceneObjects[objectIndex];
+    if (obj.primitiveCount == 0)
+      continue;
+    bool active =
+        (objectIndex < _objectActive.size()) ? _objectActive[objectIndex] : false;
+    if (!active) {
+      anyInactiveObject = true;
+      break;
+    }
+  }
+
+  if (anyInactivePrimitive || anyInactiveObject || !_recentlyDeactivated.empty()) {
+    printf("Always-resident strategy detected attempted eviction (%zu primitives pending).\n",
+           _recentlyDeactivated.size());
+  }
+
+  assert(!anyInactivePrimitive &&
+         "Always-resident strategy should keep all primitives active");
+  assert(!anyInactiveObject &&
+         "Always-resident strategy should keep populated objects active");
+  assert(_recentlyDeactivated.empty() &&
+         "Always-resident strategy should not queue primitive deactivations");
+
+  return changed;
 }
 
 bool Renderer::updateLODByDistance(bool forceAllToggles) {

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -116,6 +116,7 @@ private:
   bool updateEnergyImportance(bool forceAllToggles);
   bool updateRayHitBudget(bool forceAllToggles);
   bool updateScreenSpaceFootprint(bool forceAllToggles);
+  bool updateAlwaysResident(bool forceAllToggles);
   void flushResidencyChanges(bool forceFullRebuild);
   void beginFrameMetrics();
   void completeFrameMetrics(MTL::CommandBuffer *pCmd);

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -14,6 +14,7 @@ enum class ResidencyStrategy {
   EnergyImportance = 1,
   RayHitBudget = 2,
   ScreenSpaceFootprint = 3,
+  AlwaysResident = 4,
 };
 
 struct SceneObject {

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -276,6 +276,9 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
                    value == "screen_space_footprint" || value == "footprint" ||
                    value == "screenspace") {
             scene->setResidencyStrategy(ResidencyStrategy::ScreenSpaceFootprint);
+        } else if (value == "alwaysresident" || value == "always_resident" ||
+                   value == "always" || value == "none" || value == "off") {
+            scene->setResidencyStrategy(ResidencyStrategy::AlwaysResident);
         } else {
             printf("Unknown residency strategy '%s', defaulting to distance LOD.\n",
                    residencyAttr);


### PR DESCRIPTION
## Summary
- add an AlwaysResident residency strategy to the scene enum and XML loader options
- update the renderer to keep all primitives resident in the new mode and log/assert on eviction attempts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3d1986b04832dae4592f33cba9c70