### PR TITLE
Refine energy sibling tolerance heuristic

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -3755,8 +3755,9 @@ bool Renderer::updateEnergyImportance(bool forceAllToggles) {
       meshLastPrimaryAverage > 0.0f) {
     // Expand the selection to include mesh siblings whose per-primitive
     // averages are comparable to the last group that satisfied the target.
-    // The tolerance adapts to the neighbourhood of the cutoff instead of
-    // relying on a fixed constant threshold.
+    // The tolerance derives from the relative separation between the cutoff
+    // group and its neighbours so groups with similar intensity ratios remain
+    // together even when the absolute gap collapses toward zero.
     float prevDiff = std::numeric_limits<float>::infinity();
     if (!std::isnan(meshPrevPrimaryAverage))
       prevDiff =
@@ -3773,10 +3774,18 @@ bool Renderer::updateEnergyImportance(bool forceAllToggles) {
       }
     }
 
-    float allowedDelta = std::min(prevDiff, nextDiff);
-    if (!std::isfinite(allowedDelta) || allowedDelta <= 0.0f ||
-        allowedDelta >= meshLastPrimaryAverage)
-      allowedDelta = 0.0f;
+    float minNeighborDiff = std::min(prevDiff, nextDiff);
+    float allowedRatio = 0.0f;
+    if (std::isfinite(minNeighborDiff) && minNeighborDiff > 0.0f)
+      allowedRatio = minNeighborDiff /
+                     std::max(meshLastPrimaryAverage, std::numeric_limits<float>::min());
+
+    // Fall back to a gentle relative epsilon so identical neighbours are kept
+    // together instead of being filtered out by a zero-width band.
+    const float kRelativeFallback = 0.01f;
+    allowedRatio = std::max(allowedRatio, kRelativeFallback);
+
+    float allowedDelta = meshLastPrimaryAverage * allowedRatio;
 
     if (allowedDelta > 0.0f) {
       float epsilon = std::max(1e-5f, meshLastPrimaryAverage * 1e-3f);

--- a/MetalCpp Path Tracer/scene_energy_core_intensity.xml
+++ b/MetalCpp Path Tracer/scene_energy_core_intensity.xml
@@ -14,7 +14,8 @@
     <Rectangle position="0,45,0" u="30,0,0" v="0,0,30" albedo="1.0,1.0,1.0"
                emission="0.8,0.85,0.9" materialType="-1" emissionPower="25" />
 
-    <!-- Emissive bunnies create an energy hotspot that should remain resident -->
+    <!-- Emissive bunnies create an energy hotspot that should remain resident
+         together once the target fraction is satisfied -->
     <Mesh file="assets/bunny.obj" position="0,10,0" scale="9.0"
           clusterMaxTriangles="1536" clusterMaxExtent="36"
           albedo="0.35,0.35,0.35" emission="1.0,0.9,0.7" materialType="0" emissionPower="12" />


### PR DESCRIPTION
## Summary
- derive the sibling expansion tolerance for energy-based residency from a relative ratio so similarly bright meshes stay resident together
- clarify the residency note in the energy core intensity scene to confirm the emissive bunnies remain together once the energy target is met

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5329e3208832d8e2e92e5c290d284