### PR TITLE
Fix SaveEXR invocation with fp16 flag

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1051,10 +1051,12 @@ void Renderer::finalizeFrameCapture(
     return;
   }
 
-  const char *err = nullptr;
-  int ret = SaveEXR(rgba.data(), static_cast<int>(capture->width),
-                    static_cast<int>(capture->height), 4,
-                    capture->filePath.c_str(), &err);
+    const char *err = nullptr;
+    int saveAsFp16 =
+        capture->format == MTL::PixelFormat::PixelFormatRGBA16Float ? 1 : 0;
+    int ret = SaveEXR(rgba.data(), static_cast<int>(capture->width),
+                      static_cast<int>(capture->height), 4, saveAsFp16,
+                      capture->filePath.c_str(), &err);
   if (ret != TINYEXR_SUCCESS) {
     if (err) {
       std::printf("Failed to save EXR frame %llu: %s\n",


### PR DESCRIPTION
## Summary
- add the required fp16 save flag when calling `SaveEXR`
- preserve half-float captures by toggling the flag based on the render target format

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ecfc94cb08832da01c4f9315e86104