### PR TITLE
Synchronize ray hit counter readback

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -469,6 +469,11 @@ Renderer::~Renderer() {
     _pPrimitiveHitBufferGPU->release();
   if (_pPrimitiveHitReadback)
     _pPrimitiveHitReadback->release();
+  if (_lastRayHitCommandBuffer) {
+    _lastRayHitCommandBuffer->waitUntilCompleted();
+    _lastRayHitCommandBuffer->release();
+    _lastRayHitCommandBuffer = nullptr;
+  }
   if (_pLightIndexBuffer)
     _pLightIndexBuffer->release();
   if (_pLightCdfBuffer)
@@ -3122,7 +3127,8 @@ void Renderer::draw(MTK::View *pView) {
   pEnc->endEncoding();
 
   MTL::BlitCommandEncoder *pBlit = pCmd->blitCommandEncoder();
-  if (_pPrimitiveHitBufferGPU && _pPrimitiveHitReadback) {
+  bool performedRayHitReadback = false;
+  if (pBlit && _pPrimitiveHitBufferGPU && _pPrimitiveHitReadback) {
     size_t bytes =
         std::min(_pPrimitiveHitBufferGPU->length(),
                  _pPrimitiveHitReadback->length());
@@ -3130,12 +3136,21 @@ void Renderer::draw(MTK::View *pView) {
       pBlit->copyFromBuffer(_pPrimitiveHitBufferGPU, 0, _pPrimitiveHitReadback, 0,
                             bytes);
       pBlit->fillBuffer(_pPrimitiveHitBufferGPU, NS::Range::Make(0, bytes), 0);
+      performedRayHitReadback = true;
     }
   }
-  pBlit->endEncoding();
+  if (pBlit)
+    pBlit->endEncoding();
 
   pCmd->presentDrawable(pView->currentDrawable());
   pCmd->commit();
+
+  if (performedRayHitReadback) {
+    if (_lastRayHitCommandBuffer)
+      _lastRayHitCommandBuffer->release();
+    _lastRayHitCommandBuffer = pCmd;
+    _lastRayHitCommandBuffer->retain();
+  }
 
   pPool->release();
 }
@@ -4562,6 +4577,12 @@ double Renderer::currentGPUMemoryMB() const {
 }
 
 void Renderer::processRayHitCounters() {
+  if (_lastRayHitCommandBuffer) {
+    _lastRayHitCommandBuffer->waitUntilCompleted();
+    _lastRayHitCommandBuffer->release();
+    _lastRayHitCommandBuffer = nullptr;
+  }
+
   if (!_pPrimitiveHitReadback)
     return;
 

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -153,6 +153,7 @@ private:
   MTL::Buffer *_pPrimitiveRemapBuffer = nullptr;
   MTL::Buffer *_pPrimitiveHitBufferGPU = nullptr;
   MTL::Buffer *_pPrimitiveHitReadback = nullptr;
+  MTL::CommandBuffer *_lastRayHitCommandBuffer = nullptr;
   MTL::Buffer *_pLightIndexBuffer = nullptr;
   MTL::Buffer *_pLightCdfBuffer = nullptr;
   MTL::Buffer *_pInstanceBuffer = nullptr;


### PR DESCRIPTION
## Summary
- retain the command buffer used to copy ray hit data to the readback buffer
- wait for the ray hit copy command buffer to finish before processing the counters

## Testing
- not run (Metal runtime unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e7a76bfe08832db56b7922e81738ef