### PR TITLE
Refocus screen footprint residency on primitives

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -3603,20 +3603,21 @@ bool Renderer::updateRayHitBudget(bool forceAllToggles) {
 }
 
 bool Renderer::updateScreenSpaceFootprint(bool forceAllToggles) {
-  if (_allSceneObjects.empty())
+  const size_t primCount = _activePrimitive.size();
+  if (primCount == 0)
     return false;
 
-  const size_t objectCount = _allSceneObjects.size();
-  if (_primitiveScreenCoverage.size() != objectCount)
-    _primitiveScreenCoverage.assign(objectCount, 0.0f);
-  if (_screenCoverageSortedIndices.size() != objectCount) {
-    _screenCoverageSortedIndices.resize(objectCount);
+  if (_primitiveScreenCoverage.size() != primCount)
+    _primitiveScreenCoverage.assign(primCount, 0.0f);
+  if (_screenCoverageSortedIndices.size() != primCount) {
+    _screenCoverageSortedIndices.resize(primCount);
     std::iota(_screenCoverageSortedIndices.begin(),
               _screenCoverageSortedIndices.end(), size_t(0));
   }
 
   const float screenArea = Camera::screenSize.x * Camera::screenSize.y;
-  float halfFov = Camera::verticalFov * static_cast<float>(M_PI) / 180.0f * 0.5f;
+  float halfFov = Camera::verticalFov * static_cast<float>(M_PI) / 180.0f *
+                  0.5f;
   float tanHalfFov = std::tan(halfFov);
   if (tanHalfFov <= 0.0f)
     tanHalfFov = 1e-3f;
@@ -3635,11 +3636,11 @@ bool Renderer::updateScreenSpaceFootprint(bool forceAllToggles) {
                      : 1.0f;
   float horizontalHalfFov = std::atan(tanHalfFov * aspect);
 
-  for (size_t objectIndex = 0; objectIndex < objectCount; ++objectIndex) {
+  for (size_t primIndex = 0; primIndex < primCount; ++primIndex) {
     float coverage = 0.0f;
-    if (objectIndex < _objectBounds.size() &&
-        isInView(_objectBounds[objectIndex])) {
-      const BoundingSphere &b = _objectBounds[objectIndex];
+    if (primIndex < _primitiveBounds.size() &&
+        isInView(_primitiveBounds[primIndex])) {
+      const BoundingSphere &b = _primitiveBounds[primIndex];
       simd::float3 toCenter = b.center - Camera::position;
       float depth = simd::dot(toCenter, forward);
       if (depth > 1e-3f) {
@@ -3657,7 +3658,7 @@ bool Renderer::updateScreenSpaceFootprint(bool forceAllToggles) {
         }
       }
     }
-    _primitiveScreenCoverage[objectIndex] = coverage;
+    _primitiveScreenCoverage[primIndex] = coverage;
   }
 
   std::sort(_screenCoverageSortedIndices.begin(),
@@ -3675,8 +3676,7 @@ bool Renderer::updateScreenSpaceFootprint(bool forceAllToggles) {
               return ca > cb;
             });
 
-  std::vector<bool> desiredObjects(objectCount, false);
-  const size_t primCount = _activePrimitive.size();
+  std::vector<bool> desired(primCount, false);
   const size_t minActivePrimitives = std::min(
       primCount, _residencyConfig.screenFootprintMinActivePrimitives);
   float accumulatedCoverage = 0.0f;
@@ -3684,13 +3684,10 @@ bool Renderer::updateScreenSpaceFootprint(bool forceAllToggles) {
   float targetCoverage =
       screenArea * _residencyConfig.screenFootprintTargetFraction;
 
-  for (size_t idx : _screenCoverageSortedIndices) {
-    if (idx >= _allSceneObjects.size())
-      continue;
-    const SceneObject &obj = _allSceneObjects[idx];
-    float coverage =
-        (idx < _primitiveScreenCoverage.size()) ? _primitiveScreenCoverage[idx]
-                                                : 0.0f;
+  for (size_t primIndex : _screenCoverageSortedIndices) {
+    float coverage = (primIndex < _primitiveScreenCoverage.size())
+                         ? _primitiveScreenCoverage[primIndex]
+                         : 0.0f;
     if (accumulatedPrimitives >= minActivePrimitives &&
         accumulatedCoverage >= targetCoverage)
       break;
@@ -3700,26 +3697,19 @@ bool Renderer::updateScreenSpaceFootprint(bool forceAllToggles) {
     if (coverage <= 0.0f && accumulatedPrimitives >= minActivePrimitives)
       break;
 
-    desiredObjects[idx] = true;
+    desired[primIndex] = true;
     accumulatedCoverage += coverage;
-    accumulatedPrimitives += obj.primitiveCount;
+    ++accumulatedPrimitives;
   }
 
-  size_t ensuredPrimitives = 0;
-  for (size_t idx : _screenCoverageSortedIndices) {
-    if (idx >= _allSceneObjects.size())
-      continue;
-    if (desiredObjects[idx])
-      ensuredPrimitives += _allSceneObjects[idx].primitiveCount;
-  }
+  size_t ensuredPrimitives =
+      std::count(desired.begin(), desired.end(), true);
   if (ensuredPrimitives < minActivePrimitives) {
-    for (size_t idx : _screenCoverageSortedIndices) {
-      if (idx >= _allSceneObjects.size())
+    for (size_t primIndex : _screenCoverageSortedIndices) {
+      if (desired[primIndex])
         continue;
-      if (desiredObjects[idx])
-        continue;
-      desiredObjects[idx] = true;
-      ensuredPrimitives += _allSceneObjects[idx].primitiveCount;
+      desired[primIndex] = true;
+      ++ensuredPrimitives;
       if (ensuredPrimitives >= minActivePrimitives)
         break;
     }
@@ -3727,63 +3717,41 @@ bool Renderer::updateScreenSpaceFootprint(bool forceAllToggles) {
 
   size_t toggles = 0;
   bool changed = false;
-  for (size_t objectIndex = 0; objectIndex < objectCount; ++objectIndex) {
-    bool shouldBeActive = desiredObjects[objectIndex];
-    bool currentlyActive =
-        (objectIndex < _objectActive.size()) ? _objectActive[objectIndex] : false;
+  for (size_t primIndex = 0; primIndex < primCount; ++primIndex) {
+    bool shouldBeActive = desired[primIndex];
+    bool currentlyActive = _activePrimitive[primIndex];
     if (shouldBeActive == currentlyActive)
       continue;
     if (!forceAllToggles) {
-      if (objectIndex < _objectCooldown.size() &&
-          _objectCooldown[objectIndex] > 0)
+      if (primIndex < _primitiveCooldown.size() &&
+          _primitiveCooldown[primIndex] > 0)
         continue;
       if (toggles >= _residencyConfig.screenFootprintMaxTogglesPerFrame)
         break;
     }
 
-    size_t toggledPrimitives = setObjectActive(objectIndex, shouldBeActive);
-    if (toggledPrimitives > 0 || shouldBeActive != currentlyActive) {
+    if (setPrimitiveActive(primIndex, shouldBeActive)) {
       ++toggles;
       changed = true;
     }
-  }
-
-  bool anyActiveObject =
-      std::any_of(_objectActive.begin(), _objectActive.end(),
-                  [](bool active) { return active; });
-  if (!anyActiveObject && !_screenCoverageSortedIndices.empty()) {
-    size_t fallback = _screenCoverageSortedIndices.front();
-    bool wasActive =
-        (fallback < _objectActive.size()) ? _objectActive[fallback] : false;
-    size_t toggled = setObjectActive(fallback, true);
-    if (toggled > 0 || !wasActive)
-      changed = true;
   }
 
   bool anyActivePrimitive = std::any_of(
       _activePrimitive.begin(), _activePrimitive.end(), [](bool active) {
         return active;
       });
-  if (!anyActivePrimitive && !_activePrimitive.empty()) {
-    size_t fallbackPrim = 0;
-    bool foundFallback = false;
-    for (size_t idx : _screenCoverageSortedIndices) {
-      if (idx >= _allSceneObjects.size())
-        continue;
-      const SceneObject &obj = _allSceneObjects[idx];
-      if (obj.primitiveCount == 0)
-        continue;
-      fallbackPrim = obj.firstPrimitive;
-      foundFallback = true;
-      break;
-    }
-    if (!foundFallback && !_allSceneObjects.empty()) {
-      const SceneObject &obj = _allSceneObjects.front();
-      if (obj.primitiveCount > 0)
-        fallbackPrim = obj.firstPrimitive;
-    }
+  if (!anyActivePrimitive && !_screenCoverageSortedIndices.empty()) {
+    size_t fallbackPrim = _screenCoverageSortedIndices.front();
+    if (fallbackPrim >= _activePrimitive.size())
+      fallbackPrim = 0;
     if (fallbackPrim < _activePrimitive.size() &&
         setPrimitiveActive(fallbackPrim, true))
+      changed = true;
+  }
+
+  if (!anyActivePrimitive && !_activePrimitive.empty() && !changed) {
+    size_t fallbackPrim = 0;
+    if (setPrimitiveActive(fallbackPrim, true))
       changed = true;
   }
 


### PR DESCRIPTION
## Summary
- compute screen-space coverage per primitive using primitive bounds and sort residency candidates accordingly
- replace object-level residency toggles with primitive-aware toggles that observe primitive cooldowns and toggle budgets
- ensure fallback activation also operates on primitives via setPrimitiveActive

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4f521ac2c832db39427b0a91a368c