### PR TITLE
Tune screen-space demo residency targets

### DIFF
--- a/MetalCpp Path Tracer/scene_screenspace_panorama.xml
+++ b/MetalCpp Path Tracer/scene_screenspace_panorama.xml
@@ -1,6 +1,6 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="screenSpaceFootprint"
        textureResidencyMemoryCapMB="16"
-       screenTargetFraction="0.22" screenMinActive="120" screenToggleBudget="900"
+       screenTargetFraction="0.92" screenMinActive="240" screenToggleBudget="120"
        screenMinPixelCoverage="24">
     <CameraPath>
         <!-- Pan across a wide stage so objects shrink on screen and release residency -->

--- a/MetalCpp Path Tracer/scene_screenspace_zoom.xml
+++ b/MetalCpp Path Tracer/scene_screenspace_zoom.xml
@@ -1,6 +1,6 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="screenSpaceFootprint"
        textureResidencyMemoryCapMB="16"
-       screenTargetFraction="0.18" screenMinActive="100" screenToggleBudget="750"
+       screenTargetFraction="0.90" screenMinActive="200" screenToggleBudget="100"
        screenMinPixelCoverage="18">
     <CameraPath>
         <!-- Rapid zoom exposes how screen coverage reduction frees GPU memory -->


### PR DESCRIPTION
## Summary
- raise the screen-space residency targets for the panorama demo to better match on-screen coverage while limiting toggles
- retune the zoom demo's screen-space residency thresholds to improve coverage without incurring large rebuild spikes

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e7952cb0d4832d8c39e80dfa0bed9c