### PR TITLE
Adjust screen footprint toggle budget handling

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -4315,7 +4315,6 @@ bool Renderer::updateScreenSpaceFootprint(bool forceAllToggles) {
     const MeshGroupCoverage &group = meshGroups[groupIndex];
     std::vector<size_t> objectsToToggle;
     objectsToToggle.reserve(group.objectIndices.size());
-    size_t groupTogglePrimitives = 0;
     bool canToggleGroup = true;
 
     for (size_t objectIndex : group.objectIndices) {
@@ -4342,13 +4341,6 @@ bool Renderer::updateScreenSpaceFootprint(bool forceAllToggles) {
           continue;
         if (!forceAllToggles && prim < _primitiveCooldown.size() &&
             _primitiveCooldown[prim] > 0) {
-          canToggleGroup = false;
-          break;
-        }
-        ++groupTogglePrimitives;
-        if (!forceAllToggles &&
-            toggledPrimitiveCount + groupTogglePrimitives >
-                _residencyConfig.screenFootprintMaxTogglesPerFrame) {
           canToggleGroup = false;
           break;
         }


### PR DESCRIPTION
## Summary
- allow the screen-space residency pass to toggle large mesh groups and clamp the frame budget afterwards, matching the energy residency behaviour
- keep the existing cooldown guards so objects that are still cooling down continue to defer their toggles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e79052d858832d80ade8d5503a435e