### PR TITLE
Add texture-aware triangle data and image loader

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -2219,13 +2219,13 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   if (needFullUpload) {
     _cachedPrimitiveData.assign(totalPrimitiveCount * 3,
                                 simd::float4{0.0f, 0.0f, 0.0f, 0.0f});
-    _cachedMaterialData.assign(totalPrimitiveCount * 2,
+    _cachedMaterialData.assign(totalPrimitiveCount * 3,
                                simd::float4{0.0f, 0.0f, 0.0f, 0.0f});
 
     for (size_t i = 0; i < totalPrimitiveCount; ++i) {
       const Primitive &p = _allPrimitives[i];
       simd::float4 *primBase = &_cachedPrimitiveData[3 * i];
-      simd::float4 *matBase = &_cachedMaterialData[2 * i];
+      simd::float4 *matBase = &_cachedMaterialData[3 * i];
 
       switch (p.type) {
       case PrimitiveType::Sphere: {
@@ -2255,6 +2255,8 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       const Material &m = p.material;
       matBase[0] = simd::make_float4(m.albedo, m.materialType);
       matBase[1] = simd::make_float4(m.emissionColor, m.emissionPower);
+      matBase[2] = simd::make_float4(static_cast<float>(m.diffuseTextureIndex),
+                                     0.0f, 0.0f, 0.0f);
     }
 
     _pScene->createTriangleBuffers(_cachedTriangleVertices,
@@ -2447,7 +2449,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     compactActiveMask.clear();
 
     compactPrimitiveData.reserve(_activePrimitiveCount * 3);
-    compactMaterialData.reserve(_activePrimitiveCount * 2);
+    compactMaterialData.reserve(_activePrimitiveCount * 3);
     compactPrimitiveIndices.reserve(_activePrimitiveCount);
     compactActiveMask.reserve(_activePrimitiveCount);
 
@@ -2551,6 +2553,8 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
               simd::make_float4(m.albedo, m.materialType));
           compactMaterialData.push_back(
               simd::make_float4(m.emissionColor, m.emissionPower));
+          compactMaterialData.push_back(simd::make_float4(
+              static_cast<float>(m.diffuseTextureIndex), 0.0f, 0.0f, 0.0f));
           compactActiveMask.push_back(1);
           compactPrimitiveIndices.push_back(
               static_cast<int>(record.primitiveBase + activeCount));
@@ -2760,6 +2764,8 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         compactMaterialData.push_back(simd::make_float4(m.albedo, m.materialType));
         compactMaterialData.push_back(
             simd::make_float4(m.emissionColor, m.emissionPower));
+        compactMaterialData.push_back(simd::make_float4(
+            static_cast<float>(m.diffuseTextureIndex), 0.0f, 0.0f, 0.0f));
         compactActiveMask.push_back(1);
       }
 

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -445,16 +445,19 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
                                     memory_order_relaxed);
       }
     }
-    int matIndex = bestHit.primitiveId * 2;
-    if (matIndex + 1 >= int(primitiveCount) * 2)
+    int matIndex = bestHit.primitiveId * 3;
+    if (matIndex + 2 >= int(primitiveCount) * 3)
       break;
     float4 m0 = materials[matIndex + 0];
     float4 m1 = materials[matIndex + 1];
+    float4 m2 = materials[matIndex + 2];
 
     float3 albedo = m0.xyz * lodAtten;
     float materialType = m0.w;
     float3 emissionColor = m1.xyz;
     float emissionPower = m1.w;
+    float diffuseTextureIndex = m2.x;
+    (void)diffuseTextureIndex;
 
     if (emissionPower > 0.0 || materialType == 2) {
       light += absorption * float4(emissionColor, 1.0) * emissionPower;
@@ -518,8 +521,8 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
                       visible = true;
                     }
                     if (visible) {
-                      int lightMatIndex = int(lightPrimIndex) * 2;
-                      if (lightMatIndex + 1 < int(primitiveCount) * 2) {
+                      int lightMatIndex = int(lightPrimIndex) * 3;
+                      if (lightMatIndex + 2 < int(primitiveCount) * 3) {
                         float4 lightM1 = materials[lightMatIndex + 1];
                         float3 lightRadiance = lightM1.xyz * lightM1.w;
                         float3 throughput = absorption.xyz * (albedo / M_PI);

--- a/MetalCpp Path Tracer/Scene/ImageLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/ImageLoader.cpp
@@ -1,0 +1,121 @@
+#include "ImageLoader.h"
+
+#include <CoreGraphics/CoreGraphics.h>
+#include <ImageIO/ImageIO.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <cstdio>
+#include <utility>
+
+namespace MetalCppPathTracer {
+
+namespace {
+
+std::string NormalizePath(const std::filesystem::path &path) {
+    std::filesystem::path normalized = path.lexically_normal();
+    normalized.make_preferred();
+    return normalized.string();
+}
+
+} // namespace
+
+ImageLoader &GetGlobalImageLoader() {
+    static ImageLoader loader;
+    return loader;
+}
+
+int ImageLoader::loadImage(const std::filesystem::path &baseDir,
+                           const std::string &filename) {
+    if (filename.empty())
+        return -1;
+
+    std::filesystem::path resolved = baseDir / filename;
+    std::string key = NormalizePath(resolved);
+
+    auto it = _pathToIndex.find(key);
+    if (it != _pathToIndex.end())
+        return it->second;
+
+    LoadedImage image;
+    if (!loadImageFile(resolved, image)) {
+        std::printf("Failed to load texture: %s\n", key.c_str());
+        return -1;
+    }
+
+    int index = static_cast<int>(_images.size());
+    _images.push_back(std::move(image));
+    _pathToIndex.emplace(std::move(key), index);
+    return index;
+}
+
+const LoadedImage *ImageLoader::getImage(int index) const {
+    if (index < 0 || static_cast<size_t>(index) >= _images.size())
+        return nullptr;
+    return &_images[static_cast<size_t>(index)];
+}
+
+void ImageLoader::clear() {
+    _pathToIndex.clear();
+    _images.clear();
+}
+
+bool ImageLoader::loadImageFile(const std::filesystem::path &path,
+                                LoadedImage &outImage) {
+    std::string utf8 = NormalizePath(path);
+    CFStringRef cfPath = CFStringCreateWithCString(nullptr, utf8.c_str(),
+                                                   kCFStringEncodingUTF8);
+    if (!cfPath)
+        return false;
+
+    CFURLRef url = CFURLCreateWithFileSystemPath(nullptr, cfPath,
+                                                 kCFURLPOSIXPathStyle, false);
+    CFRelease(cfPath);
+    if (!url)
+        return false;
+
+    CGImageSourceRef source = CGImageSourceCreateWithURL(url, nullptr);
+    CFRelease(url);
+    if (!source)
+        return false;
+
+    CGImageRef image = CGImageSourceCreateImageAtIndex(source, 0, nullptr);
+    CFRelease(source);
+    if (!image)
+        return false;
+
+    size_t width = CGImageGetWidth(image);
+    size_t height = CGImageGetHeight(image);
+    if (width == 0 || height == 0) {
+        CGImageRelease(image);
+        return false;
+    }
+
+    outImage.width = static_cast<int>(width);
+    outImage.height = static_cast<int>(height);
+    outImage.channels = 4;
+    outImage.pixels.resize(width * height * 4);
+
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    if (!colorSpace) {
+        CGImageRelease(image);
+        return false;
+    }
+
+    CGContextRef context = CGBitmapContextCreate(
+        outImage.pixels.data(), width, height, 8, width * 4, colorSpace,
+        kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Little);
+    CGColorSpaceRelease(colorSpace);
+    if (!context) {
+        CGImageRelease(image);
+        return false;
+    }
+
+    CGRect rect = CGRectMake(0, 0, static_cast<double>(width),
+                             static_cast<double>(height));
+    CGContextDrawImage(context, rect, image);
+
+    CGContextRelease(context);
+    CGImageRelease(image);
+    return true;
+}
+
+} // namespace MetalCppPathTracer

--- a/MetalCpp Path Tracer/Scene/ImageLoader.h
+++ b/MetalCpp Path Tracer/Scene/ImageLoader.h
@@ -1,0 +1,37 @@
+#ifndef IMAGELOADER_H
+#define IMAGELOADER_H
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace MetalCppPathTracer {
+
+struct LoadedImage {
+    int width = 0;
+    int height = 0;
+    int channels = 0;
+    std::vector<uint8_t> pixels;
+};
+
+class ImageLoader {
+public:
+    int loadImage(const std::filesystem::path &baseDir, const std::string &filename);
+    const LoadedImage *getImage(int index) const;
+    const std::vector<LoadedImage> &images() const { return _images; }
+    void clear();
+
+private:
+    bool loadImageFile(const std::filesystem::path &path, LoadedImage &outImage);
+
+    std::unordered_map<std::string, int> _pathToIndex;
+    std::vector<LoadedImage> _images;
+};
+
+ImageLoader &GetGlobalImageLoader();
+
+} // namespace MetalCppPathTracer
+
+#endif

--- a/MetalCpp Path Tracer/Scene/Material.h
+++ b/MetalCpp Path Tracer/Scene/Material.h
@@ -1,6 +1,7 @@
 #ifndef MATERIAL_H
 #define MATERIAL_H
 
+#include <cstdint>
 #include <simd/simd.h>
 
 namespace MetalCppPathTracer {
@@ -11,9 +12,9 @@ struct Material
     float materialType;
     simd::float3 emissionColor;
     float emissionPower;
+    int32_t diffuseTextureIndex = -1;
 };
 
-};
-
+} // namespace MetalCppPathTracer
 
 #endif

--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -245,11 +245,14 @@ simd::float4 *Scene::createTransformsBuffer() const {
 }
 
 simd::float4 *Scene::createMaterialsBuffer() const {
-  simd::float4 *buffer = new simd::float4[2 * primitives.size()];
+  simd::float4 *buffer = new simd::float4[3 * primitives.size()];
   for (size_t i = 0; i < primitives.size(); ++i) {
     const auto &m = primitives[i].material;
-    buffer[2 * i + 0] = simd::make_float4(m.albedo, m.materialType);
-    buffer[2 * i + 1] = simd::make_float4(m.emissionColor, m.emissionPower);
+    buffer[3 * i + 0] = simd::make_float4(m.albedo, m.materialType);
+    buffer[3 * i + 1] = simd::make_float4(m.emissionColor, m.emissionPower);
+    buffer[3 * i + 2] =
+        simd::make_float4(static_cast<float>(m.diffuseTextureIndex), 0.0f, 0.0f,
+                          0.0f);
   }
   return buffer;
 }
@@ -270,15 +273,18 @@ simd::float4 *Scene::createSphereBuffer() {
 
 simd::float4 *Scene::createSphereMaterialsBuffer() {
   size_t sphereCount = getSphereCount();
-  simd::float4 *buffer = new simd::float4[2 * sphereCount];
+  simd::float4 *buffer = new simd::float4[3 * sphereCount];
 
   size_t index = 0;
   for (const auto &p : primitives) {
     if (p.type == PrimitiveType::Sphere) {
       const auto &m = p.material;
-      buffer[2 * index + 0] = simd::make_float4(m.albedo, m.materialType);
-      buffer[2 * index + 1] =
+      buffer[3 * index + 0] = simd::make_float4(m.albedo, m.materialType);
+      buffer[3 * index + 1] =
           simd::make_float4(m.emissionColor, m.emissionPower);
+      buffer[3 * index + 2] =
+          simd::make_float4(static_cast<float>(m.diffuseTextureIndex), 0.0f,
+                            0.0f, 0.0f);
       index++;
     }
   }

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -1,5 +1,6 @@
 #include "SceneLoader.h"
 #include "Material.h"
+#include "ImageLoader.h"
 #include <tinyxml2.h>
 #include <simd/simd.h>
 #include <algorithm>
@@ -13,6 +14,7 @@
 #include <utility>
 #include <vector>
 #include <limits>
+#include <functional>
 #include "tiny_obj_loader.h"
 
 using namespace tinyxml2;
@@ -26,6 +28,26 @@ static simd::float3 parseVec3(const char* str) {
 }
 
 namespace {
+
+static Material DefaultMaterial() {
+    Material m;
+    m.albedo = simd::make_float3(0.8f, 0.8f, 0.8f);
+    m.materialType = 0.0f;
+    m.emissionColor = simd::make_float3(0.0f, 0.0f, 0.0f);
+    m.emissionPower = 0.0f;
+    m.diffuseTextureIndex = -1;
+    return m;
+}
+
+static Material ConvertMaterial(const tinyobj::material_t &src,
+                                int textureIndex) {
+    Material m = DefaultMaterial();
+    m.albedo = simd::make_float3(src.diffuse[0], src.diffuse[1], src.diffuse[2]);
+    m.emissionColor =
+        simd::make_float3(src.emission[0], src.emission[1], src.emission[2]);
+    m.diffuseTextureIndex = textureIndex;
+    return m;
+}
 
 static float AxisValue(const simd::float3& v, int axis) {
     switch (axis) {
@@ -161,7 +183,9 @@ static void EmitMeshPartitions(Scene* scene, std::vector<Primitive>& prims,
 // single scene load.
 struct CachedMesh {
     std::vector<simd::float3> vertices;
+    std::vector<simd::float2> uvs;
     std::vector<simd::uint3> indices;
+    std::vector<int32_t> triangleTextureIndices;
 };
 
 using MeshCache = std::unordered_map<std::string, CachedMesh>;
@@ -171,13 +195,20 @@ MeshCache& GetMeshCache() {
     return cache;
 }
 
-static void LoadOBJ(const std::string& path, std::vector<simd::float3>& verts, std::vector<simd::uint3>& tris) {
+static void LoadOBJ(const std::filesystem::path &path, CachedMesh &outMesh) {
+    outMesh.vertices.clear();
+    outMesh.uvs.clear();
+    outMesh.indices.clear();
+    outMesh.triangleTextureIndices.clear();
+
     tinyobj::attrib_t attrib;
     std::vector<tinyobj::shape_t> shapes;
     std::vector<tinyobj::material_t> materials;
     std::string warn, err;
 
-    bool ret = tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, path.c_str());
+    std::string pathStr = path.string();
+    bool ret = tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err,
+                                pathStr.c_str());
 
     if (!warn.empty()) {
         printf("tinyobjloader warning: %s\n", warn.c_str());
@@ -186,50 +217,127 @@ static void LoadOBJ(const std::string& path, std::vector<simd::float3>& verts, s
         printf("tinyobjloader error: %s\n", err.c_str());
     }
     if (!ret) {
-        printf("Failed to load OBJ: %s\n", path.c_str());
+        printf("Failed to load OBJ: %s\n", pathStr.c_str());
         return;
     }
 
-    verts.reserve(attrib.vertices.size() / 3);
-    for (size_t v = 0; v < attrib.vertices.size(); v += 3) {
-        verts.push_back(simd::make_float3(
-            attrib.vertices[v],
-            attrib.vertices[v + 1],
-            attrib.vertices[v + 2]
-        ));
+    std::filesystem::path baseDir = path.parent_path();
+    ImageLoader &imageLoader = GetGlobalImageLoader();
+    std::vector<int> materialTextureIndices(materials.size(), -1);
+    for (size_t i = 0; i < materials.size(); ++i) {
+        int textureIndex = -1;
+        if (!materials[i].diffuse_texname.empty()) {
+            textureIndex = imageLoader.loadImage(baseDir, materials[i].diffuse_texname);
+        }
+        Material converted = ConvertMaterial(materials[i], textureIndex);
+        materialTextureIndices[i] = converted.diffuseTextureIndex;
     }
 
-    for (const auto& shape : shapes) {
+    struct VertexKey {
+        int positionIndex;
+        int texcoordIndex;
+
+        bool operator==(const VertexKey &other) const {
+            return positionIndex == other.positionIndex &&
+                   texcoordIndex == other.texcoordIndex;
+        }
+    };
+
+    struct VertexKeyHash {
+        size_t operator()(const VertexKey &key) const {
+            size_t h1 = std::hash<int>{}(key.positionIndex);
+            size_t h2 = std::hash<int>{}(key.texcoordIndex);
+            return h1 ^ (h2 << 1);
+        }
+    };
+
+    std::unordered_map<VertexKey, uint32_t, VertexKeyHash> remap;
+    remap.reserve(attrib.vertices.size());
+
+    auto getPosition = [&](int index) -> simd::float3 {
+        size_t base = static_cast<size_t>(index) * 3;
+        if (base + 2 >= attrib.vertices.size())
+            return simd::make_float3(0.0f, 0.0f, 0.0f);
+        return simd::make_float3(attrib.vertices[base + 0],
+                                 attrib.vertices[base + 1],
+                                 attrib.vertices[base + 2]);
+    };
+
+    auto getUV = [&](int index) -> simd::float2 {
+        if (index < 0)
+            return simd::make_float2(0.0f, 0.0f);
+        size_t base = static_cast<size_t>(index) * 2;
+        if (base + 1 >= attrib.texcoords.size())
+            return simd::make_float2(0.0f, 0.0f);
+        return simd::make_float2(attrib.texcoords[base + 0],
+                                 attrib.texcoords[base + 1]);
+    };
+
+    for (const auto &shape : shapes) {
         size_t indexOffset = 0;
-        for (size_t f = 0; f < shape.mesh.num_face_vertices.size(); f++) {
-            size_t fv = size_t(shape.mesh.num_face_vertices[f]);
+        for (size_t f = 0; f < shape.mesh.num_face_vertices.size(); ++f) {
+            size_t fv = static_cast<size_t>(shape.mesh.num_face_vertices[f]);
             if (fv != 3) {
                 indexOffset += fv;
                 continue;
             }
 
-            uint32_t idx0 = shape.mesh.indices[indexOffset + 0].vertex_index;
-            uint32_t idx1 = shape.mesh.indices[indexOffset + 1].vertex_index;
-            uint32_t idx2 = shape.mesh.indices[indexOffset + 2].vertex_index;
+            simd::uint3 tri = {0, 0, 0};
+            bool valid = true;
+            for (size_t v = 0; v < 3; ++v) {
+                const tinyobj::index_t &idx = shape.mesh.indices[indexOffset + v];
+                if (idx.vertex_index < 0) {
+                    valid = false;
+                    break;
+                }
 
-            if (idx0 >= verts.size() || idx1 >= verts.size() || idx2 >= verts.size()) {
-                printf("Invalid triangle indices\n");
+                size_t vertexBase = static_cast<size_t>(idx.vertex_index) * 3;
+                if (vertexBase + 2 >= attrib.vertices.size()) {
+                    valid = false;
+                    break;
+                }
+
+                VertexKey key{idx.vertex_index, idx.texcoord_index};
+                auto it = remap.find(key);
+                if (it == remap.end()) {
+                    simd::float3 position = getPosition(idx.vertex_index);
+                    remap[key] = static_cast<uint32_t>(outMesh.vertices.size());
+                    outMesh.vertices.push_back(position);
+                    outMesh.uvs.push_back(getUV(idx.texcoord_index));
+                    tri[v] = static_cast<uint32_t>(outMesh.vertices.size() - 1);
+                } else {
+                    tri[v] = it->second;
+                }
+            }
+
+            if (!valid) {
                 indexOffset += fv;
                 continue;
             }
 
-            tris.push_back(simd::make_uint3(idx0, idx1, idx2));
+            outMesh.indices.push_back(tri);
+            int materialId = -1;
+            if (f < shape.mesh.material_ids.size())
+                materialId = shape.mesh.material_ids[f];
+            int textureIndex = -1;
+            if (materialId >= 0 &&
+                materialId < static_cast<int>(materialTextureIndices.size()))
+                textureIndex = materialTextureIndices[static_cast<size_t>(materialId)];
+            outMesh.triangleTextureIndices.push_back(textureIndex);
+
             indexOffset += fv;
         }
     }
 
-    printf("Loaded OBJ: %zu vertices, %zu triangles\n", verts.size(), tris.size());
+    printf("Loaded OBJ: %zu vertices, %zu triangles\n", outMesh.vertices.size(),
+           outMesh.indices.size());
 }
 
 } // namespace
 
 void SceneLoader::ClearCache() {
     GetMeshCache().clear();
+    GetGlobalImageLoader().clear();
 }
 
 bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
@@ -344,6 +452,7 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             p.sphere.center = parseVec3(e->Attribute("position"));
             p.sphere.radius = e->FloatAttribute("radius", 1.0f);
 
+            p.material = DefaultMaterial();
             p.material.albedo = parseVec3(e->Attribute("albedo"));
             p.material.emissionColor = parseVec3(e->Attribute("emission"));
             p.material.materialType = e->FloatAttribute("materialType", 0);
@@ -358,6 +467,7 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             p.rectangle.u = parseVec3(e->Attribute("u"));
             p.rectangle.v = parseVec3(e->Attribute("v"));
 
+            p.material = DefaultMaterial();
             p.material.albedo = parseVec3(e->Attribute("albedo"));
             p.material.emissionColor = parseVec3(e->Attribute("emission"));
             p.material.materialType = e->FloatAttribute("materialType", 0);
@@ -369,15 +479,16 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             // Build full path to mesh file relative to the scene's directory
             const char* fileAttr = e->Attribute("file");
             std::filesystem::path meshPath = baseDir / (fileAttr ? fileAttr : "");
-            std::string normalizedPath = meshPath.lexically_normal().string();
+            std::filesystem::path normalizedMeshPath = meshPath.lexically_normal();
+            std::string cacheKey = normalizedMeshPath.string();
 
             auto& cache = GetMeshCache();
-            auto it = cache.find(normalizedPath);
+            auto it = cache.find(cacheKey);
             if (it == cache.end()) {
                 // First time encountering this mesh path in the current load.
                 CachedMesh entry;
-                LoadOBJ(normalizedPath, entry.vertices, entry.indices);
-                it = cache.emplace(normalizedPath, std::move(entry)).first;
+                LoadOBJ(normalizedMeshPath, entry);
+                it = cache.emplace(cacheKey, std::move(entry)).first;
             }
 
             const CachedMesh& meshData = it->second;
@@ -399,7 +510,7 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
                 basisZ = parseVec3(bzAttr);
             }
 
-            Material m;
+            Material m = DefaultMaterial();
             m.albedo = parseVec3(e->Attribute("albedo"));
             m.emissionColor = parseVec3(e->Attribute("emission"));
             m.materialType = e->FloatAttribute("materialType", 0);
@@ -415,14 +526,28 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             auto transformVertex = [&](const simd::float3& v) {
                 return pos + basisX * v.x + basisY * v.y + basisZ * v.z;
             };
+            auto fetchUV = [&](uint32_t index) {
+                if (index < meshData.uvs.size())
+                    return meshData.uvs[index];
+                return simd::make_float2(0.0f, 0.0f);
+            };
+
+            size_t triangleIndex = 0;
             for (const auto& tri : meshData.indices) {
                 Primitive p{};
                 p.type = PrimitiveType::Triangle;
                 p.triangle.v0 = transformVertex(meshData.vertices[tri.x]);
                 p.triangle.v1 = transformVertex(meshData.vertices[tri.y]);
                 p.triangle.v2 = transformVertex(meshData.vertices[tri.z]);
+                p.triangle.uv0 = fetchUV(tri.x);
+                p.triangle.uv1 = fetchUV(tri.y);
+                p.triangle.uv2 = fetchUV(tri.z);
                 p.material = m;
+                if (triangleIndex < meshData.triangleTextureIndices.size())
+                    p.material.diffuseTextureIndex =
+                        meshData.triangleTextureIndices[triangleIndex];
                 meshPrimitives.push_back(p);
+                ++triangleIndex;
             }
             int meshGroupId = nextMeshGroupId++;
             EmitMeshPartitions(scene, meshPrimitives, clusterMaxTriangles,

--- a/MetalCpp Path Tracer/Scene/Triangle.h
+++ b/MetalCpp Path Tracer/Scene/Triangle.h
@@ -9,6 +9,9 @@ struct Triangle {
     simd::float3 v0;
     simd::float3 v1;
     simd::float3 v2;
+    simd::float2 uv0;
+    simd::float2 uv1;
+    simd::float2 uv2;
 };
 
 }


### PR DESCRIPTION
## Summary
- add UV storage to triangles and propagate the values into scene and renderer material buffers
- extend materials with a diffuse texture index and widen CPU/GPU uploads accordingly
- cache mesh UVs and texture assignments while introducing a CoreGraphics-based image loader for OBJ textures

## Testing
- not run (platform-specific project)

------
https://chatgpt.com/codex/tasks/task_e_68eefcf0259c832d8a7b3b1051853e81