### PR TITLE
Add diffuse texture support to Metal path tracer

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -4,7 +4,9 @@
 #include "InputSystem.h"
 #include "Scene.h"
 #include "SceneLoader.h"
+#include "../Scene/ImageLoader.h"
 #include <Metal/MTLArgument.hpp>
+#include <Metal/MTLArgumentEncoder.hpp>
 #include <Metal/MTLComputePipeline.hpp>
 #include <algorithm>
 #include <array>
@@ -127,6 +129,10 @@ struct UniformsData {
   uint32_t sampleImportanceTextureIndex = 0;
   uint32_t minSamplesPerPixel = 1;
   uint32_t maxSamplesPerPixel = 1;
+  uint32_t materialTextureCount = 0;
+  uint32_t materialTexturePadding0 = 0;
+  uint32_t materialTexturePadding1 = 0;
+  uint32_t materialTexturePadding2 = 0;
 };
 
 inline uint32_t bitm_random() {
@@ -150,6 +156,8 @@ size_t alignTo(size_t value, size_t alignment) {
 
 constexpr size_t kTextureResidencyPrimitiveBudget = 1;
 constexpr double kDefaultTextureResidencyMemoryCapMB = 2048.0;
+constexpr size_t kMaxMaterialTextures = 256;
+constexpr NS::UInteger kMaterialTextureArgumentBufferIndex = 16;
 constexpr float kFrustumDebugNear = 0.1f;
 constexpr float kFrustumDebugFarMultiplier = 5.0f;
 
@@ -352,6 +360,84 @@ void markBufferModified(MTL::Buffer *buffer, NS::Range range) {
 
   if (buffer->storageMode() == MTL::StorageModeManaged)
     buffer->didModifyRange(range);
+}
+
+void Renderer::releaseMaterialTextures() {
+  for (MTL::Texture *texture : _materialTextures) {
+    if (texture)
+      texture->release();
+  }
+  _materialTextures.clear();
+}
+
+void Renderer::updateMaterialTextureBindings() {
+  if (!_pMaterialTextureArgumentEncoder || !_pMaterialTextureArgumentBuffer)
+    return;
+
+  _pMaterialTextureArgumentEncoder->setArgumentBuffer(
+      _pMaterialTextureArgumentBuffer, 0);
+
+  size_t slotCount = kMaxMaterialTextures;
+  size_t available = std::min(_materialTextures.size(), slotCount);
+  for (size_t i = 0; i < slotCount; ++i) {
+    MTL::Texture *texture = (i < available) ? _materialTextures[i] : nullptr;
+    _pMaterialTextureArgumentEncoder->setTexture(texture, i);
+  }
+
+  if (_pMaterialTextureArgumentBuffer->storageMode() ==
+      MTL::StorageModeManaged) {
+    NS::UInteger length = _pMaterialTextureArgumentBuffer->length();
+    markBufferModified(_pMaterialTextureArgumentBuffer,
+                       NS::Range::Make(0, length));
+  }
+}
+
+void Renderer::rebuildMaterialTextures() {
+  releaseMaterialTextures();
+
+  updateMaterialTextureBindings();
+
+  if (!_pDevice)
+    return;
+
+  const auto &images = GetGlobalImageLoader().images();
+  size_t totalImages = images.size();
+  if (totalImages > kMaxMaterialTextures) {
+    printf("Truncating diffuse texture set to %zu entries (have %zu).\n",
+           kMaxMaterialTextures, totalImages);
+  }
+
+  size_t textureCount = std::min(totalImages, kMaxMaterialTextures);
+  _materialTextures.resize(textureCount, nullptr);
+
+  for (size_t i = 0; i < textureCount; ++i) {
+    const LoadedImage &image = images[i];
+    if (image.width <= 0 || image.height <= 0 || image.pixels.empty() ||
+        image.channels <= 0)
+      continue;
+
+    MTL::TextureDescriptor *descriptor =
+        MTL::TextureDescriptor::texture2DDescriptor(
+            MTL::PixelFormatRGBA8Unorm, image.width, image.height, false);
+    descriptor->setStorageMode(MTL::StorageModeManaged);
+    descriptor->setUsage(MTL::TextureUsageShaderRead);
+
+    MTL::Texture *texture = _pDevice->newTexture(descriptor);
+    descriptor->release();
+
+    if (texture) {
+      MTL::Region region = MTL::Region::Make2D(0, 0, image.width, image.height);
+      size_t rowBytes = static_cast<size_t>(image.width) *
+                        static_cast<size_t>(image.channels);
+      texture->replaceRegion(region, 0, image.pixels.data(), rowBytes);
+    } else {
+      printf("Failed to create texture for diffuse map %zu.\n", i);
+    }
+
+    _materialTextures[i] = texture;
+  }
+
+  updateMaterialTextureBindings();
 }
 
 static bool cameraStatesDiffer(const Camera::State &a, const Camera::State &b,
@@ -633,6 +719,10 @@ Renderer::~Renderer() {
     _pTriangleVertexBuffer->release();
   if (_pTriangleIndexBuffer)
     _pTriangleIndexBuffer->release();
+  if (_pTriangleUVBuffer)
+    _pTriangleUVBuffer->release();
+  if (_pMaterialTextureIndexBuffer)
+    _pMaterialTextureIndexBuffer->release();
   if (_pUniformsBuffer)
     _pUniformsBuffer->release();
   if (_pBVHBuffer)
@@ -660,6 +750,10 @@ Renderer::~Renderer() {
     _pGeometryHandleBuffer->release();
   if (_pFrustumVertexBuffer)
     _pFrustumVertexBuffer->release();
+  if (_pMaterialTextureArgumentBuffer)
+    _pMaterialTextureArgumentBuffer->release();
+  if (_pMaterialTextureArgumentEncoder)
+    _pMaterialTextureArgumentEncoder->release();
 
   _cachedInstanceDescriptors.clear();
   _cachedInstancedAccelerationStructures.clear();
@@ -674,6 +768,8 @@ Renderer::~Renderer() {
     releaseTextureSlot(slot);
   releaseTextureSlot(_sampleCountSlot);
   releaseTextureSlot(_sampleImportanceSlot);
+
+  releaseMaterialTextures();
 
   if (_pTextureClearBuffer)
     _pTextureClearBuffer->release();
@@ -1102,6 +1198,15 @@ void Renderer::buildShaders() {
     _pAdaptiveSamplingPSO->release();
     _pAdaptiveSamplingPSO = nullptr;
   }
+  if (_pMaterialTextureArgumentBuffer) {
+    _pMaterialTextureArgumentBuffer->release();
+    _pMaterialTextureArgumentBuffer = nullptr;
+    _materialTextureArgumentBufferCapacity = 0;
+  }
+  if (_pMaterialTextureArgumentEncoder) {
+    _pMaterialTextureArgumentEncoder->release();
+    _pMaterialTextureArgumentEncoder = nullptr;
+  }
 
   NS::Error *pError = nullptr;
   MTL::Library *pLibrary = _pDevice->newDefaultLibrary();
@@ -1197,6 +1302,28 @@ void Renderer::buildShaders() {
         }
       }
     }
+    if (_pPathTracePSO) {
+      MTL::ArgumentEncoder *encoder =
+          pPathTraceFn->newArgumentEncoder(
+              kMaterialTextureArgumentBufferIndex);
+      if (encoder) {
+        size_t encodedLength =
+            alignTo(static_cast<size_t>(encoder->encodedLength()), 256);
+        if (encodedLength == 0)
+          encodedLength = 256;
+        MTL::Buffer *argumentBuffer =
+            _pDevice->newBuffer(encodedLength, MTL::ResourceStorageModeManaged);
+        if (argumentBuffer) {
+          _pMaterialTextureArgumentEncoder = encoder;
+          _pMaterialTextureArgumentBuffer = argumentBuffer;
+          _materialTextureArgumentBufferCapacity = encodedLength;
+          _pMaterialTextureArgumentEncoder->setArgumentBuffer(
+              _pMaterialTextureArgumentBuffer, 0);
+        } else {
+          encoder->release();
+        }
+      }
+    }
     pPathTraceFn->release();
   }
 
@@ -1216,6 +1343,8 @@ void Renderer::buildShaders() {
   pFragFn->release();
   pDesc->release();
   pLibrary->release();
+
+  updateMaterialTextureBindings();
 }
 
 void Renderer::updateVisibleScene() {
@@ -2215,12 +2344,21 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   bool sizeChanged = cachedTotalPrimitiveCount != totalPrimitiveCount;
   bool needFullUpload =
       forceFullRebuild || !_residentBuffersInitialized || sizeChanged;
+  size_t maxTextureSlots =
+      std::min(_materialTextures.size(), kMaxMaterialTextures);
 
   if (needFullUpload) {
+    rebuildMaterialTextures();
+    maxTextureSlots =
+        std::min(_materialTextures.size(), kMaxMaterialTextures);
+
     _cachedPrimitiveData.assign(totalPrimitiveCount * 3,
                                 simd::float4{0.0f, 0.0f, 0.0f, 0.0f});
     _cachedMaterialData.assign(totalPrimitiveCount * 3,
                                simd::float4{0.0f, 0.0f, 0.0f, 0.0f});
+    _cachedTriangleUVs.assign(totalPrimitiveCount * 3,
+                              simd::make_float2(0.0f, 0.0f));
+    _cachedMaterialTextureIndices.assign(totalPrimitiveCount, -1);
 
     for (size_t i = 0; i < totalPrimitiveCount; ++i) {
       const Primitive &p = _allPrimitives[i];
@@ -2248,15 +2386,24 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
             simd::make_float4(p.triangle.v0, static_cast<float>(p.type));
         primBase[1] = simd::make_float4(p.triangle.v1, 0.0f);
         primBase[2] = simd::make_float4(p.triangle.v2, 0.0f);
+        simd::float2 *uvBase = &_cachedTriangleUVs[3 * i];
+        uvBase[0] = p.triangle.uv0;
+        uvBase[1] = p.triangle.uv1;
+        uvBase[2] = p.triangle.uv2;
         break;
       }
       }
 
       const Material &m = p.material;
+      int32_t textureIndex = m.diffuseTextureIndex;
+      if (textureIndex < 0 ||
+          static_cast<size_t>(textureIndex) >= maxTextureSlots)
+        textureIndex = -1;
       matBase[0] = simd::make_float4(m.albedo, m.materialType);
       matBase[1] = simd::make_float4(m.emissionColor, m.emissionPower);
-      matBase[2] = simd::make_float4(static_cast<float>(m.diffuseTextureIndex),
-                                     0.0f, 0.0f, 0.0f);
+      matBase[2] =
+          simd::make_float4(static_cast<float>(textureIndex), 0.0f, 0.0f, 0.0f);
+      _cachedMaterialTextureIndices[i] = textureIndex;
     }
 
     _pScene->createTriangleBuffers(_cachedTriangleVertices,
@@ -2394,6 +2541,8 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   std::vector<simd::float4> compactBVHNodes;
   std::vector<simd::float3> compactTriangleVertices;
   std::vector<simd::uint3> compactTriangleIndices;
+  std::vector<simd::float2> compactTriangleUVs;
+  std::vector<int32_t> compactMaterialTextureIndices;
 
   const std::vector<simd::float4> *primitiveSource = &_cachedPrimitiveData;
   const std::vector<simd::float4> *materialSource = &_cachedMaterialData;
@@ -2404,6 +2553,9 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       &_cachedTriangleVertices;
   const std::vector<simd::uint3> *triangleIndexSource =
       &_cachedTriangleIndices;
+  const std::vector<simd::float2> *triangleUVSource = &_cachedTriangleUVs;
+  const std::vector<int32_t> *materialTextureIndexSource =
+      &_cachedMaterialTextureIndices;
 
   if (!useCompaction) {
     remapUpload.resize(totalPrimitiveCount);
@@ -2446,11 +2598,15 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     compactBVHNodes.clear();
     compactTriangleVertices.clear();
     compactTriangleIndices.clear();
+    compactTriangleUVs.clear();
+    compactMaterialTextureIndices.clear();
     compactActiveMask.clear();
 
     compactPrimitiveData.reserve(_activePrimitiveCount * 3);
     compactMaterialData.reserve(_activePrimitiveCount * 3);
     compactPrimitiveIndices.reserve(_activePrimitiveCount);
+    compactTriangleUVs.reserve(_activePrimitiveCount * 3);
+    compactMaterialTextureIndices.reserve(_activePrimitiveCount);
     compactActiveMask.reserve(_activePrimitiveCount);
 
     std::vector<int32_t> cachedRemap;
@@ -2485,6 +2641,9 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         size_t compactBVHNodesStart = compactBVHNodes.size();
         size_t compactTriangleVerticesStart = compactTriangleVertices.size();
         size_t compactTriangleIndicesStart = compactTriangleIndices.size();
+        size_t compactTriangleUVsStart = compactTriangleUVs.size();
+        size_t compactMaterialTextureIndicesStart =
+            compactMaterialTextureIndices.size();
 
         std::vector<std::pair<size_t, int32_t>> residentIndexEdits;
         residentIndexEdits.reserve(obj.cachedPrimitiveIndices.size());
@@ -2548,13 +2707,29 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
           compactPrimitiveData.push_back(prim1);
           compactPrimitiveData.push_back(prim2);
 
+          if (p.type == PrimitiveType::Triangle) {
+            compactTriangleUVs.push_back(p.triangle.uv0);
+            compactTriangleUVs.push_back(p.triangle.uv1);
+            compactTriangleUVs.push_back(p.triangle.uv2);
+          } else {
+            compactTriangleUVs.push_back(simd::make_float2(0.0f, 0.0f));
+            compactTriangleUVs.push_back(simd::make_float2(0.0f, 0.0f));
+            compactTriangleUVs.push_back(simd::make_float2(0.0f, 0.0f));
+          }
+
           const Material &m = p.material;
+          int32_t textureIndex = m.diffuseTextureIndex;
+          if (textureIndex < 0 ||
+              static_cast<size_t>(textureIndex) >= maxTextureSlots)
+            textureIndex = -1;
           compactMaterialData.push_back(
               simd::make_float4(m.albedo, m.materialType));
           compactMaterialData.push_back(
               simd::make_float4(m.emissionColor, m.emissionPower));
-          compactMaterialData.push_back(simd::make_float4(
-              static_cast<float>(m.diffuseTextureIndex), 0.0f, 0.0f, 0.0f));
+          compactMaterialData.push_back(
+              simd::make_float4(static_cast<float>(textureIndex), 0.0f, 0.0f,
+                                 0.0f));
+          compactMaterialTextureIndices.push_back(textureIndex);
           compactActiveMask.push_back(1);
           compactPrimitiveIndices.push_back(
               static_cast<int>(record.primitiveBase + activeCount));
@@ -2564,6 +2739,17 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
 
         record.primitiveCount = static_cast<uint32_t>(activeCount);
         if (activeCount == 0) {
+          remapUpload.resize(remapStart);
+          compactPrimitiveData.resize(compactPrimitiveDataStart);
+          compactMaterialData.resize(compactMaterialDataStart);
+          compactPrimitiveIndices.resize(compactPrimitiveIndicesStart);
+          compactActiveMask.resize(compactActiveMaskStart);
+          compactBVHNodes.resize(compactBVHNodesStart);
+          compactTriangleVertices.resize(compactTriangleVerticesStart);
+          compactTriangleIndices.resize(compactTriangleIndicesStart);
+          compactTriangleUVs.resize(compactTriangleUVsStart);
+          compactMaterialTextureIndices.resize(
+              compactMaterialTextureIndicesStart);
           for (const auto &edit : residentIndexEdits)
             if (edit.first < _primitiveToResidentIndex.size())
               _primitiveToResidentIndex[edit.first] = edit.second;
@@ -2666,6 +2852,9 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         compactBVHNodes.resize(compactBVHNodesStart);
         compactTriangleVertices.resize(compactTriangleVerticesStart);
         compactTriangleIndices.resize(compactTriangleIndicesStart);
+        compactTriangleUVs.resize(compactTriangleUVsStart);
+        compactMaterialTextureIndices.resize(
+            compactMaterialTextureIndicesStart);
 
         for (const auto &edit : residentIndexEdits)
           if (edit.first < _primitiveToResidentIndex.size())
@@ -2760,12 +2949,28 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         compactPrimitiveData.push_back(prim1);
         compactPrimitiveData.push_back(prim2);
 
+        if (p.type == PrimitiveType::Triangle) {
+          compactTriangleUVs.push_back(p.triangle.uv0);
+          compactTriangleUVs.push_back(p.triangle.uv1);
+          compactTriangleUVs.push_back(p.triangle.uv2);
+        } else {
+          compactTriangleUVs.push_back(simd::make_float2(0.0f, 0.0f));
+          compactTriangleUVs.push_back(simd::make_float2(0.0f, 0.0f));
+          compactTriangleUVs.push_back(simd::make_float2(0.0f, 0.0f));
+        }
+
         const Material &m = p.material;
+        int32_t textureIndex = m.diffuseTextureIndex;
+        if (textureIndex < 0 ||
+            static_cast<size_t>(textureIndex) >= maxTextureSlots)
+          textureIndex = -1;
         compactMaterialData.push_back(simd::make_float4(m.albedo, m.materialType));
         compactMaterialData.push_back(
             simd::make_float4(m.emissionColor, m.emissionPower));
-        compactMaterialData.push_back(simd::make_float4(
-            static_cast<float>(m.diffuseTextureIndex), 0.0f, 0.0f, 0.0f));
+        compactMaterialData.push_back(
+            simd::make_float4(static_cast<float>(textureIndex), 0.0f, 0.0f,
+                               0.0f));
+        compactMaterialTextureIndices.push_back(textureIndex);
         compactActiveMask.push_back(1);
       }
 
@@ -2811,6 +3016,8 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     tlasSource = &_cachedTLASNodes;
     triangleVertexSource = &compactTriangleVertices;
     triangleIndexSource = &compactTriangleIndices;
+    triangleUVSource = &compactTriangleUVs;
+    materialTextureIndexSource = &compactMaterialTextureIndices;
 
     _residentPrimitiveCount = remapUpload.size();
     _residentTriangleCount = compactTriangleIndices.size();
@@ -3063,6 +3270,42 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         dst[0] = simd::make_uint3(0, 0, 0);
       markBufferModified(_pTriangleIndexBuffer,
                          NS::Range::Make(0, indexBytes));
+    }
+
+    size_t triangleUVCount = triangleUVSource->size();
+    size_t triangleUVBytes =
+        std::max<size_t>(triangleUVCount, size_t(1)) * sizeof(simd::float2);
+    ensureBufferCapacity(_pTriangleUVBuffer, triangleUVBytes,
+                         _triangleUVBufferCapacity, allowShrink);
+    if (_pTriangleUVBuffer) {
+      simd::float2 *dst =
+          static_cast<simd::float2 *>(_pTriangleUVBuffer->contents());
+      if (triangleUVCount > 0)
+        std::memcpy(dst, triangleUVSource->data(),
+                    triangleUVCount * sizeof(simd::float2));
+      else
+        dst[0] = simd::make_float2(0.0f, 0.0f);
+      markBufferModified(_pTriangleUVBuffer,
+                         NS::Range::Make(0, triangleUVBytes));
+    }
+
+    size_t materialTextureIndexCount = materialTextureIndexSource->size();
+    size_t materialTextureIndexBytes =
+        std::max<size_t>(materialTextureIndexCount, size_t(1)) *
+        sizeof(int32_t);
+    ensureBufferCapacity(_pMaterialTextureIndexBuffer,
+                         materialTextureIndexBytes,
+                         _materialTextureIndexBufferCapacity, allowShrink);
+    if (_pMaterialTextureIndexBuffer) {
+      auto *dst = static_cast<int32_t *>(
+          _pMaterialTextureIndexBuffer->contents());
+      if (materialTextureIndexCount > 0)
+        std::memcpy(dst, materialTextureIndexSource->data(),
+                    materialTextureIndexCount * sizeof(int32_t));
+      else
+        dst[0] = -1;
+      markBufferModified(_pMaterialTextureIndexBuffer,
+                         NS::Range::Make(0, materialTextureIndexBytes));
     }
 
     _residentBuffersInitialized = true;
@@ -3662,6 +3905,9 @@ void Renderer::updateUniforms(bool cameraChanged) {
   u.sampleImportanceTextureIndex = 3;
   u.minSamplesPerPixel = minSamples;
   u.maxSamplesPerPixel = maxSamples;
+  u.materialTextureCount =
+      static_cast<uint32_t>(std::min(_materialTextures.size(),
+                                     static_cast<size_t>(kMaxMaterialTextures)));
 
   uint64_t residentPrimitiveCount = _residentPrimitiveCount;
   uint64_t residentTriangleCount = _residentTriangleCount;
@@ -3811,6 +4057,9 @@ void Renderer::draw(MTK::View *pView) {
         pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 8);
         pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 9);
         pCompute->setBuffer(_pInstanceBuffer, 0, 10);
+        pCompute->setBuffer(_pTriangleUVBuffer, 0, 14);
+        pCompute->setBuffer(_pMaterialTextureIndexBuffer, 0, 15);
+        pCompute->setBuffer(_pMaterialTextureArgumentBuffer, 0, 16);
       } else {
         pCompute->setBuffer(_pBVHBuffer, 0, 0);
         pCompute->setBuffer(_pSphereBuffer, 0, 1);
@@ -3826,6 +4075,9 @@ void Renderer::draw(MTK::View *pView) {
         pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
         pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
         pCompute->setBuffer(_pInstanceBuffer, 0, 13);
+        pCompute->setBuffer(_pTriangleUVBuffer, 0, 14);
+        pCompute->setBuffer(_pMaterialTextureIndexBuffer, 0, 15);
+        pCompute->setBuffer(_pMaterialTextureArgumentBuffer, 0, 16);
       }
       pCompute->setTexture(accum0, 0);
       pCompute->setTexture(accum1, 1);

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -161,6 +161,9 @@ private:
   std::array<simd::float3, 8>
   buildFrustumCorners(const Camera::State &state, float nearDistance,
                       float farDistance) const;
+  void rebuildMaterialTextures();
+  void releaseMaterialTextures();
+  void updateMaterialTextureBindings();
 
   MTL::Device *_pDevice = nullptr;
   MTL::CommandQueue *_pCommandQueue = nullptr;
@@ -177,6 +180,8 @@ private:
   MTL::Buffer *_pSphereMaterialBuffer = nullptr;
   MTL::Buffer *_pTriangleVertexBuffer = nullptr;
   MTL::Buffer *_pTriangleIndexBuffer = nullptr;
+  MTL::Buffer *_pTriangleUVBuffer = nullptr;
+  MTL::Buffer *_pMaterialTextureIndexBuffer = nullptr;
   MTL::Buffer *_pUniformsBuffer = nullptr;
   MTL::Buffer *_pBVHBuffer = nullptr;
   MTL::Buffer *_pPrimitiveIndexBuffer = nullptr;
@@ -193,6 +198,8 @@ private:
   MTL::Buffer *_pTlasInstanceDescriptorBuffer = nullptr;
   MTL::Buffer *_pGeometryHandleBuffer = nullptr;
   MTL::Buffer *_pFrustumVertexBuffer = nullptr;
+  MTL::Buffer *_pMaterialTextureArgumentBuffer = nullptr;
+  MTL::ArgumentEncoder *_pMaterialTextureArgumentEncoder = nullptr;
   size_t _blasNodeCount = 0;
   size_t _tlasNodeCount = 0;
   size_t _activeNodeCount = 0;
@@ -322,8 +329,11 @@ private:
   std::vector<simd::float4> _cachedTLASNodes;
   std::vector<simd::float3> _cachedTriangleVertices;
   std::vector<simd::uint3> _cachedTriangleIndices;
+  std::vector<simd::float2> _cachedTriangleUVs;
+  std::vector<int32_t> _cachedMaterialTextureIndices;
   std::vector<uint32_t> _cachedLightIndices;
   std::vector<float> _cachedLightCdf;
+  std::vector<MTL::Texture *> _materialTextures;
 
   size_t _maxPrimitiveCount = 0;
   size_t _maxTriangleVertexCount = 0;
@@ -335,6 +345,7 @@ private:
   size_t _sphereMaterialBufferCapacity = 0;
   size_t _triangleVertexBufferCapacity = 0;
   size_t _triangleIndexBufferCapacity = 0;
+  size_t _triangleUVBufferCapacity = 0;
   size_t _bvhBufferCapacity = 0;
   size_t _tlasBufferCapacity = 0;
   size_t _primitiveIndexBufferCapacity = 0;
@@ -347,6 +358,8 @@ private:
   size_t _geometryHandleBufferCapacity = 0;
   size_t _primitiveHitReadbackCapacity = 0;
   size_t _frustumVertexCapacity = 0;
+  size_t _materialTextureIndexBufferCapacity = 0;
+  size_t _materialTextureArgumentBufferCapacity = 0;
 
   std::chrono::high_resolution_clock::time_point _cpuStart;
   double _lastCPUTime = 0.0;

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -19,6 +19,9 @@ kernel void pathTraceKernel(
     device const uint *primitiveRemap [[buffer(11)]],
     device atomic_uint *primitiveHitCounts [[buffer(12)]],
     device const InstanceRecord *instanceRecords [[buffer(13)]],
+    device const float2 *triangleUVs [[buffer(14)]],
+    device const int *materialTextureIndices [[buffer(15)]],
+    constant MaterialTextureArguments &materialTextures [[buffer(16)]],
     texture2d<half, access::read> lastFrame [[texture(0)]],
     texture2d<half, access::write> currentFrame [[texture(1)]],
     texture2d<half, access::read_write> sampleCount [[texture(2)]],
@@ -80,7 +83,9 @@ kernel void pathTraceKernel(
     accumulatedColor += rayColor(r, rayDx, rayDy, tlasNodes, u.tlasNodeCount, bvhNodes,
                                  primitives, materials, u.primitiveCount, primitiveIndices,
                                  activeMask, instanceRecords, lightIndices, lightCdf,
-                                 primitiveRemap, primitiveHitCounts, seed, u.maxRayDepth,
+                                 primitiveRemap, primitiveHitCounts, triangleUVs,
+                                 materialTextureIndices, materialTextures,
+                                 u.materialTextureCount, seed, u.maxRayDepth,
                                  u.debugAS, u.blasNodeCount, u.lightCount,
                                  u.lightTotalWeight, static_cast<uint>(u.totalPrimitiveCount));
   }

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -26,6 +26,15 @@ template <typename T> inline void swap(thread T &a, thread T &b) {
   b = tmp;
 }
 
+constexpr uint kMaxMaterialTextures = 256;
+
+struct MaterialTextureArguments {
+  array<texture2d<float, access::sample>, kMaxMaterialTextures> textures;
+};
+
+constexpr sampler kMaterialSampler(filter::linear, mip_filter::linear,
+                                   address::repeat, coord::normalized);
+
 inline float3 randomUnitVector(thread uint32_t &seed) {
   float z = 2.0 * randomFloat(seed) - 1.0;
   float t = 2.0 * M_PI * randomFloat(seed);
@@ -43,6 +52,24 @@ inline float3 randomInUnitSphere(thread uint32_t &seed) {
     if (length_squared(p) < 1.0)
       return p;
   }
+}
+
+inline float3 barycentricFromPoint(float3 p, float3 v0, float3 v1, float3 v2) {
+  float3 v0v1 = v1 - v0;
+  float3 v0v2 = v2 - v0;
+  float3 v0p = p - v0;
+  float d00 = dot(v0v1, v0v1);
+  float d01 = dot(v0v1, v0v2);
+  float d11 = dot(v0v2, v0v2);
+  float d20 = dot(v0p, v0v1);
+  float d21 = dot(v0p, v0v2);
+  float denom = d00 * d11 - d01 * d01;
+  if (fabs(denom) < 1e-8f)
+    return float3(1.0, 0.0, 0.0);
+  float v = (d11 * d20 - d01 * d21) / denom;
+  float w = (d00 * d21 - d01 * d20) / denom;
+  float u = 1.0 - v - w;
+  return float3(u, v, w);
 }
 
 inline uint selectLightOffset(float xi, device const float *lightCdf,
@@ -190,6 +217,7 @@ inline intersection firstHitBVH(thread const Ray &r,
         float tHit = INFINITY;
         float3 n = float3(0);
         float3 hit = float3(0);
+        float3 bary = float3(1.0, 0.0, 0.0);
         bool hitThis = false;
 
         if (primitiveType == 0) {
@@ -233,6 +261,7 @@ inline intersection firstHitBVH(thread const Ray &r,
                   tHit = tt;
                   hit = r.origin + tHit * r.direction;
                   n = normalize(cross(edge1, edge2));
+                  bary = float3(1.0 - u - v, u, v);
                   hitThis = true;
                   in.isTriangle = 1;
                 }
@@ -267,6 +296,7 @@ inline intersection firstHitBVH(thread const Ray &r,
           in.primitiveId = primIdx;
           in.normal = n;
           in.point = hit;
+          in.barycentric = bary;
           in.isTriangle = primitiveType;
           in.nodeIndex = nodeIdx;
         }
@@ -305,6 +335,7 @@ inline intersection firstHitTLAS(
   bestHit.primitiveId = -1;
   bestHit.nodeIndex = -1;
   bestHit.isTriangle = 0;
+  bestHit.barycentric = float3(0.0);
 
   if (tlasNodeCount == 0)
     return bestHit;
@@ -393,7 +424,11 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
                        device const float *lightCdf,
                        device const uint *primitiveRemap,
                        device atomic_uint *primitiveHitCounts,
-                       thread uint32_t &seed, uint maxRayDepth,
+                       device const float2 *triangleUVs,
+                       device const int *materialTextureIndices,
+                       constant MaterialTextureArguments &materialTextures,
+                       uint materialTextureCount, thread uint32_t &seed,
+                       uint maxRayDepth,
                        uint debugAS, uint blasNodeCount, uint lightCount,
                        float lightTotalWeight, uint totalPrimitiveCount) {
   float footprint = length(cross(rayDx, rayDy));
@@ -452,12 +487,84 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
     float4 m1 = materials[matIndex + 1];
     float4 m2 = materials[matIndex + 2];
 
-    float3 albedo = m0.xyz * lodAtten;
+    float3 baseAlbedo = m0.xyz;
     float materialType = m0.w;
     float3 emissionColor = m1.xyz;
     float emissionPower = m1.w;
-    float diffuseTextureIndex = m2.x;
-    (void)diffuseTextureIndex;
+    float3 albedo = baseAlbedo;
+
+    int textureIndex = -1;
+    if (materialTextureIndices && bestHit.primitiveId >= 0)
+      textureIndex = materialTextureIndices[bestHit.primitiveId];
+    else
+      textureIndex = int(m2.x);
+    if (textureIndex >= 0 &&
+        textureIndex < int(materialTextureCount) && triangleUVs &&
+        bestHit.primitiveId >= 0 && textureIndex < int(kMaxMaterialTextures)) {
+      int uvBase = bestHit.primitiveId * 3;
+      float2 uv0 = triangleUVs[uvBase + 0];
+      float2 uv1 = triangleUVs[uvBase + 1];
+      float2 uv2 = triangleUVs[uvBase + 2];
+      float3 bary = bestHit.barycentric;
+      float2 hitUV = uv0 * bary.x + uv1 * bary.y + uv2 * bary.z;
+
+      float2 dUVdx = float2(0.0);
+      float2 dUVdy = float2(0.0);
+      bool haveGradients = false;
+      if (bestHit.isTriangle == 1) {
+        int primBase = bestHit.primitiveId * 3;
+        float3 v0 = primitives[primBase + 0].xyz;
+        float3 v1 = primitives[primBase + 1].xyz;
+        float3 v2 = primitives[primBase + 2].xyz;
+        float3 normal = normalize(cross(v1 - v0, v2 - v0));
+
+        float3 dirX = r.direction + rayDx;
+        float denomX = dot(normal, dirX);
+        bool validDx = false;
+        if (fabs(denomX) > 1e-6f) {
+          float tX = dot(normal, v0 - r.origin) / denomX;
+          if (tX > 0.0f) {
+            float3 hitX = r.origin + dirX * tX;
+            float3 baryX = barycentricFromPoint(hitX, v0, v1, v2);
+            float2 uvX = uv0 * baryX.x + uv1 * baryX.y + uv2 * baryX.z;
+            dUVdx = uvX - hitUV;
+            validDx = isfinite(dUVdx.x) && isfinite(dUVdx.y);
+          }
+        }
+
+        float3 dirY = r.direction + rayDy;
+        float denomY = dot(normal, dirY);
+        bool validDy = false;
+        if (fabs(denomY) > 1e-6f) {
+          float tY = dot(normal, v0 - r.origin) / denomY;
+          if (tY > 0.0f) {
+            float3 hitY = r.origin + dirY * tY;
+            float3 baryY = barycentricFromPoint(hitY, v0, v1, v2);
+            float2 uvY = uv0 * baryY.x + uv1 * baryY.y + uv2 * baryY.z;
+            dUVdy = uvY - hitUV;
+            validDy = isfinite(dUVdy.x) && isfinite(dUVdy.y);
+          }
+        }
+
+        haveGradients = validDx && validDy;
+      }
+
+      texture2d<float, access::sample> diffuseTexture =
+          materialTextures.textures[textureIndex];
+      if (diffuseTexture.get_width() > 0 && diffuseTexture.get_height() > 0) {
+        float4 texColor;
+        if (haveGradients) {
+          texColor = diffuseTexture.sample(
+              kMaterialSampler, hitUV, gradient2d<float>(dUVdx, dUVdy));
+        } else {
+          texColor = diffuseTexture.sample(kMaterialSampler, hitUV,
+                                           level(0.0f));
+        }
+        albedo = texColor.xyz * baseAlbedo;
+      }
+    }
+
+    albedo *= lodAtten;
 
     if (emissionPower > 0.0 || materialType == 2) {
       light += absorption * float4(emissionColor, 1.0) * emissionPower;

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -16,6 +16,7 @@ struct intersection
     float t = INFINITY;
     float3 point;
     float3 normal;
+    float3 barycentric = float3(0.0);
     bool frontFace;
     int primitiveId = -1;
     int isTriangle = 0;
@@ -71,6 +72,10 @@ struct UniformsData
     uint sampleImportanceTextureIndex;
     uint minSamplesPerPixel;
     uint maxSamplesPerPixel;
+    uint materialTextureCount;
+    uint materialTexturePadding0;
+    uint materialTexturePadding1;
+    uint materialTexturePadding2;
 };
 
 


### PR DESCRIPTION
## Summary
- add cached triangle UV and material texture index buffers and bind them in the path tracing kernel
- manage a pool of Metal textures for diffuse maps and expose them through an argument buffer
- update the path tracing shaders to sample diffuse textures with UV gradients and fall back to albedo when unavailable

## Testing
- not run (requires Metal runtime)


------
https://chatgpt.com/codex/tasks/task_e_68ef00090900832da7a591597a152bd2