### PR TITLE
Fix missing geometry in screen-space scenes

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -702,6 +702,13 @@ void Renderer::updateVisibleScene() {
   _primitiveScreenCoverage.assign(primCount, 0.0f);
   _screenCoverageSortedIndices.resize(primCount);
   _totalPrimitiveImportance = 0.0f;
+
+  // Build the acceleration structures before copying the scene objects so
+  // their cached bounds are populated for residency heuristics.
+  _maxBlasNodeCount = 1;
+  _maxTlasNodeCount = 1;
+  _pScene->buildBVH();
+
   _allSceneObjects = _pScene->getObjects();
   size_t objectCount = _allSceneObjects.size();
   _objectBounds.resize(objectCount);
@@ -851,10 +858,6 @@ void Renderer::updateVisibleScene() {
 
   _rayHitRebuildCooldown = 0;
 
-  _maxBlasNodeCount = 1;
-  _maxTlasNodeCount = 1;
-
-  _pScene->buildBVH();
   size_t blasNodeCount = _pScene->getBVHNodeCount();
   _maxBlasNodeCount = std::max<size_t>(blasNodeCount, _maxBlasNodeCount);
 


### PR DESCRIPTION
## Summary
- build the scene BVH before copying cached objects so their bounds are valid
- avoid rebuilding the BVH a second time while retaining residency bookkeeping

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4da94d710832d96c815c2731900cf