### PR TITLE
Prevent observer screen clamp underflow

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -3451,8 +3451,13 @@ simd::float2 Renderer::computeObserverScreenSize(
     desiredWidth = desiredHeight * aspect;
   }
 
-  desiredWidth = std::clamp(desiredWidth, 160.0f, mainWidth - 64.0f);
-  desiredHeight = std::clamp(desiredHeight, 120.0f, mainHeight - 64.0f);
+  const float minObserverWidth = 160.0f;
+  const float minObserverHeight = 120.0f;
+  const float maxWidthClamp = std::max(mainWidth - 64.0f, minObserverWidth);
+  const float maxHeightClamp = std::max(mainHeight - 64.0f, minObserverHeight);
+
+  desiredWidth = std::clamp(desiredWidth, minObserverWidth, maxWidthClamp);
+  desiredHeight = std::clamp(desiredHeight, minObserverHeight, maxHeightClamp);
 
   return {desiredWidth, desiredHeight};
 }


### PR DESCRIPTION
## Summary
- guard observer screen size clamps by ensuring maximum bounds never fall below minimum thresholds
- use local variables to precompute safe clamp limits for both width and height

## Testing
- not run (macOS/Metal toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e85f5edc8c832daa2e314c5c6bbd91