### PR TITLE
Refine screen-space residency selection

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -3717,27 +3717,33 @@ bool Renderer::updateScreenSpaceFootprint(bool forceAllToggles) {
   for (size_t idx : _screenCoverageSortedIndices) {
     if (idx >= _allSceneObjects.size())
       continue;
-    if (accumulatedPrimitives >= minActivePrimitives &&
-        accumulatedCoverage >= targetCoverage)
-      break;
 
     const SceneObject &obj = _allSceneObjects[idx];
     float coverage =
         (idx < _primitiveScreenCoverage.size()) ? _primitiveScreenCoverage[idx]
                                                 : 0.0f;
-    size_t futurePrimitives = accumulatedPrimitives + obj.primitiveCount;
-    float futureCoverage = accumulatedCoverage + coverage;
-    bool futureNeedsPrimitives = futurePrimitives < minActivePrimitives;
-    bool futureNeedsCoverage = futureCoverage < targetCoverage;
+
+    bool needsPrimitives = accumulatedPrimitives < minActivePrimitives;
+    bool needsCoverage = accumulatedCoverage < targetCoverage;
+
+    if (!needsPrimitives && !needsCoverage)
+      break;
+
+    bool hasCoverage = coverage > 0.0f;
     bool meetsPixelThreshold =
         coverage >= _residencyConfig.screenFootprintMinPixelCoverage;
 
-    if (!futureNeedsPrimitives && !futureNeedsCoverage && !meetsPixelThreshold)
-      break;
+    if (!needsPrimitives) {
+      if (!hasCoverage)
+        continue;
+
+      if (!needsCoverage && !meetsPixelThreshold)
+        continue;
+    }
 
     desiredObjects[idx] = true;
-    accumulatedCoverage = futureCoverage;
-    accumulatedPrimitives = futurePrimitives;
+    accumulatedCoverage += coverage;
+    accumulatedPrimitives += obj.primitiveCount;
   }
 
   size_t ensuredPrimitives = 0;


### PR DESCRIPTION
## Summary
- refine the screen-space footprint selection loop to skip objects that do not contribute coverage once quotas are satisfied
- ensure coverage and primitive requirements are still met without prematurely exiting, keeping other residency strategies unaffected

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e4f85703f8832db311fbb959b771d7