### PR TITLE
Allow energy importance toggles to saturate budget

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -3543,14 +3543,18 @@ bool Renderer::updateEnergyImportance(bool forceAllToggles) {
     if (!canToggle || togglesNeeded == 0)
       continue;
 
+    // Allow large object toggles to saturate the frame budget instead of being
+    // rejected outright. We only stop once the current frame's budget has
+    // already been consumed, matching the behaviour of other residency passes.
     if (!forceAllToggles &&
-        toggledPrimitiveCount + togglesNeeded >
-            _residencyConfig.energyMaxTogglesPerFrame)
+        toggledPrimitiveCount >= _residencyConfig.energyMaxTogglesPerFrame)
       continue;
 
     size_t toggled = setObjectActive(objectIndex, shouldBeActive);
     if (toggled > 0) {
-      toggledPrimitiveCount += toggled;
+      toggledPrimitiveCount =
+          std::min(toggledPrimitiveCount + toggled,
+                   _residencyConfig.energyMaxTogglesPerFrame);
       changed = true;
     }
   }


### PR DESCRIPTION
## Summary
- allow energy-based residency toggles to proceed until the budget is exhausted instead of rejecting large objects outright
- clamp the per-frame toggle counter after toggling to ensure it never exceeds the configured budget
- document that large toggles saturate the budget for consistency with other residency passes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5027b4078832d8af9a42d52ab34a4