### PR TITLE
Parallelize ray hit counter processing

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -4741,14 +4741,16 @@ void Renderer::processRayHitCounters() {
   if (_primitiveHitLastFrame.size() < totalPrimitiveCount)
     _primitiveHitLastFrame.resize(totalPrimitiveCount, 0);
 
-  for (size_t i = 0; i < count; ++i) {
-    uint32_t hits = hitPtr[i];
-    _primitiveHitLastFrame[i] = hits;
-    _primitiveHitScores[i] =
-        _primitiveHitScores[i] * _residencyConfig.rayHitDecay +
-        static_cast<float>(hits);
-    hitPtr[i] = 0;
-  }
+  parallelChunkedAsync(0, count, [&](size_t chunkStart, size_t chunkEnd) {
+    for (size_t i = chunkStart; i < chunkEnd; ++i) {
+      uint32_t hits = hitPtr[i];
+      _primitiveHitLastFrame[i] = hits;
+      _primitiveHitScores[i] =
+          _primitiveHitScores[i] * _residencyConfig.rayHitDecay +
+          static_cast<float>(hits);
+      hitPtr[i] = 0;
+    }
+  });
 }
 
 void Renderer::beginFrameMetrics() {


### PR DESCRIPTION
## Summary
- replace the serial ray hit counter loop with `parallelChunkedAsync` so the updates run per-chunk

## Testing
- not run (Metal tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e7c7fd0a2c832db3ffe14df0f44ba8