### PR TITLE
Add environment controls for renderer frame capture

### DIFF
--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -1,0 +1,10 @@
+# Benchmarks and Frame Capture Controls
+
+The path tracer can emit additional metrics and frame captures while running benchmarks. Configure the behavior with the following environment variables before launching the app:
+
+- `MPT_RUNS_PATH` (default: unset) – directory where run artifacts such as acceleration structure dumps and CSV metrics are written.
+- `MPT_MAX_FRAMES` (default: unset) – stop rendering after the specified number of frames when keyframes are present.
+- `MPT_CAPTURE_EXR` (default: `0`) – set to `1`, `true`, or `yes` to enable EXR frame capture from the renderer.
+- `MPT_CAPTURE_INTERVAL` (default: `1`) – capture every _n_ frames when EXR capture is enabled. Values less than `1` are ignored and treated as `1`.
+
+These variables can be exported in your shell or added to any run scripts you maintain for benchmarking sessions.

--- a/MetalCpp Path Tracer/Window/ViewDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.cpp
@@ -2,6 +2,7 @@
 #include "ControllerView.hpp"
 #include <AppKit/AppKit.hpp>
 #include <chrono>
+#include <cctype>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
@@ -33,6 +34,28 @@ ViewDelegate::ViewDelegate(MTL::Device *pDevice)
     if (_gpuMemLog.is_open())
       _gpuMemLog << "frame,gpu_memory_mb\n";
   }
+
+  auto parseBoolEnv = [](const char *value) {
+    if (!value || !value[0])
+      return false;
+    if (std::isdigit(static_cast<unsigned char>(value[0])))
+      return std::strtoul(value, nullptr, 10) != 0;
+    char first = static_cast<char>(
+        std::tolower(static_cast<unsigned char>(value[0])));
+    return first == 't' || first == 'y';
+  };
+
+  bool captureEnabled = parseBoolEnv(std::getenv("MPT_CAPTURE_EXR"));
+
+  size_t captureInterval = 1;
+  if (const char *intervalEnv = std::getenv("MPT_CAPTURE_INTERVAL")) {
+    unsigned long parsed = std::strtoul(intervalEnv, nullptr, 10);
+    if (parsed > 0)
+      captureInterval = parsed;
+  }
+
+  _pRenderer->setFrameCaptureEnabled(captureEnabled);
+  _pRenderer->setFrameCaptureInterval(captureInterval);
 }
 
 ViewDelegate::~ViewDelegate() {


### PR DESCRIPTION
## Summary
- parse the MPT_CAPTURE_EXR and MPT_CAPTURE_INTERVAL environment variables in the view delegate
- forward the parsed values to the renderer so frame capture can be enabled and scheduled
- document the benchmark-related environment variables, including the new capture options

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ecf0965720832d90809d514e0cc364