### PR TITLE
Capture strategy labels in run comparison plots

### DIFF
--- a/compare_runs.py
+++ b/compare_runs.py
@@ -3,15 +3,17 @@
 
 The tool expects the CSVs to contain a ``frame`` column plus one or more
 numeric metric columns.  For every metric that exists in both files a
-``frame vs metric`` plot is written next to the CSVs.  This is useful when
-benchmark runs are timestamped under ``benchmarks/runs1``.
+``frame vs metric`` plot is written next to the CSVs.  When present, a
+``strategy`` column provides the legend label; otherwise the filename stem
+is used.  This is useful when benchmark runs are timestamped under
+``benchmarks/runs1``.
 """
 from __future__ import annotations
 
 import argparse
 import csv
 from pathlib import Path
-from typing import Dict, Iterable, List, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 
@@ -19,11 +21,12 @@ Frames = List[int]
 Series = Dict[str, List[float]]
 
 
-def _load_csv(path: Path) -> Tuple[Frames, Series]:
-    """Return frame numbers and numeric metric series from ``path``."""
+def _load_csv(path: Path) -> Tuple[Frames, Series, str]:
+    """Return frame numbers, numeric metric series, and the shared strategy."""
 
     frames: Frames = []
     metrics: Series = {}
+    strategy: Optional[str] = None
 
     with path.open("r", encoding="utf-8") as fh:
         reader = csv.DictReader(fh)
@@ -35,6 +38,15 @@ def _load_csv(path: Path) -> Tuple[Frames, Series]:
             if frame_value is None or frame_value == "":
                 raise ValueError(f"Missing 'frame' value in {path}")
             frames.append(int(float(frame_value)))
+
+            row_strategy = row.get("strategy")
+            if row_strategy:
+                if strategy is None:
+                    strategy = row_strategy
+                elif strategy != row_strategy:
+                    raise ValueError(
+                        f"Inconsistent strategy values in {path}: '{strategy}' vs '{row_strategy}'"
+                    )
 
             for key, value in row.items():
                 if key == "frame" or value in (None, ""):
@@ -52,7 +64,7 @@ def _load_csv(path: Path) -> Tuple[Frames, Series]:
         for key, values in metrics.items()
         if len(values) == valid_frame_count
     }
-    return frames, metrics
+    return frames, metrics, strategy or ""
 
 
 def _metric_names(metrics_a: Series, metrics_b: Series) -> Iterable[str]:
@@ -76,11 +88,10 @@ def plot_metrics(
     frames_b: Frames,
     metrics_a: Series,
     metrics_b: Series,
+    label_a: str,
+    label_b: str,
 ) -> None:
     """Plot shared metrics between ``csv_a`` and ``csv_b``."""
-
-    label_a = csv_a.stem
-    label_b = csv_b.stem
 
     for metric in _metric_names(metrics_a, metrics_b):
         plt.figure(figsize=(10, 6))
@@ -116,13 +127,26 @@ def main() -> None:
     if not csv_a.is_file() or not csv_b.is_file():
         raise FileNotFoundError("Both CSV paths must point to files")
 
-    frames_a, metrics_a = _load_csv(csv_a)
-    frames_b, metrics_b = _load_csv(csv_b)
+    frames_a, metrics_a, strategy_a = _load_csv(csv_a)
+    frames_b, metrics_b, strategy_b = _load_csv(csv_b)
+
+    label_a = strategy_a if strategy_a else csv_a.stem
+    label_b = strategy_b if strategy_b else csv_b.stem
 
     output_dir = args.output_dir.resolve() if args.output_dir else csv_a.parent
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    plot_metrics(csv_a, csv_b, output_dir, frames_a, frames_b, metrics_a, metrics_b)
+    plot_metrics(
+        csv_a,
+        csv_b,
+        output_dir,
+        frames_a,
+        frames_b,
+        metrics_a,
+        metrics_b,
+        label_a,
+        label_b,
+    )
 
     print(f"Saved plots to: {output_dir}")
 


### PR DESCRIPTION
## Summary
- extract the shared strategy label while loading benchmark CSVs and validate consistency
- surface strategy labels in plot legends, falling back to filename stems when absent
- document how the labels are derived during comparisons

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e8331e2e9c832dbb01f500eca95734