### PR TITLE
Normalize energy residency coverage bias

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -3436,6 +3436,16 @@ bool Renderer::updateEnergyImportance(bool forceAllToggles) {
 
   float visibilityBoost = std::max(_residencyConfig.energyVisibilityBoost, 1.0f);
   const bool applyVisibilityBoost = visibilityBoost > 1.0001f;
+  float referenceCoverageFraction =
+      std::max(_residencyConfig.energyVisibilityReferenceCoverage, 1e-5f);
+  float referenceCoverage = screenArea * referenceCoverageFraction;
+  if (referenceCoverage <= 0.0f)
+    referenceCoverage = 1.0f;
+  const float averageImportanceAcrossObjects =
+      (objectCount > 0)
+          ? _totalPrimitiveImportance /
+                std::max(static_cast<float>(objectCount), 1.0f)
+          : 0.0f;
 
   simd::float3 forward = simd::normalize(Camera::forward);
   simd::float3 up = simd::normalize(Camera::up);
@@ -3500,9 +3510,16 @@ bool Renderer::updateEnergyImportance(bool forceAllToggles) {
       if (objectIndex < _objectBounds.size())
         sphereCoverage = coverageForSphere(_objectBounds[objectIndex]);
       float combinedCoverage = std::max(coverage, sphereCoverage);
-      float visibilityFactor = combinedCoverage > 0.0f ? 1.0f : 0.0f;
-      float multiplier = 1.0f + (visibilityBoost - 1.0f) * visibilityFactor;
-      _objectImportance[objectIndex] = totalImportance * multiplier;
+      float normalizedCoverage = 0.0f;
+      if (combinedCoverage > 0.0f && referenceCoverage > 0.0f)
+        normalizedCoverage =
+            std::clamp(combinedCoverage / referenceCoverage, 0.0f, 1.0f);
+      float multiplier = 1.0f + (visibilityBoost - 1.0f) * normalizedCoverage;
+      float coverageFloor = normalizedCoverage * visibilityBoost *
+                            averageImportanceAcrossObjects;
+      float weightedImportance = totalImportance * multiplier;
+      _objectImportance[objectIndex] =
+          std::max(weightedImportance, coverageFloor);
     } else {
       _objectImportance[objectIndex] = totalImportance;
     }

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -39,6 +39,7 @@ struct ResidencyParameters {
   size_t energyMinActivePrimitives = 16;
   size_t energyMaxTogglesPerFrame = 32;
   float energyVisibilityBoost = 1.75f;
+  float energyVisibilityReferenceCoverage = 0.003f;
 
   float rayHitDecay = 0.85f;
   float rayHitTargetFraction = 0.6f;

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -303,6 +303,9 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         "energyToggleBudget", static_cast<uint64_t>(params.energyMaxTogglesPerFrame)));
     params.energyVisibilityBoost =
         root->FloatAttribute("energyVisibilityBoost", params.energyVisibilityBoost);
+    params.energyVisibilityReferenceCoverage = root->FloatAttribute(
+        "energyVisibilityReferenceCoverage",
+        params.energyVisibilityReferenceCoverage);
 
     params.rayHitDecay = root->FloatAttribute("rayHitDecay", params.rayHitDecay);
     params.rayHitTargetFraction =


### PR DESCRIPTION
## Summary
- add a configurable reference coverage value for the energy residency strategy
- normalize screen coverage to drive the visibility boost and apply a coverage floor for object importance

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e57d23d7b8832d92c26854febca6ef