### PR TITLE
Add configurable observer camera

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Camera.h
+++ b/MetalCpp Path Tracer/Renderer/Camera.h
@@ -9,6 +9,15 @@ namespace MetalCppPathTracer {
 namespace Camera
 {
 
+struct State
+{
+    simd::float3 position {0, 0, 0};
+    simd::float3 forward {0, 0, -1};
+    simd::float3 up {0, 1, 0};
+    float verticalFov = 60.0f;
+    float focalLength = 1.0f;
+};
+
 inline simd::float3 position;
 inline simd::float3 forward;
 inline simd::float3 up;
@@ -31,6 +40,20 @@ inline static void reset()
     verticalFov = 60.0;
     focalLength = 1.0;
     deltaTime = 0.0f;
+}
+
+inline State captureState()
+{
+    return {position, forward, up, verticalFov, focalLength};
+}
+
+inline void applyState(const State& state)
+{
+    position = state.position;
+    forward = state.forward;
+    up = state.up;
+    verticalFov = state.verticalFov;
+    focalLength = state.focalLength;
 }
 
 

--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -296,6 +296,39 @@ void markBufferModified(MTL::Buffer *buffer, NS::Range range) {
     buffer->didModifyRange(range);
 }
 
+static bool cameraStatesDiffer(const Camera::State &a, const Camera::State &b,
+                               float epsilon = 1e-3f) {
+  if (simd::length(a.position - b.position) > epsilon)
+    return true;
+  if (simd::length(a.forward - b.forward) > epsilon)
+    return true;
+  if (simd::length(a.up - b.up) > epsilon)
+    return true;
+  if (std::abs(a.verticalFov - b.verticalFov) > epsilon)
+    return true;
+  if (std::abs(a.focalLength - b.focalLength) > epsilon)
+    return true;
+  return false;
+}
+
+static Camera::State makeCameraState(const simd::float3 &position,
+                                     const simd::float3 &lookAt,
+                                     float verticalFov, float focalLength,
+                                     const simd::float3 &fallbackForward) {
+  Camera::State state{};
+  state.position = position;
+  simd::float3 direction = lookAt - position;
+  if (simd::length_squared(direction) > 1e-6f) {
+    state.forward = simd::normalize(direction);
+  } else {
+    state.forward = fallbackForward;
+  }
+  state.up = {0, 1, 0};
+  state.verticalFov = verticalFov;
+  state.focalLength = focalLength;
+  return state;
+}
+
 int buildBVHRecursive(const std::vector<Primitive> &primitives,
                       std::vector<int> &primitiveIndices,
                       std::vector<BVHNode> &nodes, size_t start, size_t end) {
@@ -522,6 +555,8 @@ Renderer::Renderer(MTL::Device *pDevice)
   _dummyBlasResources.initialize(_pDevice);
 
   Camera::reset();
+  _primaryCameraState = Camera::captureState();
+  _observerCameraState = _primaryCameraState;
 
   updateVisibleScene();
   buildShaders();
@@ -895,13 +930,32 @@ void Renderer::updateVisibleScene() {
   }
 
   Camera::screenSize = _pScene->screenSize;
+  _animationFrame = 0;
+  _observerActive = false;
 
   if (!_pScene->cameraPath.empty()) {
     const auto &k = _pScene->cameraPath.front();
-    Camera::position = k.position;
-    Camera::forward = simd::normalize(k.lookAt - k.position);
-    Camera::up = {0, 1, 0};
+    _primaryCameraState = makeCameraState(
+        k.position, k.lookAt, _primaryCameraState.verticalFov,
+        _primaryCameraState.focalLength, _primaryCameraState.forward);
   }
+
+  Camera::applyState(_primaryCameraState);
+  _primaryCameraState = Camera::captureState();
+
+  if (_pScene->hasObserverCamera()) {
+    const auto &observer = _pScene->getObserverCamera();
+    float fov = observer.verticalFov > 0.0f ? observer.verticalFov
+                                            : _primaryCameraState.verticalFov;
+    _observerCameraState =
+        makeCameraState(observer.position, observer.lookAt, fov,
+                        _primaryCameraState.focalLength,
+                        _primaryCameraState.forward);
+  } else {
+    _observerCameraState = _primaryCameraState;
+  }
+
+  Camera::applyState(_primaryCameraState);
 
   printf("Scene loaded: %zu total primitives (%zu spheres, %zu triangles, %zu "
          "rectangles)\n",
@@ -3145,19 +3199,35 @@ void Renderer::updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd) {
   pCompute->endEncoding();
 }
 
-bool Renderer::updateCamera() {
+bool Renderer::updateCameraStates() {
   const auto &path = _pScene->cameraPath;
+  bool hadObserver = _observerActive;
+  Camera::State previousViewState =
+      hadObserver ? _observerCameraState : _primaryCameraState;
 
-  // If the scene defines a camera path, advance along it every render pass
+  bool toggled = false;
+  if (InputSystem::observerToggleRequest) {
+    _observerActive = !_observerActive;
+    InputSystem::observerToggleRequest = false;
+    toggled = true;
+  }
+
+  double originalDelta = _deltaTimeSeconds;
+
   if (!path.empty()) {
+    Camera::State newState = _primaryCameraState;
     if (_animationFrame <= path.front().frame) {
-      Camera::position = path.front().position;
-      simd::float3 look = path.front().lookAt;
-      Camera::forward = simd::normalize(look - Camera::position);
+      const auto &k = path.front();
+      newState = makeCameraState(k.position, k.lookAt,
+                                 _primaryCameraState.verticalFov,
+                                 _primaryCameraState.focalLength,
+                                 _primaryCameraState.forward);
     } else if (_animationFrame >= path.back().frame) {
-      Camera::position = path.back().position;
-      simd::float3 look = path.back().lookAt;
-      Camera::forward = simd::normalize(look - Camera::position);
+      const auto &k = path.back();
+      newState = makeCameraState(k.position, k.lookAt,
+                                 _primaryCameraState.verticalFov,
+                                 _primaryCameraState.focalLength,
+                                 _primaryCameraState.forward);
     } else {
       for (size_t i = 0; i + 1 < path.size(); ++i) {
         const auto &k0 = path[i];
@@ -3165,41 +3235,56 @@ bool Renderer::updateCamera() {
         if (_animationFrame >= k0.frame && _animationFrame <= k1.frame) {
           float t =
               float(_animationFrame - k0.frame) / float(k1.frame - k0.frame);
-          Camera::position = k0.position + t * (k1.position - k0.position);
+          simd::float3 position =
+              k0.position + t * (k1.position - k0.position);
           simd::float3 look = k0.lookAt + t * (k1.lookAt - k0.lookAt);
-          Camera::forward = simd::normalize(look - Camera::position);
+          newState = makeCameraState(position, look,
+                                     _primaryCameraState.verticalFov,
+                                     _primaryCameraState.focalLength,
+                                     _primaryCameraState.forward);
           break;
         }
       }
     }
 
-    Camera::up = {0, 1, 0};
-    // Reset the frame delta while scripted motion drives the camera so the
-    // timeline remains frame-locked.
+    if (cameraStatesDiffer(newState, _primaryCameraState))
+      _primaryCameraState = newState;
+
     _deltaTimeSeconds = 0.0;
     Camera::deltaTime = 0.0f;
-    InputSystem::clearInputs();
 
-    // Update view dependent data for the new camera transform
-    recalculateViewport();
+    Camera::applyState(_observerCameraState);
+    Camera::deltaTime = static_cast<float>(originalDelta);
+    if (Camera::transformWithInputs())
+      _observerCameraState = Camera::captureState();
 
-    // Move to the next keyframe for the following frame
     _animationFrame++;
-    return true;
+  } else {
+    Camera::State *target =
+        _observerActive ? &_observerCameraState : &_primaryCameraState;
+    Camera::applyState(*target);
+    Camera::deltaTime = static_cast<float>(_deltaTimeSeconds);
+    if (Camera::transformWithInputs())
+      *target = Camera::captureState();
   }
 
-  // Fall back to interactive controls when no keyframes are present
-  bool changed = Camera::transformWithInputs();
-  if (changed) {
+  const Camera::State &activeView =
+      _observerActive ? _observerCameraState : _primaryCameraState;
+  Camera::applyState(activeView);
+  Camera::deltaTime = _observerActive ? 0.0f
+                                      : static_cast<float>(_deltaTimeSeconds);
+
+  bool viewChanged = toggled || cameraStatesDiffer(activeView, previousViewState) ||
+                     hadObserver != _observerActive;
+  if (viewChanged)
     recalculateViewport();
-  }
-  return changed;
+
+  return viewChanged;
 }
 
-void Renderer::updateUniforms() {
+void Renderer::updateUniforms(bool cameraChanged) {
   UniformsData &u = *((UniformsData *)_pUniformsBuffer->contents());
 
-  bool cameraChanged = updateCamera();
   if (cameraChanged)
     _needsAccumulationReset = true;
 
@@ -3262,8 +3347,17 @@ void Renderer::updateUniforms() {
 
 void Renderer::draw(MTK::View *pView) {
   processRayHitCounters();
+  bool cameraChanged = updateCameraStates();
+  Camera::State viewCamera =
+      _observerActive ? _observerCameraState : _primaryCameraState;
+
+  Camera::applyState(_primaryCameraState);
   updateResidency();
-  updateUniforms();
+
+  Camera::applyState(viewCamera);
+  Camera::deltaTime =
+      _observerActive ? 0.0f : static_cast<float>(_deltaTimeSeconds);
+  updateUniforms(cameraChanged);
   beginFrameMetrics();
   std::swap(_accumulationSlots[0], _accumulationSlots[1]);
 

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "GpuHeapResources.h"
+#include "Camera.h"
 #include "Scene.h"
 
 namespace MetalCppPathTracer {
@@ -72,9 +73,9 @@ public:
   void buildTextures();
 
   void recalculateViewport();
-  bool updateCamera();
+  bool updateCameraStates();
 
-  void updateUniforms();
+  void updateUniforms(bool cameraChanged);
   void draw(MTK::View *pView);
   void drawableSizeWillChange(MTK::View *pView, CGSize size);
   void setDeltaTime(double deltaSeconds);
@@ -96,6 +97,10 @@ public:
   size_t totalNodeCount() const;
 
   std::vector<std::pair<simd::float3, float>> _allSpheres;
+
+  Camera::State _primaryCameraState{};
+  Camera::State _observerCameraState{};
+  bool _observerActive = false;
 
   struct Chunk {
     std::vector<std::pair<simd::float4, simd::float4>>

--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -27,6 +27,8 @@ void Scene::clear() {
   residencyParams = ResidencyParameters{};
   startCompacted = false;
   textureResidencyMemoryCapMB = 2048.0;
+  observerCameraValid = false;
+  observerCamera = ObserverCamera{};
 }
 
 size_t Scene::addPrimitive(const Primitive &p) {
@@ -137,6 +139,17 @@ double Scene::getTextureResidencyMemoryCapMB() const {
 
 void Scene::setTextureResidencyMemoryCapMB(double capMB) {
   textureResidencyMemoryCapMB = capMB;
+}
+
+void Scene::setObserverCamera(const ObserverCamera &camera) {
+  observerCamera = camera;
+  observerCameraValid = true;
+}
+
+bool Scene::hasObserverCamera() const { return observerCameraValid; }
+
+const ObserverCamera &Scene::getObserverCamera() const {
+  return observerCamera;
 }
 
 void Scene::buildBVH() {

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -65,6 +65,12 @@ struct CameraKeyframe {
   simd::float3 lookAt;
 };
 
+struct ObserverCamera {
+  simd::float3 position = simd::make_float3(0.0f, 0.0f, 0.0f);
+  simd::float3 lookAt = simd::make_float3(0.0f, 0.0f, -1.0f);
+  float verticalFov = 60.0f;
+};
+
 class Scene {
 public:
   Scene();
@@ -123,6 +129,10 @@ public:
 
   std::vector<CameraKeyframe> cameraPath;
 
+  void setObserverCamera(const ObserverCamera &camera);
+  bool hasObserverCamera() const;
+  const ObserverCamera &getObserverCamera() const;
+
 private:
   std::vector<Primitive> primitives;
   std::vector<size_t> primitiveIndices;
@@ -134,6 +144,8 @@ private:
   ResidencyParameters residencyParams;
   bool startCompacted;
   double textureResidencyMemoryCapMB;
+  bool observerCameraValid;
+  ObserverCamera observerCamera;
 
   size_t addObjectInternal(const Primitive *prims, size_t count,
                           bool logPrimitives, int meshGroupId);

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -420,6 +420,17 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
                 scene->cameraPath.push_back(key);
             }
         }
+        else if (tag == "ObserverCamera") {
+            ObserverCamera observer{};
+            if (const char* posAttr = e->Attribute("position")) {
+                observer.position = parseVec3(posAttr);
+            }
+            if (const char* lookAttr = e->Attribute("lookAt")) {
+                observer.lookAt = parseVec3(lookAttr);
+            }
+            observer.verticalFov = e->FloatAttribute("verticalFov", observer.verticalFov);
+            scene->setObserverCamera(observer);
+        }
     }
 
     return true;

--- a/MetalCpp Path Tracer/Window/ControllerView.mm
+++ b/MetalCpp Path Tracer/Window/ControllerView.mm
@@ -92,6 +92,9 @@ MTK::View *MetalCppPathTracer::ControllerView::get(CGRect frame) {
     if(event.keyCode == 11) { // b - toggle BLAS debug
         MetalCppPathTracer::InputSystem::debugAS = (MetalCppPathTracer::InputSystem::debugAS == 2) ? 0 : 2;
     }
+    if(event.keyCode == 31) { // o - toggle observer camera
+        MetalCppPathTracer::InputSystem::observerToggleRequest = true;
+    }
 }
 
 - (void)keyUp:(NSEvent *)event {

--- a/MetalCpp Path Tracer/Window/InputSystem.h
+++ b/MetalCpp Path Tracer/Window/InputSystem.h
@@ -13,6 +13,7 @@ inline simd::float2 rotationInput {0};
 inline float zoomInput = 0;
 inline bool resetInput = 0;
 inline int debugAS = 0; // 0:none, 1:TLAS, 2:BLAS
+inline bool observerToggleRequest = false;
 
 inline void clearInputs()
 {

--- a/MetalCpp Path Tracer/scene_distance_lod_staggered.xml
+++ b/MetalCpp Path Tracer/scene_distance_lod_staggered.xml
@@ -1,6 +1,8 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="distance"
        textureResidencyMemoryCapMB="16"
        lodEnterDistance="45" lodExitDistance="65" residencyCooldown="2" lodToggleBudget="8000">
+    <ObserverCamera position="0,48,-140" lookAt="0,12,-60" verticalFov="45" />
+
     <CameraPath>
         <!-- Climb up and orbit so outer rings fall outside the distance budget -->
         <Keyframe frame="0" position="0,6,-25" lookAt="0,3,0" />

--- a/MetalCpp Path Tracer/scene_distance_lod_sweep.xml
+++ b/MetalCpp Path Tracer/scene_distance_lod_sweep.xml
@@ -1,6 +1,8 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="distance"
        textureResidencyMemoryCapMB="16"
        lodEnterDistance="55" lodExitDistance="80" residencyCooldown="0" lodToggleBudget="12000">
+    <ObserverCamera position="-70,42,-15" lookAt="0,10,-100" verticalFov="40" />
+
     <CameraPath>
         <!-- Slow dolly backwards so distant clusters can be released from memory -->
         <Keyframe frame="0" position="0,12,20" lookAt="0,5,-60" />


### PR DESCRIPTION
## Summary
- add camera state helpers and track both primary and observer viewpoints
- extend scene loading with an <ObserverCamera> definition and input toggle to activate it
- drive residency from the primary camera while allowing the observer view to render independently

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e862b5ab40832db8b2c55aa9132e07