### PR TITLE
Optimize small workloads in parallelChunkedAsync

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -171,6 +171,14 @@ void parallelChunkedAsync(size_t start, size_t end, Func &&func) {
   const size_t total = end - start;
   const unsigned int threadCount =
       std::max(1u, std::thread::hardware_concurrency());
+  const size_t smallWorkThreshold =
+      static_cast<size_t>(threadCount) * static_cast<size_t>(64);
+
+  if (total <= smallWorkThreshold) {
+    work(start, end);
+    return;
+  }
+
   const size_t chunkSize = std::max<size_t>(
       1, (total + static_cast<size_t>(threadCount) - 1) /
              static_cast<size_t>(threadCount));


### PR DESCRIPTION
## Summary
- add an early exit in `parallelChunkedAsync` to run small workloads on the calling thread
- keep the existing dispatch-based chunking path for larger ranges

## Testing
- not run (macOS-specific tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e7cb48df0c832dafc70431518e0e8e