### PR TITLE
Lower screenspace residency thresholds for zoom and panorama scenes

### DIFF
--- a/MetalCpp Path Tracer/scene_screenspace_panorama.xml
+++ b/MetalCpp Path Tracer/scene_screenspace_panorama.xml
@@ -1,7 +1,7 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="screenSpaceFootprint"
        textureResidencyMemoryCapMB="16"
-       screenTargetFraction="0.22" screenMinActive="120" screenToggleBudget="900"
-       screenMinPixelCoverage="24">
+       screenTargetFraction="0.08" screenMinActive="80" screenToggleBudget="900"
+       screenMinPixelCoverage="8">
     <CameraPath>
         <!-- Pan across a wide stage so objects shrink on screen and release residency -->
         <Keyframe frame="0" position="-90,18,20" lookAt="0,10,0" />

--- a/MetalCpp Path Tracer/scene_screenspace_zoom.xml
+++ b/MetalCpp Path Tracer/scene_screenspace_zoom.xml
@@ -1,7 +1,7 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="screenSpaceFootprint"
        textureResidencyMemoryCapMB="16"
-       screenTargetFraction="0.18" screenMinActive="100" screenToggleBudget="750"
-       screenMinPixelCoverage="18">
+       screenTargetFraction="0.06" screenMinActive="60" screenToggleBudget="750"
+       screenMinPixelCoverage="6">
     <CameraPath>
         <!-- Rapid zoom exposes how screen coverage reduction frees GPU memory -->
         <Keyframe frame="0" position="0,10,8" lookAt="0,6,-25" />


### PR DESCRIPTION
## Summary
- reduce the screenspace residency thresholds in `scene_screenspace_zoom.xml` so distant clusters can deactivate during the zoom-out
- lower the coverage requirements in `scene_screenspace_panorama.xml` to let shrinking geometry fall below the residency goals

## Testing
- `./MetalPathTracer --scene 'MetalCpp Path Tracer/scene_screenspace_zoom.xml'` *(fails: executable is unavailable in this Linux container environment)*
- `./MetalPathTracer --scene 'MetalCpp Path Tracer/scene_screenspace_panorama.xml'` *(fails: executable is unavailable in this Linux container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4e6f4b918832dbd379f02631107f8