### PR TITLE
Boost energy residency by screen visibility

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -3430,6 +3430,55 @@ bool Renderer::updateEnergyImportance(bool forceAllToggles) {
   std::iota(_energySortedIndices.begin(), _energySortedIndices.end(),
             size_t(0));
 
+  float screenArea = Camera::screenSize.x * Camera::screenSize.y;
+  if (screenArea <= 0.0f)
+    screenArea = 1.0f;
+
+  float visibilityBoost = std::max(_residencyConfig.energyVisibilityBoost, 1.0f);
+  const bool applyVisibilityBoost = visibilityBoost > 1.0001f;
+
+  simd::float3 forward = simd::normalize(Camera::forward);
+  simd::float3 up = simd::normalize(Camera::up);
+  simd::float3 right = simd::cross(forward, up);
+  float rightLenSq = simd::length_squared(right);
+  if (rightLenSq < 1e-6f)
+    right = {1.0f, 0.0f, 0.0f};
+  else
+    right /= std::sqrt(rightLenSq);
+
+  float halfFov = Camera::verticalFov * static_cast<float>(M_PI) / 180.0f * 0.5f;
+  float tanHalfFov = std::tan(halfFov);
+  if (tanHalfFov <= 0.0f)
+    tanHalfFov = 1e-3f;
+
+  float aspect = Camera::screenSize.y > 0.0f
+                     ? Camera::screenSize.x / Camera::screenSize.y
+                     : 1.0f;
+  float horizontalHalfFov = std::atan(tanHalfFov * aspect);
+
+  auto coverageForSphere = [&](const BoundingSphere &b) -> float {
+    if (!applyVisibilityBoost)
+      return 0.0f;
+    if (!isInView(b))
+      return 0.0f;
+    simd::float3 toCenter = b.center - Camera::position;
+    float depth = simd::dot(toCenter, forward);
+    if (depth <= 1e-3f)
+      return 0.0f;
+    float dist = simd::length(toCenter);
+    float cosAngle = depth / std::max(dist, 1e-3f);
+    float horiz = simd::dot(toCenter, right);
+    float horizAngle = std::atan2(std::fabs(horiz), depth);
+    if (horizAngle > horizontalHalfFov + 0.1f)
+      return 0.0f;
+    float radiusPixels = (b.radius / depth) / tanHalfFov *
+                         (Camera::screenSize.y * 0.5f);
+    radiusPixels = std::max(radiusPixels, 0.0f);
+    float area = static_cast<float>(M_PI) * radiusPixels * radiusPixels;
+    float angleFactor = std::max(cosAngle, 0.0f);
+    return std::min(area * angleFactor, screenArea);
+  };
+
   std::vector<size_t> objectPrimitiveCounts(objectCount, 0);
   bool anyMeshGroups = false;
   for (size_t objectIndex = 0; objectIndex < objectCount; ++objectIndex) {
@@ -3438,12 +3487,26 @@ bool Renderer::updateEnergyImportance(bool forceAllToggles) {
     size_t last = first + obj.primitiveCount;
     float totalImportance = 0.0f;
     size_t count = 0;
+    float coverage = 0.0f;
     for (size_t prim = first; prim < last && prim < _primitiveImportance.size();
          ++prim) {
       totalImportance += std::max(_primitiveImportance[prim], 0.0f);
+      if (applyVisibilityBoost && prim < _primitiveScreenCoverage.size())
+        coverage += std::max(_primitiveScreenCoverage[prim], 0.0f);
       ++count;
     }
-    _objectImportance[objectIndex] = totalImportance;
+    if (applyVisibilityBoost) {
+      float sphereCoverage = 0.0f;
+      if (objectIndex < _objectBounds.size())
+        sphereCoverage = coverageForSphere(_objectBounds[objectIndex]);
+      float combinedCoverage = std::max(coverage, sphereCoverage);
+      float normalized =
+          std::clamp(combinedCoverage / screenArea, 0.0f, 1.0f);
+      float multiplier = 1.0f + (visibilityBoost - 1.0f) * normalized;
+      _objectImportance[objectIndex] = totalImportance * multiplier;
+    } else {
+      _objectImportance[objectIndex] = totalImportance;
+    }
     objectPrimitiveCounts[objectIndex] = count;
     if (obj.meshGroupId >= 0)
       anyMeshGroups = true;

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -38,6 +38,7 @@ struct ResidencyParameters {
   float energyTargetFraction = 0.9f;
   size_t energyMinActivePrimitives = 16;
   size_t energyMaxTogglesPerFrame = 32;
+  float energyVisibilityBoost = 1.75f;
 
   float rayHitDecay = 0.85f;
   float rayHitTargetFraction = 0.6f;

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -301,6 +301,8 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         "energyMinActive", static_cast<uint64_t>(params.energyMinActivePrimitives)));
     params.energyMaxTogglesPerFrame = static_cast<size_t>(root->Unsigned64Attribute(
         "energyToggleBudget", static_cast<uint64_t>(params.energyMaxTogglesPerFrame)));
+    params.energyVisibilityBoost =
+        root->FloatAttribute("energyVisibilityBoost", params.energyVisibilityBoost);
 
     params.rayHitDecay = root->FloatAttribute("rayHitDecay", params.rayHitDecay);
     params.rayHitTargetFraction =


### PR DESCRIPTION
## Summary
- boost per-object energy importance using screen-space coverage so visible emitters are prioritized
- add a configurable energyVisibilityBoost residency parameter that can disable or scale the visibility weighting
- fall back to bounding-sphere visibility estimates when footprint data is unavailable

## Testing
- not run (Metal renderer unavailable in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5363a0050832d8f6efec82fd0e42e