### PR TITLE
Avoid blocking ray hit counter readback

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -3242,6 +3242,7 @@ void Renderer::draw(MTK::View *pView) {
       _lastRayHitCommandBuffer->release();
     _lastRayHitCommandBuffer = pCmd;
     _lastRayHitCommandBuffer->retain();
+    _rayHitCopyError = false;
   }
 
   pPool->release();
@@ -4704,16 +4705,44 @@ double Renderer::currentGPUMemoryMB() const {
          (1024.0 * 1024.0);
 }
 
-void Renderer::flushRayHitCopy() {
-  if (_lastRayHitCommandBuffer) {
-    _lastRayHitCommandBuffer->waitUntilCompleted();
-    _lastRayHitCommandBuffer->release();
-    _lastRayHitCommandBuffer = nullptr;
+bool Renderer::rayHitCopyReady() const {
+  if (!_lastRayHitCommandBuffer)
+    return true;
+
+  auto status = _lastRayHitCommandBuffer->status();
+  return status == MTL::CommandBufferStatus::CommandBufferStatusCompleted ||
+         status == MTL::CommandBufferStatus::CommandBufferStatusError;
+}
+
+bool Renderer::flushRayHitCopy() {
+  if (!_lastRayHitCommandBuffer)
+    return true;
+
+  auto status = _lastRayHitCommandBuffer->status();
+
+  switch (status) {
+  case MTL::CommandBufferStatus::CommandBufferStatusCompleted:
+    _rayHitCopyError = false;
+    break;
+  case MTL::CommandBufferStatus::CommandBufferStatusError:
+    _rayHitCopyError = true;
+    break;
+  case MTL::CommandBufferStatus::CommandBufferStatusCommitted:
+  case MTL::CommandBufferStatus::CommandBufferStatusScheduled:
+  case MTL::CommandBufferStatus::CommandBufferStatusEnqueued:
+  case MTL::CommandBufferStatus::CommandBufferStatusNotEnqueued:
+  default:
+    return false;
   }
+
+  _lastRayHitCommandBuffer->release();
+  _lastRayHitCommandBuffer = nullptr;
+  return true;
 }
 
 void Renderer::processRayHitCounters() {
-  flushRayHitCopy();
+  if (!flushRayHitCopy())
+    return;
 
   if (!_pPrimitiveHitReadback)
     return;
@@ -4723,6 +4752,14 @@ void Renderer::processRayHitCounters() {
       static_cast<uint32_t *>(_pPrimitiveHitReadback->contents());
   if (!hitPtr)
     return;
+
+  if (_rayHitCopyError) {
+    std::memset(hitPtr, 0, bufferLength);
+    _primitiveHitScores.clear();
+    _primitiveHitLastFrame.clear();
+    _rayHitCopyError = false;
+    return;
+  }
 
   if (!_pScene ||
       _pScene->getResidencyStrategy() != ResidencyStrategy::RayHitBudget) {

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -120,7 +120,8 @@ private:
   void flushResidencyChanges(bool forceFullRebuild);
   void beginFrameMetrics();
   void completeFrameMetrics(MTL::CommandBuffer *pCmd);
-  void flushRayHitCopy();
+  bool flushRayHitCopy();
+  bool rayHitCopyReady() const;
   void processRayHitCounters();
   bool buildObjectBlas(size_t objectIndex, const SceneObject &object,
                        ResidentObjectGpuResources &residentResources);
@@ -155,6 +156,7 @@ private:
   MTL::Buffer *_pPrimitiveHitBufferGPU = nullptr;
   MTL::Buffer *_pPrimitiveHitReadback = nullptr;
   MTL::CommandBuffer *_lastRayHitCommandBuffer = nullptr;
+  bool _rayHitCopyError = false;
   MTL::Buffer *_pLightIndexBuffer = nullptr;
   MTL::Buffer *_pLightCdfBuffer = nullptr;
   MTL::Buffer *_pInstanceBuffer = nullptr;


### PR DESCRIPTION
## Summary
- check the ray hit readback command buffer status before releasing it and expose readiness helpers
- skip CPU-side accumulation until the GPU copy completes while clearing counters on errors

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e7d0dbc974832db38e67b75a2825ce