### PR TITLE
Enhance material handling for OBJ assets

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -288,8 +288,10 @@ float primitiveImportance(const Primitive &p) {
   float area = std::max(primitiveArea(p), 1e-4f);
   const Material &m = p.material;
   float emissive = m.emissionPower * luminance(m.emissionColor);
-  float reflective = luminance(m.albedo);
-  return area * (emissive + reflective);
+  float diffuse = luminance(m.diffuseColor) * m.opacity;
+  float specular = luminance(m.specularColor) * m.opacity;
+  float transmission = (1.0f - m.opacity) * luminance(m.transmissionColor);
+  return area * (emissive + diffuse + specular + transmission);
 }
 
 float sanitizeSortValue(float value) {
@@ -2219,13 +2221,14 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   if (needFullUpload) {
     _cachedPrimitiveData.assign(totalPrimitiveCount * 3,
                                 simd::float4{0.0f, 0.0f, 0.0f, 0.0f});
-    _cachedMaterialData.assign(totalPrimitiveCount * 2,
+    _cachedMaterialData.assign(totalPrimitiveCount * kMaterialFloat4Count,
                                simd::float4{0.0f, 0.0f, 0.0f, 0.0f});
 
     for (size_t i = 0; i < totalPrimitiveCount; ++i) {
       const Primitive &p = _allPrimitives[i];
       simd::float4 *primBase = &_cachedPrimitiveData[3 * i];
-      simd::float4 *matBase = &_cachedMaterialData[2 * i];
+      simd::float4 *matBase =
+          &_cachedMaterialData[kMaterialFloat4Count * i];
 
       switch (p.type) {
       case PrimitiveType::Sphere: {
@@ -2253,8 +2256,10 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       }
 
       const Material &m = p.material;
-      matBase[0] = simd::make_float4(m.albedo, m.materialType);
-      matBase[1] = simd::make_float4(m.emissionColor, m.emissionPower);
+      auto packed = encodeMaterial(m);
+      for (size_t j = 0; j < kMaterialFloat4Count; ++j) {
+        matBase[j] = packed[j];
+      }
     }
 
     _pScene->createTriangleBuffers(_cachedTriangleVertices,
@@ -2447,7 +2452,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     compactActiveMask.clear();
 
     compactPrimitiveData.reserve(_activePrimitiveCount * 3);
-    compactMaterialData.reserve(_activePrimitiveCount * 2);
+    compactMaterialData.reserve(_activePrimitiveCount * kMaterialFloat4Count);
     compactPrimitiveIndices.reserve(_activePrimitiveCount);
     compactActiveMask.reserve(_activePrimitiveCount);
 
@@ -2547,10 +2552,10 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
           compactPrimitiveData.push_back(prim2);
 
           const Material &m = p.material;
-          compactMaterialData.push_back(
-              simd::make_float4(m.albedo, m.materialType));
-          compactMaterialData.push_back(
-              simd::make_float4(m.emissionColor, m.emissionPower));
+          auto packedMaterial = encodeMaterial(m);
+          for (size_t j = 0; j < kMaterialFloat4Count; ++j) {
+            compactMaterialData.push_back(packedMaterial[j]);
+          }
           compactActiveMask.push_back(1);
           compactPrimitiveIndices.push_back(
               static_cast<int>(record.primitiveBase + activeCount));
@@ -2757,9 +2762,10 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         compactPrimitiveData.push_back(prim2);
 
         const Material &m = p.material;
-        compactMaterialData.push_back(simd::make_float4(m.albedo, m.materialType));
-        compactMaterialData.push_back(
-            simd::make_float4(m.emissionColor, m.emissionPower));
+        auto packedMaterial = encodeMaterial(m);
+        for (size_t j = 0; j < kMaterialFloat4Count; ++j) {
+          compactMaterialData.push_back(packedMaterial[j]);
+        }
         compactActiveMask.push_back(1);
       }
 

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -8,6 +8,8 @@
 
 using namespace metal;
 
+constant uint kMaterialFloat4Count = 5;
+
 struct Ray {
   float3 origin;
   float3 direction;
@@ -43,6 +45,43 @@ inline float3 randomInUnitSphere(thread uint32_t &seed) {
     if (length_squared(p) < 1.0)
       return p;
   }
+}
+
+inline int decodeTextureIndex(float value) {
+  return (value >= -0.5f) ? int(floor(value + 0.5f)) : -1;
+}
+
+inline MaterialPayload decodeMaterial(int baseIndex,
+                                      device const float4 *materials,
+                                      float lodAttenuation) {
+  MaterialPayload payload;
+  float4 m0 = materials[baseIndex + 0];
+  float4 m1 = materials[baseIndex + 1];
+  float4 m2 = materials[baseIndex + 2];
+  float4 m3 = materials[baseIndex + 3];
+  float4 m4 = materials[baseIndex + 4];
+
+  payload.diffuseColor = max(m0.xyz * lodAttenuation, float3(0.0f));
+  payload.opacity = clamp(m0.w, 0.0f, 1.0f);
+  payload.specularColor = max(m1.xyz, float3(0.0f));
+  payload.shininess = max(m1.w, 1.0f);
+  payload.emissionColor = max(m2.xyz, float3(0.0f));
+  payload.emissionPower = max(m2.w, 0.0f);
+  payload.transmissionColor = max(m3.xyz, float3(0.0f));
+  payload.indexOfRefraction = max(m3.w, 1e-3f);
+  payload.roughness = clamp(m4.w, 0.0f, 1.0f);
+  payload.diffuseTextureIndex = decodeTextureIndex(m4.x);
+  payload.specularTextureIndex = decodeTextureIndex(m4.y);
+  payload.normalTextureIndex = decodeTextureIndex(m4.z);
+  payload.pad0 = 0.0f;
+  payload.pad1 = 0;
+
+  if (payload.opacity < 1.0f && luminance(payload.transmissionColor) <= 0.0f) {
+    float trans = 1.0f - payload.opacity;
+    payload.transmissionColor = float3(trans);
+  }
+
+  return payload;
 }
 
 inline uint selectLightOffset(float xi, device const float *lightCdf,
@@ -445,24 +484,25 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
                                     memory_order_relaxed);
       }
     }
-    int matIndex = bestHit.primitiveId * 2;
-    if (matIndex + 1 >= int(primitiveCount) * 2)
+    int matBase = bestHit.primitiveId * int(kMaterialFloat4Count);
+    int totalEntries = int(primitiveCount) * int(kMaterialFloat4Count);
+    if (matBase + int(kMaterialFloat4Count) > totalEntries)
       break;
-    float4 m0 = materials[matIndex + 0];
-    float4 m1 = materials[matIndex + 1];
 
-    float3 albedo = m0.xyz * lodAtten;
-    float materialType = m0.w;
-    float3 emissionColor = m1.xyz;
-    float emissionPower = m1.w;
+    MaterialPayload material = decodeMaterial(matBase, materials, lodAtten);
 
-    if (emissionPower > 0.0 || materialType == 2) {
-      light += absorption * float4(emissionColor, 1.0) * emissionPower;
+    float emissionStrength = material.emissionPower *
+                             luminance(material.emissionColor);
+    if (emissionStrength > 0.0f) {
+      light += absorption * float4(material.emissionColor, 1.0) *
+               material.emissionPower;
     }
 
     float3 offsetNormal = bestHit.frontFace ? bestHit.normal : -bestHit.normal;
 
-    if (materialType == 0.0 && lightCount > 0 && lightTotalWeight > 0.0f) {
+    float3 diffuseColor = material.diffuseColor * material.opacity;
+    float diffuseLum = luminance(diffuseColor);
+    if (diffuseLum > 0.0f && lightCount > 0 && lightTotalWeight > 0.0f) {
       float lightXi = randomFloat(seed);
       seed = random(seed);
       uint selectedOffset =
@@ -494,7 +534,7 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
                 float lightPdf =
                     (lightTotalWeight > 0.0f && weight > 0.0f)
                         ? weight / lightTotalWeight
-                        : 0.0f;
+                    : 0.0f;
                 if (lightPdf > 0.0f) {
                   float pdfArea = 1.0f / area;
                   float pdfSolid = pdfArea * dist2 / cosLight;
@@ -518,11 +558,16 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
                       visible = true;
                     }
                     if (visible) {
-                      int lightMatIndex = int(lightPrimIndex) * 2;
-                      if (lightMatIndex + 1 < int(primitiveCount) * 2) {
-                        float4 lightM1 = materials[lightMatIndex + 1];
-                        float3 lightRadiance = lightM1.xyz * lightM1.w;
-                        float3 throughput = absorption.xyz * (albedo / M_PI);
+                      int lightMatIndex = int(lightPrimIndex) *
+                                          int(kMaterialFloat4Count);
+                      if (lightMatIndex + int(kMaterialFloat4Count) <=
+                          int(primitiveCount) * int(kMaterialFloat4Count)) {
+                        MaterialPayload lightMaterial =
+                            decodeMaterial(lightMatIndex, materials, 1.0f);
+                        float3 lightRadiance = lightMaterial.emissionColor *
+                                              lightMaterial.emissionPower;
+                        float3 throughput =
+                            absorption.xyz * (diffuseColor / M_PI);
                         float3 contribution =
                             throughput * lightRadiance * (cosTheta / totalPdf);
                         light.xyz += contribution;
@@ -540,9 +585,10 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
     r.origin = bestHit.point + 0.0001 * offsetNormal;
     r.minDistance = 0.0001f;
     r.maxDistance = INFINITY;
-    scatter(r, bestHit, materialType, seed);
+    float3 scatterWeight = scatter(r, bestHit, material, seed);
     seed = random(seed);
-    absorption *= float4(albedo, 1.0);
+    absorption.xyz *= scatterWeight;
+    absorption.w = 1.0f;
 
     if (depth >= 5) {
       float p = max(absorption.x, max(absorption.y, absorption.z));

--- a/MetalCpp Path Tracer/Renderer/Shaders/Scatter.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Scatter.h
@@ -6,40 +6,149 @@
 #include "Random.h"
 #include "Structs.h"
 
-inline bool mirrorAngle(float refractionIndex, thread const float3 &normal, thread const float3 &rayDir, thread uint32_t &seed)
-{
-    const float cosTheta = dot(-1*rayDir, normal);
-    const float sinTheta = sqrt(1.0 - cosTheta*cosTheta);
-    
-    auto r0 =  (1 - refractionIndex) / (1 + refractionIndex);
-    r0 = r0*r0;
-    const float reflectance = r0 + (1-r0)*pow((1 - cosTheta),5);
+struct MaterialPayload {
+    float3 diffuseColor;
+    float opacity;
+    float3 specularColor;
+    float shininess;
+    float3 emissionColor;
+    float emissionPower;
+    float3 transmissionColor;
+    float indexOfRefraction;
+    float roughness;
+    float pad0;
+    int diffuseTextureIndex;
+    int specularTextureIndex;
+    int normalTextureIndex;
+    int pad1;
+};
 
-    return ((refractionIndex * sinTheta > 1.0) || (reflectance > randomFloat(seed)));
+inline float luminance(float3 c) {
+    return dot(c, float3(0.2126f, 0.7152f, 0.0722f));
 }
 
-inline void scatter(thread Ray &r, thread const intersection &i, float materialType,
-                    thread uint32_t &seed)
-{
-    if(!materialType)
-    {
-        r.direction = i.normal + normalize(randomFloat3(seed));
-    }
-    else if(materialType < 0)
-    {
-        r.direction = reflect(r.direction, i.normal);
-    }
-    else
-    {
-        float rIndex = materialType;
-        rIndex = i.frontFace ? 1 / rIndex : rIndex;
+inline bool mirrorAngle(float refractionIndex, thread const float3 &normal,
+                        thread const float3 &rayDir, thread uint32_t &seed) {
+    const float cosTheta = dot(-rayDir, normal);
+    const float sinTheta = sqrt(max(0.0f, 1.0f - cosTheta * cosTheta));
 
-        r.direction = mirrorAngle(rIndex, i.normal, r.direction, seed) ?
-                                    reflect(r.direction, i.normal) :
-                                    refract(r.direction, i.normal, rIndex);
+    float r0 = (1.0f - refractionIndex) / (1.0f + refractionIndex);
+    r0 = r0 * r0;
+    const float reflectance = r0 + (1.0f - r0) * pow((1.0f - cosTheta), 5.0f);
+
+    float xi = randomFloat(seed);
+    seed = random(seed);
+
+    return ((refractionIndex * sinTheta > 1.0f) || (reflectance > xi));
+}
+
+inline void buildOrthonormalBasis(thread const float3 &n,
+                                  thread float3 &t, thread float3 &b) {
+    float3 up = (fabs(n.z) < 0.999f) ? float3(0.0f, 0.0f, 1.0f)
+                                     : float3(0.0f, 1.0f, 0.0f);
+    t = normalize(cross(up, n));
+    b = normalize(cross(n, t));
+}
+
+inline float3 sampleCosineHemisphere(thread const float3 &normal,
+                                     thread uint32_t &seed) {
+    float u1 = randomFloat(seed);
+    seed = random(seed);
+    float u2 = randomFloat(seed);
+    seed = random(seed);
+
+    float r = sqrt(max(0.0f, u1));
+    float theta = 2.0f * M_PI * u2;
+    float x = r * cos(theta);
+    float y = r * sin(theta);
+    float z = sqrt(max(0.0f, 1.0f - u1));
+
+    float3 tangent;
+    float3 bitangent;
+    buildOrthonormalBasis(normal, tangent, bitangent);
+    float3 local = tangent * x + bitangent * y + normal * z;
+    return normalize(local);
+}
+
+inline float3 scatter(thread Ray &r, thread const intersection &i,
+                      thread const MaterialPayload &material,
+                      thread uint32_t &seed) {
+    float3 normal = i.frontFace ? i.normal : -i.normal;
+
+    float diffuseWeight = max(luminance(material.diffuseColor) * material.opacity,
+                              0.0f);
+    float specularWeight = max(luminance(material.specularColor) * material.opacity,
+                               0.0f);
+    float dielectricWeight = max(
+        luminance(material.transmissionColor) * (1.0f - material.opacity), 0.0f);
+
+    if (dielectricWeight > 0.0f) {
+        specularWeight = 0.0f;
     }
 
-    r.direction = normalize(r.direction);
+    float totalWeight = diffuseWeight + specularWeight + dielectricWeight;
+    if (totalWeight <= 0.0f) {
+        r.direction = normal;
+        return float3(0.0f);
+    }
+
+    float xi = randomFloat(seed) * totalWeight;
+    seed = random(seed);
+
+    if (xi < diffuseWeight) {
+        float3 direction = sampleCosineHemisphere(normal, seed);
+        r.direction = direction;
+        float probability = max(diffuseWeight / totalWeight, 1e-4f);
+        return (material.diffuseColor * material.opacity) / probability;
+    }
+
+    xi -= diffuseWeight;
+    if (xi < specularWeight) {
+        float3 reflectDir = reflect(r.direction, normal);
+        float exponent = max(material.shininess, 1.0f);
+        if (material.roughness > 0.0f) {
+            float smoothness = clamp(1.0f - material.roughness, 0.0f, 1.0f);
+            float roughExponent = max(1.0f, smoothness * smoothness * 256.0f);
+            exponent = max(exponent, roughExponent);
+        }
+
+        float u1 = randomFloat(seed);
+        seed = random(seed);
+        float u2 = randomFloat(seed);
+        seed = random(seed);
+
+        float cosTheta = pow(u1, 1.0f / (exponent + 1.0f));
+        float sinTheta = sqrt(max(0.0f, 1.0f - cosTheta * cosTheta));
+        float phi = 2.0f * M_PI * u2;
+
+        float3 tangent;
+        float3 bitangent;
+        buildOrthonormalBasis(reflectDir, tangent, bitangent);
+        float3 specDir = normalize(tangent * (sinTheta * cos(phi)) +
+                                   bitangent * (sinTheta * sin(phi)) +
+                                   reflectDir * cosTheta);
+        r.direction = specDir;
+        float probability = max(specularWeight / totalWeight, 1e-4f);
+        return material.specularColor / probability;
+    }
+
+    float probability = max(dielectricWeight / totalWeight, 1e-4f);
+    float eta = max(material.indexOfRefraction, 1e-3f);
+    float etaRatio = i.frontFace ? (1.0f / eta) : eta;
+    bool reflectSample = mirrorAngle(etaRatio, normal, r.direction, seed);
+    if (reflectSample) {
+        r.direction = reflect(r.direction, normal);
+        return material.specularColor / probability;
+    }
+
+    float3 refracted = refract(r.direction, normal, etaRatio);
+    if (!all(isfinite(refracted))) {
+        r.direction = reflect(r.direction, normal);
+        return material.specularColor / probability;
+    }
+
+    r.direction = normalize(refracted);
+    return material.transmissionColor / probability;
 }
 
 #endif

--- a/MetalCpp Path Tracer/Scene/Material.h
+++ b/MetalCpp Path Tracer/Scene/Material.h
@@ -1,17 +1,47 @@
 #ifndef MATERIAL_H
 #define MATERIAL_H
 
+#include <array>
 #include <simd/simd.h>
 
 namespace MetalCppPathTracer {
 
+inline constexpr size_t kMaterialFloat4Count = 5;
+
 struct Material
 {
-    simd::float3 albedo;
-    float materialType;
-    simd::float3 emissionColor;
-    float emissionPower;
+    simd::float3 diffuseColor = {0.8f, 0.8f, 0.8f};
+    float opacity = 1.0f;
+
+    simd::float3 specularColor = {0.04f, 0.04f, 0.04f};
+    float shininess = 32.0f;
+
+    simd::float3 emissionColor = {0.0f, 0.0f, 0.0f};
+    float emissionPower = 0.0f;
+
+    simd::float3 transmissionColor = {0.0f, 0.0f, 0.0f};
+    float indexOfRefraction = 1.0f;
+
+    float roughness = 0.5f;
+    int diffuseTextureIndex = -1;
+    int specularTextureIndex = -1;
+    int normalTextureIndex = -1;
+    int padding = 0;
 };
+
+inline std::array<simd::float4, kMaterialFloat4Count> encodeMaterial(const Material &m)
+{
+    std::array<simd::float4, kMaterialFloat4Count> data{};
+    data[0] = simd::make_float4(m.diffuseColor, m.opacity);
+    data[1] = simd::make_float4(m.specularColor, m.shininess);
+    data[2] = simd::make_float4(m.emissionColor, m.emissionPower);
+    data[3] = simd::make_float4(m.transmissionColor, m.indexOfRefraction);
+    data[4] = simd::make_float4(static_cast<float>(m.diffuseTextureIndex),
+                                 static_cast<float>(m.specularTextureIndex),
+                                 static_cast<float>(m.normalTextureIndex),
+                                 m.roughness);
+    return data;
+}
 
 };
 

--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -245,11 +245,14 @@ simd::float4 *Scene::createTransformsBuffer() const {
 }
 
 simd::float4 *Scene::createMaterialsBuffer() const {
-  simd::float4 *buffer = new simd::float4[2 * primitives.size()];
+  simd::float4 *buffer =
+      new simd::float4[kMaterialFloat4Count * primitives.size()];
   for (size_t i = 0; i < primitives.size(); ++i) {
     const auto &m = primitives[i].material;
-    buffer[2 * i + 0] = simd::make_float4(m.albedo, m.materialType);
-    buffer[2 * i + 1] = simd::make_float4(m.emissionColor, m.emissionPower);
+    auto packed = encodeMaterial(m);
+    for (size_t j = 0; j < kMaterialFloat4Count; ++j) {
+      buffer[kMaterialFloat4Count * i + j] = packed[j];
+    }
   }
   return buffer;
 }
@@ -270,15 +273,15 @@ simd::float4 *Scene::createSphereBuffer() {
 
 simd::float4 *Scene::createSphereMaterialsBuffer() {
   size_t sphereCount = getSphereCount();
-  simd::float4 *buffer = new simd::float4[2 * sphereCount];
+  simd::float4 *buffer = new simd::float4[kMaterialFloat4Count * sphereCount];
 
   size_t index = 0;
   for (const auto &p : primitives) {
     if (p.type == PrimitiveType::Sphere) {
-      const auto &m = p.material;
-      buffer[2 * index + 0] = simd::make_float4(m.albedo, m.materialType);
-      buffer[2 * index + 1] =
-          simd::make_float4(m.emissionColor, m.emissionPower);
+      auto packed = encodeMaterial(p.material);
+      for (size_t j = 0; j < kMaterialFloat4Count; ++j) {
+        buffer[kMaterialFloat4Count * index + j] = packed[j];
+      }
       index++;
     }
   }

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -14,6 +14,7 @@
 #include <utility>
 #include <vector>
 #include <limits>
+#include <cmath>
 #include "tiny_obj_loader.h"
 
 using namespace tinyxml2;
@@ -50,6 +51,137 @@ static simd::float3 rotateVectorEulerXYZ(const simd::float3& v,
 }
 
 namespace {
+
+static float clamp01(float value) {
+    return std::clamp(value, 0.0f, 1.0f);
+}
+
+static simd::float3 toFloat3(const tinyobj::real_t values[3]) {
+    return simd::make_float3(static_cast<float>(values[0]),
+                             static_cast<float>(values[1]),
+                             static_cast<float>(values[2]));
+}
+
+static float luminance(const simd::float3& c) {
+    return 0.2126f * c.x + 0.7152f * c.y + 0.0722f * c.z;
+}
+
+static float computeRoughness(float shininess, float explicitRoughness) {
+    if (explicitRoughness > 0.0f) {
+        return clamp01(explicitRoughness);
+    }
+    if (shininess <= 0.0f) {
+        return 1.0f;
+    }
+    float converted = std::sqrt(2.0f / (shininess + 2.0f));
+    return clamp01(converted);
+}
+
+static Material ConvertTinyMaterial(const tinyobj::material_t& src) {
+    Material material{};
+    material.diffuseColor = toFloat3(src.diffuse);
+    material.specularColor = toFloat3(src.specular);
+    material.transmissionColor = toFloat3(src.transmittance);
+    material.emissionColor = toFloat3(src.emission);
+
+    float emissionLum = luminance(material.emissionColor);
+    material.emissionPower = (emissionLum > 0.0f) ? 1.0f : 0.0f;
+
+    material.shininess = static_cast<float>(src.shininess);
+    material.indexOfRefraction = (src.ior != 0.0f) ? static_cast<float>(src.ior)
+                                                   : 1.0f;
+    material.opacity = clamp01(static_cast<float>(src.dissolve));
+    material.roughness = computeRoughness(material.shininess,
+                                          static_cast<float>(src.roughness));
+
+    if (luminance(material.transmissionColor) <= 0.0f && material.opacity < 1.0f) {
+        float trans = 1.0f - material.opacity;
+        material.transmissionColor = simd::make_float3(trans, trans, trans);
+    }
+
+    return material;
+}
+
+static Material ParseMaterialAttributes(const XMLElement* element) {
+    Material material{};
+
+    bool hasDiffuseAttr = false;
+    if (const char* diffuseAttr = element->Attribute("diffuse")) {
+        material.diffuseColor = parseVec3(diffuseAttr);
+        hasDiffuseAttr = true;
+    }
+    if (const char* albedoAttr = element->Attribute("albedo")) {
+        material.diffuseColor = parseVec3(albedoAttr);
+        hasDiffuseAttr = true;
+    }
+
+    if (const char* emissionAttr = element->Attribute("emission")) {
+        material.emissionColor = parseVec3(emissionAttr);
+    }
+    material.emissionPower = element->FloatAttribute("emissionPower",
+                                                     material.emissionPower);
+
+    bool hasSpecularAttr = false;
+    if (const char* specAttr = element->Attribute("specular")) {
+        material.specularColor = parseVec3(specAttr);
+        hasSpecularAttr = true;
+    }
+
+    bool hasTransmissionAttr = false;
+    if (const char* transAttr = element->Attribute("transmission")) {
+        material.transmissionColor = parseVec3(transAttr);
+        hasTransmissionAttr = true;
+    }
+
+    bool hasOpacityAttr = element->FindAttribute("opacity") != nullptr;
+    material.opacity = element->FloatAttribute("opacity", material.opacity);
+    material.shininess = element->FloatAttribute("shininess", material.shininess);
+    material.roughness = element->FloatAttribute("roughness", material.roughness);
+    material.indexOfRefraction = element->FloatAttribute("ior",
+                                                         material.indexOfRefraction);
+
+    if (!hasTransmissionAttr && material.opacity < 1.0f) {
+        float trans = 1.0f - material.opacity;
+        material.transmissionColor = simd::make_float3(trans, trans, trans);
+    }
+
+    if (const XMLAttribute* typeAttr = element->FindAttribute("materialType")) {
+        float materialType = typeAttr->FloatValue();
+        if (materialType < 0.0f) {
+            if (!hasSpecularAttr) {
+                material.specularColor = simd::make_float3(1.0f, 1.0f, 1.0f);
+            }
+            material.opacity = 1.0f;
+            material.transmissionColor = simd::make_float3(0.0f, 0.0f, 0.0f);
+            material.shininess = std::max(material.shininess, 256.0f);
+            material.roughness = std::min(material.roughness, 0.02f);
+        } else if (materialType > 0.0f) {
+            if (!hasSpecularAttr) {
+                material.specularColor = simd::make_float3(1.0f, 1.0f, 1.0f);
+            }
+            if (!hasTransmissionAttr) {
+                material.transmissionColor = simd::make_float3(1.0f, 1.0f, 1.0f);
+            }
+            material.indexOfRefraction = materialType;
+            if (!hasOpacityAttr) {
+                material.opacity = 0.0f;
+            }
+            material.shininess = std::max(material.shininess, 96.0f);
+            material.roughness = std::min(material.roughness, 0.1f);
+        }
+    }
+
+    material.opacity = clamp01(material.opacity);
+    material.roughness = clamp01(material.roughness);
+    material.shininess = std::max(material.shininess, 1.0f);
+
+    if (!hasDiffuseAttr && material.opacity < 1.0f && luminance(material.diffuseColor) <= 0.0f) {
+        float base = 1.0f - material.opacity;
+        material.diffuseColor = simd::make_float3(base, base, base);
+    }
+
+    return material;
+}
 
 static float AxisValue(const simd::float3& v, int axis) {
     switch (axis) {
@@ -186,6 +318,8 @@ static void EmitMeshPartitions(Scene* scene, std::vector<Primitive>& prims,
 struct CachedMesh {
     std::vector<simd::float3> vertices;
     std::vector<simd::uint3> indices;
+    std::vector<int> faceMaterialIndices;
+    std::vector<Material> materials;
 };
 
 using MeshCache = std::unordered_map<std::string, CachedMesh>;
@@ -195,13 +329,14 @@ MeshCache& GetMeshCache() {
     return cache;
 }
 
-static void LoadOBJ(const std::string& path, std::vector<simd::float3>& verts, std::vector<simd::uint3>& tris) {
+static void LoadOBJ(const std::string& path, CachedMesh& mesh) {
     tinyobj::attrib_t attrib;
     std::vector<tinyobj::shape_t> shapes;
-    std::vector<tinyobj::material_t> materials;
+    std::vector<tinyobj::material_t> objMaterials;
     std::string warn, err;
 
-    bool ret = tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, path.c_str());
+    bool ret = tinyobj::LoadObj(&attrib, &shapes, &objMaterials, &warn, &err,
+                                path.c_str());
 
     if (!warn.empty()) {
         printf("tinyobjloader warning: %s\n", warn.c_str());
@@ -214,13 +349,23 @@ static void LoadOBJ(const std::string& path, std::vector<simd::float3>& verts, s
         return;
     }
 
-    verts.reserve(attrib.vertices.size() / 3);
+    mesh.vertices.clear();
+    mesh.indices.clear();
+    mesh.faceMaterialIndices.clear();
+    mesh.materials.clear();
+
+    mesh.vertices.reserve(attrib.vertices.size() / 3);
     for (size_t v = 0; v < attrib.vertices.size(); v += 3) {
-        verts.push_back(simd::make_float3(
+        mesh.vertices.push_back(simd::make_float3(
             attrib.vertices[v],
             attrib.vertices[v + 1],
             attrib.vertices[v + 2]
         ));
+    }
+
+    mesh.materials.reserve(objMaterials.size());
+    for (const auto& srcMat : objMaterials) {
+        mesh.materials.push_back(ConvertTinyMaterial(srcMat));
     }
 
     for (const auto& shape : shapes) {
@@ -236,18 +381,31 @@ static void LoadOBJ(const std::string& path, std::vector<simd::float3>& verts, s
             uint32_t idx1 = shape.mesh.indices[indexOffset + 1].vertex_index;
             uint32_t idx2 = shape.mesh.indices[indexOffset + 2].vertex_index;
 
-            if (idx0 >= verts.size() || idx1 >= verts.size() || idx2 >= verts.size()) {
+            if (idx0 >= mesh.vertices.size() || idx1 >= mesh.vertices.size() ||
+                idx2 >= mesh.vertices.size()) {
                 printf("Invalid triangle indices\n");
                 indexOffset += fv;
                 continue;
             }
 
-            tris.push_back(simd::make_uint3(idx0, idx1, idx2));
+            mesh.indices.push_back(simd::make_uint3(idx0, idx1, idx2));
+
+            int materialId = -1;
+            if (f < shape.mesh.material_ids.size()) {
+                materialId = shape.mesh.material_ids[f];
+            }
+            if (materialId >= 0 &&
+                static_cast<size_t>(materialId) < mesh.materials.size()) {
+                mesh.faceMaterialIndices.push_back(materialId);
+            } else {
+                mesh.faceMaterialIndices.push_back(-1);
+            }
             indexOffset += fv;
         }
     }
 
-    printf("Loaded OBJ: %zu vertices, %zu triangles\n", verts.size(), tris.size());
+    printf("Loaded OBJ: %zu vertices, %zu triangles, %zu materials\n",
+           mesh.vertices.size(), mesh.indices.size(), mesh.materials.size());
 }
 
 } // namespace
@@ -368,10 +526,7 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             p.sphere.center = parseVec3(e->Attribute("position"));
             p.sphere.radius = e->FloatAttribute("radius", 1.0f);
 
-            p.material.albedo = parseVec3(e->Attribute("albedo"));
-            p.material.emissionColor = parseVec3(e->Attribute("emission"));
-            p.material.materialType = e->FloatAttribute("materialType", 0);
-            p.material.emissionPower = e->FloatAttribute("emissionPower", 0);
+            p.material = ParseMaterialAttributes(e);
 
             scene->addPrimitive(p);
         }
@@ -388,10 +543,7 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
                 p.rectangle.v = rotateVectorEulerXYZ(p.rectangle.v, rotationRadians);
             }
 
-            p.material.albedo = parseVec3(e->Attribute("albedo"));
-            p.material.emissionColor = parseVec3(e->Attribute("emission"));
-            p.material.materialType = e->FloatAttribute("materialType", 0);
-            p.material.emissionPower = e->FloatAttribute("emissionPower", 0);
+            p.material = ParseMaterialAttributes(e);
 
             scene->addPrimitive(p);
         }
@@ -406,7 +558,7 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             if (it == cache.end()) {
                 // First time encountering this mesh path in the current load.
                 CachedMesh entry;
-                LoadOBJ(normalizedPath, entry.vertices, entry.indices);
+                LoadOBJ(normalizedPath, entry);
                 it = cache.emplace(normalizedPath, std::move(entry)).first;
             }
 
@@ -442,11 +594,7 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
                 basisZ = rotateVectorEulerXYZ(basisZ, rotationRadians);
             }
 
-            Material m;
-            m.albedo = parseVec3(e->Attribute("albedo"));
-            m.emissionColor = parseVec3(e->Attribute("emission"));
-            m.materialType = e->FloatAttribute("materialType", 0);
-            m.emissionPower = e->FloatAttribute("emissionPower", 0);
+            Material overrideMaterial = ParseMaterialAttributes(e);
 
             size_t clusterMaxTriangles = static_cast<size_t>(
                 e->Unsigned64Attribute("clusterMaxTriangles", 0));
@@ -458,13 +606,24 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             auto transformVertex = [&](const simd::float3& v) {
                 return pos + basisX * v.x + basisY * v.y + basisZ * v.z;
             };
-            for (const auto& tri : meshData.indices) {
+            for (size_t triIndex = 0; triIndex < meshData.indices.size(); ++triIndex) {
+                const auto& tri = meshData.indices[triIndex];
                 Primitive p{};
                 p.type = PrimitiveType::Triangle;
                 p.triangle.v0 = transformVertex(meshData.vertices[tri.x]);
                 p.triangle.v1 = transformVertex(meshData.vertices[tri.y]);
                 p.triangle.v2 = transformVertex(meshData.vertices[tri.z]);
-                p.material = m;
+
+                const Material* chosenMaterial = &overrideMaterial;
+                if (triIndex < meshData.faceMaterialIndices.size()) {
+                    int materialId = meshData.faceMaterialIndices[triIndex];
+                    if (materialId >= 0 &&
+                        static_cast<size_t>(materialId) < meshData.materials.size()) {
+                        chosenMaterial = &meshData.materials[materialId];
+                    }
+                }
+
+                p.material = *chosenMaterial;
                 meshPrimitives.push_back(p);
             }
             int meshGroupId = nextMeshGroupId++;


### PR DESCRIPTION
## Summary
- expand the CPU-side material definition and encoding to carry diffuse/specular/transmission, IOR, roughness, and texture handles
- convert OBJ materials and per-face assignments when loading meshes, falling back to XML overrides only when an OBJ face lacks a material
- update GPU material buffers, shading, and scattering logic to consume the richer material payloads and respect `.mtl` parameters during direct and indirect lighting
- refresh renderer material uploads and compaction paths to match the new buffer layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef613285a0832d835eeb28b68991a5