### PR TITLE
Guard ray hit copy completion before releasing buffers

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -465,15 +465,11 @@ Renderer::~Renderer() {
     _pActiveBuffer->release();
   if (_pPrimitiveRemapBuffer)
     _pPrimitiveRemapBuffer->release();
+  flushRayHitCopy();
   if (_pPrimitiveHitBufferGPU)
     _pPrimitiveHitBufferGPU->release();
   if (_pPrimitiveHitReadback)
     _pPrimitiveHitReadback->release();
-  if (_lastRayHitCommandBuffer) {
-    _lastRayHitCommandBuffer->waitUntilCompleted();
-    _lastRayHitCommandBuffer->release();
-    _lastRayHitCommandBuffer = nullptr;
-  }
   if (_pLightIndexBuffer)
     _pLightIndexBuffer->release();
   if (_pLightCdfBuffer)
@@ -754,6 +750,7 @@ void Renderer::updateVisibleScene() {
 
   size_t hitCount = std::max<size_t>(_maxPrimitiveCount, 1);
   size_t hitBytes = hitCount * sizeof(uint32_t);
+  flushRayHitCopy();
   ensureBufferCapacity(_pPrimitiveHitBufferGPU, hitBytes,
                        _primitiveHitBufferCapacity, false,
                        MTL::ResourceStorageModePrivate);
@@ -4576,12 +4573,16 @@ double Renderer::currentGPUMemoryMB() const {
          (1024.0 * 1024.0);
 }
 
-void Renderer::processRayHitCounters() {
+void Renderer::flushRayHitCopy() {
   if (_lastRayHitCommandBuffer) {
     _lastRayHitCommandBuffer->waitUntilCompleted();
     _lastRayHitCommandBuffer->release();
     _lastRayHitCommandBuffer = nullptr;
   }
+}
+
+void Renderer::processRayHitCounters() {
+  flushRayHitCopy();
 
   if (!_pPrimitiveHitReadback)
     return;

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -120,6 +120,7 @@ private:
   void flushResidencyChanges(bool forceFullRebuild);
   void beginFrameMetrics();
   void completeFrameMetrics(MTL::CommandBuffer *pCmd);
+  void flushRayHitCopy();
   void processRayHitCounters();
   bool buildObjectBlas(size_t objectIndex, const SceneObject &object,
                        ResidentObjectGpuResources &residentResources);


### PR DESCRIPTION
## Summary
- add a flushRayHitCopy helper to centralize waiting for the ray-hit copy command buffer
- invoke the helper before releasing the ray-hit buffers in the destructor and when reallocating them

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7ad75ab14832dae00f22a69c868f8