### PR TITLE
Convert scene_v0.6 to SceneLoader XML schema

### DIFF
--- a/MetalCpp Path Tracer/scene_v0.6.xml
+++ b/MetalCpp Path Tracer/scene_v0.6.xml
@@ -1,188 +1,46 @@
-<?xml version="1.0" encoding="utf-8"?>
+<Scene width="1280" height="720" maxRayDepth="17" startCompacted="false" residencyStrategy="alwaysResident">
+    <!-- Converted from Mitsuba-style scene_v0.6.xml to the custom loader schema -->
+    <ObserverCamera position="58.206,24.9284,52.9501" lookAt="58.921531,25.156785,53.610294" verticalFov="35" />
 
-<scene version="0.5.0" >
-	<integrator type="path" >
-		<integer name="maxDepth" value="17" />
-		<boolean name="strictNormals" value="true" />
-	</integrator>
-	<sensor type="perspective" >
-		<float name="fov" value="35" />
-		<transform name="toWorld" >
-			<matrix value="-0.678116 -0.167853 -0.715531 58.206 -4.39487e-008 0.973571 -0.228385 24.9284 0.734955 -0.154871 -0.660194 52.9501 0 0 0 1"/>
-		</transform>
-		<sampler type="sobol" >
-			<integer name="sampleCount" value="64" />
-		</sampler>
-		<film type="ldrfilm" >
-			<integer name="width" value="1280" />
-			<integer name="height" value="720" />
-			<string name="fileFormat" value="png" />
-			<string name="pixelFormat" value="rgb" />
-			<float name="gamma" value="2.2" />
-			<boolean name="banner" value="false" />
-			<rfilter type="tent" />
-		</film>
-	</sensor>
-	<bsdf type="twosided" id="GroundInner" >
-		<bsdf type="diffuse" >
-			<rgb name="reflectance" value="0.456263, 0.456263, 0.456263"/>
-		</bsdf>
-	</bsdf>
-	<bsdf type="twosided" id="GroundOuter" >
-		<bsdf type="diffuse" >
-			<rgb name="reflectance" value="0.456263, 0.456263, 0.456263"/>
-		</bsdf>
-	</bsdf>
-	<bsdf type="twosided" id="Cloth" >
-		<bsdf type="diffuse" >
-			<rgb name="reflectance" value="0.456263, 0.456263, 0.456263"/>
-		</bsdf>
-	</bsdf>
-	<bsdf type="twosided" id="Dragon" >
-		<bsdf type="diffuse" >
-			<rgb name="reflectance" value="0.79311, 0.79311, 0.79311"/>
-		</bsdf>
-	</bsdf>
-	<bsdf type="twosided" id="Blade" >
-		<bsdf type="diffuse" >
-			<rgb name="reflectance" value="0.79311, 0.79311, 0.79311"/>
-		</bsdf>
-	</bsdf>
-	<bsdf type="twosided" id="Sword" >
-		<bsdf type="diffuse" >
-			<rgb name="reflectance" value="0.79311, 0.79311, 0.79311"/>
-		</bsdf>
-	</bsdf>
-	<bsdf type="twosided" id="Deco" >
-		<bsdf type="diffuse" >
-			<rgb name="reflectance" value="0.79311, 0.79311, 0.79311"/>
-		</bsdf>
-	</bsdf>
-	<bsdf type="twosided" id="Diamond" >
-		<bsdf type="diffuse" >
-			<rgb name="reflectance" value="0.79311, 0.79311, 0.79311"/>
-		</bsdf>
-	</bsdf>
-	<bsdf type="twosided" id="Deco2" >
-		<bsdf type="diffuse" >
-			<rgb name="reflectance" value="0.79311, 0.79311, 0.79311"/>
-		</bsdf>
-	</bsdf>
-	<shape type="obj" >
-		<string name="filename" value="models/Mesh011.obj" />
-		<transform name="toWorld" >
-			<matrix value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-		</transform>
-		<ref id="GroundOuter" />
-	</shape>
-	<shape type="obj" >
-		<string name="filename" value="models/Mesh010.obj" />
-		<transform name="toWorld" >
-			<matrix value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-		</transform>
-		<ref id="Cloth" />
-	</shape>
-	<shape type="obj" >
-		<string name="filename" value="models/Mesh005.obj" />
-		<transform name="toWorld" >
-			<matrix value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-		</transform>
-		<ref id="GroundOuter" />
-	</shape>
-	<shape type="obj" >
-		<string name="filename" value="models/Mesh006.obj" />
-		<transform name="toWorld" >
-			<matrix value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-		</transform>
-		<ref id="GroundOuter" />
-	</shape>
-	<shape type="obj" >
-		<string name="filename" value="models/Mesh012.obj" />
-		<transform name="toWorld" >
-			<matrix value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-		</transform>
-		<ref id="GroundInner" />
-	</shape>
-	<shape type="obj" >
-		<string name="filename" value="models/Mesh007.obj" />
-		<transform name="toWorld" >
-			<matrix value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-		</transform>
-		<ref id="GroundOuter" />
-	</shape>
-	<shape type="obj" >
-		<string name="filename" value="models/Mesh008.obj" />
-		<transform name="toWorld" >
-			<matrix value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-		</transform>
-		<ref id="Dragon" />
-	</shape>
-	<shape type="obj" >
-		<string name="filename" value="models/Mesh013.obj" />
-		<transform name="toWorld" >
-			<matrix value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-		</transform>
-		<ref id="Dragon" />
-	</shape>
-	<shape type="obj" >
-		<string name="filename" value="models/Mesh014.obj" />
-		<transform name="toWorld" >
-			<matrix value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-		</transform>
-		<ref id="Dragon" />
-	</shape>
-	<shape type="obj" >
-		<string name="filename" value="models/Mesh015.obj" />
-		<transform name="toWorld" >
-			<matrix value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-		</transform>
-		<ref id="Dragon" />
-	</shape>
-	<shape type="obj" >
-		<string name="filename" value="models/Mesh004.obj" />
-		<transform name="toWorld" >
-			<matrix value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-		</transform>
-		<ref id="Blade" />
-	</shape>
-	<shape type="obj" >
-		<string name="filename" value="models/Mesh009.obj" />
-		<transform name="toWorld" >
-			<matrix value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-		</transform>
-		<ref id="Sword" />
-	</shape>
-	<shape type="obj" >
-		<string name="filename" value="models/Mesh003.obj" />
-		<transform name="toWorld" >
-			<matrix value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-		</transform>
-		<ref id="Deco" />
-	</shape>
-	<shape type="obj" >
-		<string name="filename" value="models/Mesh002.obj" />
-		<transform name="toWorld" >
-			<matrix value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-		</transform>
-		<ref id="Diamond" />
-	</shape>
-	<shape type="obj" >
-		<string name="filename" value="models/Mesh001.obj" />
-		<transform name="toWorld" >
-			<matrix value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-		</transform>
-		<ref id="Deco2" />
-	</shape>
-	<shape type="obj" >
-		<string name="filename" value="models/Mesh000.obj" />
-		<transform name="toWorld" >
-			<matrix value="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"/>
-		</transform>
-		<ref id="Deco2" />
-	</shape>
-	<emitter type="sun" >
-		<vector name="sunDirection" x="-0.18862" y="0.692312" z="0.69651" />
-		<float name="scale" value="8" />
-		<float name="sunRadiusScale" value="37.9165" />
-	</emitter>
-</scene>
+    <!-- Ground and environment pieces -->
+    <Mesh file="assets/Mesh011.obj" position="0,0,0" scale="1"
+          albedo="0.456263,0.456263,0.456263" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/Mesh010.obj" position="0,0,0" scale="1"
+          albedo="0.456263,0.456263,0.456263" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/Mesh005.obj" position="0,0,0" scale="1"
+          albedo="0.456263,0.456263,0.456263" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/Mesh006.obj" position="0,0,0" scale="1"
+          albedo="0.456263,0.456263,0.456263" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/Mesh012.obj" position="0,0,0" scale="1"
+          albedo="0.456263,0.456263,0.456263" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/Mesh007.obj" position="0,0,0" scale="1"
+          albedo="0.456263,0.456263,0.456263" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Hero object cluster -->
+    <Mesh file="assets/Mesh008.obj" position="0,0,0" scale="1"
+          albedo="0.79311,0.79311,0.79311" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/Mesh013.obj" position="0,0,0" scale="1"
+          albedo="0.79311,0.79311,0.79311" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/Mesh014.obj" position="0,0,0" scale="1"
+          albedo="0.79311,0.79311,0.79311" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/Mesh015.obj" position="0,0,0" scale="1"
+          albedo="0.79311,0.79311,0.79311" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Sword and decorative props -->
+    <Mesh file="assets/Mesh004.obj" position="0,0,0" scale="1"
+          albedo="0.79311,0.79311,0.79311" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/Mesh009.obj" position="0,0,0" scale="1"
+          albedo="0.79311,0.79311,0.79311" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/Mesh003.obj" position="0,0,0" scale="1"
+          albedo="0.79311,0.79311,0.79311" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/Mesh002.obj" position="0,0,0" scale="1"
+          albedo="0.79311,0.79311,0.79311" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/Mesh001.obj" position="0,0,0" scale="1"
+          albedo="0.79311,0.79311,0.79311" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/Mesh000.obj" position="0,0,0" scale="1"
+          albedo="0.79311,0.79311,0.79311" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Soft fill light approximating the original sun emitter -->
+    <Rectangle position="0,50,0" u="30,0,0" v="0,0,30" albedo="1,1,1"
+               emission="0.9,0.92,0.94" materialType="-1" emissionPower="25" />
+</Scene>


### PR DESCRIPTION
## Summary
- convert the Mitsuba-formatted `scene_v0.6.xml` into the custom `Scene` schema consumed by `SceneLoader`
- preserve all mesh assignments, materials, and camera settings while adding a soft fill light approximating the original sun emitter

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eef0b146b4832dab074d1e04b64ff6