### PR TITLE
Adjust visibility boost factor for energy residency

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -3500,9 +3500,8 @@ bool Renderer::updateEnergyImportance(bool forceAllToggles) {
       if (objectIndex < _objectBounds.size())
         sphereCoverage = coverageForSphere(_objectBounds[objectIndex]);
       float combinedCoverage = std::max(coverage, sphereCoverage);
-      float normalized =
-          std::clamp(combinedCoverage / screenArea, 0.0f, 1.0f);
-      float multiplier = 1.0f + (visibilityBoost - 1.0f) * normalized;
+      float visibilityFactor = combinedCoverage > 0.0f ? 1.0f : 0.0f;
+      float multiplier = 1.0f + (visibilityBoost - 1.0f) * visibilityFactor;
       _objectImportance[objectIndex] = totalImportance * multiplier;
     } else {
       _objectImportance[objectIndex] = totalImportance;


### PR DESCRIPTION
## Summary
- ensure objects with measurable screen coverage receive the full energy visibility boost multiplier
- keep off-screen objects at the baseline energy importance multiplier

## Testing
- not run (Metal renderer not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5397f3d00832da3cb3cb96a24b9eb