### PR TITLE
Add texture image loading support

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -127,6 +127,7 @@ struct UniformsData {
   uint32_t sampleImportanceTextureIndex = 0;
   uint32_t minSamplesPerPixel = 1;
   uint32_t maxSamplesPerPixel = 1;
+  uint32_t textureCount = 0;
 };
 
 inline uint32_t bitm_random() {
@@ -662,6 +663,10 @@ Renderer::~Renderer() {
     _pGeometryHandleBuffer->release();
   if (_pFrustumVertexBuffer)
     _pFrustumVertexBuffer->release();
+  if (_pTextureInfoBuffer)
+    _pTextureInfoBuffer->release();
+  if (_pTextureDataBuffer)
+    _pTextureDataBuffer->release();
 
   _cachedInstanceDescriptors.clear();
   _cachedInstancedAccelerationStructures.clear();
@@ -2219,14 +2224,15 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       forceFullRebuild || !_residentBuffersInitialized || sizeChanged;
 
   if (needFullUpload) {
-    _cachedPrimitiveData.assign(totalPrimitiveCount * 3,
+    _cachedPrimitiveData.assign(totalPrimitiveCount * kPrimitiveFloat4Count,
                                 simd::float4{0.0f, 0.0f, 0.0f, 0.0f});
     _cachedMaterialData.assign(totalPrimitiveCount * kMaterialFloat4Count,
                                simd::float4{0.0f, 0.0f, 0.0f, 0.0f});
 
     for (size_t i = 0; i < totalPrimitiveCount; ++i) {
       const Primitive &p = _allPrimitives[i];
-      simd::float4 *primBase = &_cachedPrimitiveData[3 * i];
+      simd::float4 *primBase =
+          &_cachedPrimitiveData[kPrimitiveFloat4Count * i];
       simd::float4 *matBase =
           &_cachedMaterialData[kMaterialFloat4Count * i];
 
@@ -2237,6 +2243,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         primBase[1] = simd::make_float4(
             simd::make_float3(p.sphere.radius, 0.0f, 0.0f), 0.0f);
         primBase[2] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+        primBase[3] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
         break;
       }
       case PrimitiveType::Rectangle: {
@@ -2244,13 +2251,16 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
             simd::make_float4(p.rectangle.center, static_cast<float>(p.type));
         primBase[1] = simd::make_float4(p.rectangle.u, 0.0f);
         primBase[2] = simd::make_float4(p.rectangle.v, 0.0f);
+        primBase[3] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
         break;
       }
       case PrimitiveType::Triangle: {
         primBase[0] =
             simd::make_float4(p.triangle.v0, static_cast<float>(p.type));
-        primBase[1] = simd::make_float4(p.triangle.v1, 0.0f);
-        primBase[2] = simd::make_float4(p.triangle.v2, 0.0f);
+        primBase[1] = simd::make_float4(p.triangle.v1, p.triangle.uv0.x);
+        primBase[2] = simd::make_float4(p.triangle.v2, p.triangle.uv0.y);
+        primBase[3] = simd::make_float4(p.triangle.uv1.x, p.triangle.uv1.y,
+                                        p.triangle.uv2.x, p.triangle.uv2.y);
         break;
       }
       }
@@ -2259,6 +2269,31 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       auto packed = encodeMaterial(m);
       for (size_t j = 0; j < kMaterialFloat4Count; ++j) {
         matBase[j] = packed[j];
+      }
+    }
+
+    _cachedTextureInfos.clear();
+    _cachedTextureData.clear();
+    size_t texelOffset = 0;
+    if (_pScene) {
+      const auto &sceneTextures = _pScene->getTextures();
+      for (const auto &tex : sceneTextures) {
+        TextureInfo info{};
+        info.offset = static_cast<uint32_t>(texelOffset);
+        info.width = tex.width;
+        info.height = tex.height;
+        _cachedTextureInfos.push_back(info);
+
+        size_t texelCount = static_cast<size_t>(tex.width) * tex.height;
+        for (size_t t = 0; t < texelCount; ++t) {
+          size_t idx = t * 4;
+          float r = (idx < tex.pixels.size()) ? tex.pixels[idx + 0] : 0.0f;
+          float g = (idx + 1 < tex.pixels.size()) ? tex.pixels[idx + 1] : 0.0f;
+          float b = (idx + 2 < tex.pixels.size()) ? tex.pixels[idx + 2] : 0.0f;
+          float a = (idx + 3 < tex.pixels.size()) ? tex.pixels[idx + 3] : 1.0f;
+          _cachedTextureData.push_back(simd::make_float4(r, g, b, a));
+        }
+        texelOffset += texelCount;
       }
     }
 
@@ -2407,6 +2442,8 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       &_cachedTriangleVertices;
   const std::vector<simd::uint3> *triangleIndexSource =
       &_cachedTriangleIndices;
+  const std::vector<TextureInfo> *textureInfoSource = &_cachedTextureInfos;
+  const std::vector<simd::float4> *textureDataSource = &_cachedTextureData;
 
   if (!useCompaction) {
     remapUpload.resize(totalPrimitiveCount);
@@ -2451,7 +2488,8 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     compactTriangleIndices.clear();
     compactActiveMask.clear();
 
-    compactPrimitiveData.reserve(_activePrimitiveCount * 3);
+    compactPrimitiveData.reserve(_activePrimitiveCount *
+                                 kPrimitiveFloat4Count);
     compactMaterialData.reserve(_activePrimitiveCount * kMaterialFloat4Count);
     compactPrimitiveIndices.reserve(_activePrimitiveCount);
     compactActiveMask.reserve(_activePrimitiveCount);
@@ -2514,6 +2552,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
           simd::float4 prim0;
           simd::float4 prim1;
           simd::float4 prim2;
+          simd::float4 prim3 = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
           switch (p.type) {
           case PrimitiveType::Sphere: {
             prim0 =
@@ -2533,8 +2572,10 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
           case PrimitiveType::Triangle: {
             prim0 =
                 simd::make_float4(p.triangle.v0, static_cast<float>(p.type));
-            prim1 = simd::make_float4(p.triangle.v1, 0.0f);
-            prim2 = simd::make_float4(p.triangle.v2, 0.0f);
+            prim1 = simd::make_float4(p.triangle.v1, p.triangle.uv0.x);
+            prim2 = simd::make_float4(p.triangle.v2, p.triangle.uv0.y);
+            prim3 = simd::make_float4(p.triangle.uv1.x, p.triangle.uv1.y,
+                                      p.triangle.uv2.x, p.triangle.uv2.y);
             size_t baseVertex = compactTriangleVertices.size();
             compactTriangleVertices.push_back(p.triangle.v0);
             compactTriangleVertices.push_back(p.triangle.v1);
@@ -2550,6 +2591,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
           compactPrimitiveData.push_back(prim0);
           compactPrimitiveData.push_back(prim1);
           compactPrimitiveData.push_back(prim2);
+          compactPrimitiveData.push_back(prim3);
 
           const Material &m = p.material;
           auto packedMaterial = encodeMaterial(m);
@@ -2727,6 +2769,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         simd::float4 prim0;
         simd::float4 prim1;
         simd::float4 prim2;
+        simd::float4 prim3 = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
         switch (p.type) {
         case PrimitiveType::Sphere: {
           prim0 = simd::make_float4(p.sphere.center, static_cast<float>(p.type));
@@ -2743,8 +2786,10 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         }
         case PrimitiveType::Triangle: {
           prim0 = simd::make_float4(p.triangle.v0, static_cast<float>(p.type));
-          prim1 = simd::make_float4(p.triangle.v1, 0.0f);
-          prim2 = simd::make_float4(p.triangle.v2, 0.0f);
+          prim1 = simd::make_float4(p.triangle.v1, p.triangle.uv0.x);
+          prim2 = simd::make_float4(p.triangle.v2, p.triangle.uv0.y);
+          prim3 = simd::make_float4(p.triangle.uv1.x, p.triangle.uv1.y,
+                                    p.triangle.uv2.x, p.triangle.uv2.y);
           size_t baseVertex = compactTriangleVertices.size();
           compactTriangleVertices.push_back(p.triangle.v0);
           compactTriangleVertices.push_back(p.triangle.v1);
@@ -2760,6 +2805,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         compactPrimitiveData.push_back(prim0);
         compactPrimitiveData.push_back(prim1);
         compactPrimitiveData.push_back(prim2);
+        compactPrimitiveData.push_back(prim3);
 
         const Material &m = p.material;
         auto packedMaterial = encodeMaterial(m);
@@ -3063,6 +3109,44 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         dst[0] = simd::make_uint3(0, 0, 0);
       markBufferModified(_pTriangleIndexBuffer,
                          NS::Range::Make(0, indexBytes));
+    }
+
+    size_t textureInfoCount = std::max<size_t>(textureInfoSource->size(),
+                                               size_t(1));
+    size_t textureInfoBytes = textureInfoCount * sizeof(TextureInfo);
+    ensureBufferCapacity(_pTextureInfoBuffer, textureInfoBytes,
+                         _textureInfoBufferCapacity, allowShrink);
+    if (_pTextureInfoBuffer) {
+      auto *dst = static_cast<TextureInfo *>(_pTextureInfoBuffer->contents());
+      if (textureInfoSource->empty()) {
+        dst[0] = TextureInfo{};
+      } else {
+        std::memcpy(dst, textureInfoSource->data(),
+                    textureInfoSource->size() * sizeof(TextureInfo));
+        if (textureInfoSource->size() < textureInfoCount)
+          dst[textureInfoSource->size()] = TextureInfo{};
+      }
+      markBufferModified(_pTextureInfoBuffer,
+                         NS::Range::Make(0, textureInfoBytes));
+    }
+
+    size_t textureDataCount = std::max<size_t>(textureDataSource->size(),
+                                               size_t(1));
+    size_t textureDataBytes = textureDataCount * sizeof(simd::float4);
+    ensureBufferCapacity(_pTextureDataBuffer, textureDataBytes,
+                         _textureDataBufferCapacity, allowShrink);
+    if (_pTextureDataBuffer) {
+      auto *dst = static_cast<simd::float4 *>(_pTextureDataBuffer->contents());
+      if (textureDataSource->empty()) {
+        dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 1.0f};
+      } else {
+        std::memcpy(dst, textureDataSource->data(),
+                    textureDataSource->size() * sizeof(simd::float4));
+        if (textureDataSource->size() < textureDataCount)
+          dst[textureDataSource->size()] = simd::float4{0.0f, 0.0f, 0.0f, 1.0f};
+      }
+      markBufferModified(_pTextureDataBuffer,
+                         NS::Range::Make(0, textureDataBytes));
     }
 
     _residentBuffersInitialized = true;
@@ -3662,6 +3746,7 @@ void Renderer::updateUniforms(bool cameraChanged) {
   u.sampleImportanceTextureIndex = 3;
   u.minSamplesPerPixel = minSamples;
   u.maxSamplesPerPixel = maxSamples;
+  u.textureCount = static_cast<uint32_t>(_cachedTextureInfos.size());
 
   uint64_t residentPrimitiveCount = _residentPrimitiveCount;
   uint64_t residentTriangleCount = _residentTriangleCount;
@@ -3811,6 +3896,8 @@ void Renderer::draw(MTK::View *pView) {
         pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 8);
         pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 9);
         pCompute->setBuffer(_pInstanceBuffer, 0, 10);
+        pCompute->setBuffer(_pTextureInfoBuffer, 0, 14);
+        pCompute->setBuffer(_pTextureDataBuffer, 0, 15);
       } else {
         pCompute->setBuffer(_pBVHBuffer, 0, 0);
         pCompute->setBuffer(_pSphereBuffer, 0, 1);
@@ -3826,6 +3913,8 @@ void Renderer::draw(MTK::View *pView) {
         pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
         pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
         pCompute->setBuffer(_pInstanceBuffer, 0, 13);
+        pCompute->setBuffer(_pTextureInfoBuffer, 0, 14);
+        pCompute->setBuffer(_pTextureDataBuffer, 0, 15);
       }
       pCompute->setTexture(accum0, 0);
       pCompute->setTexture(accum1, 1);

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -37,6 +37,13 @@ struct GeometryHandle {
   uint32_t padding = 0;
 };
 
+struct TextureInfo {
+  uint32_t offset = 0;
+  uint32_t width = 0;
+  uint32_t height = 0;
+  uint32_t flags = 0;
+};
+
 class Renderer;
 
 struct ResidentObjectGpuResources {
@@ -193,6 +200,8 @@ private:
   MTL::Buffer *_pTlasInstanceDescriptorBuffer = nullptr;
   MTL::Buffer *_pGeometryHandleBuffer = nullptr;
   MTL::Buffer *_pFrustumVertexBuffer = nullptr;
+  MTL::Buffer *_pTextureInfoBuffer = nullptr;
+  MTL::Buffer *_pTextureDataBuffer = nullptr;
   size_t _blasNodeCount = 0;
   size_t _tlasNodeCount = 0;
   size_t _activeNodeCount = 0;
@@ -322,6 +331,8 @@ private:
   std::vector<simd::float4> _cachedTLASNodes;
   std::vector<simd::float3> _cachedTriangleVertices;
   std::vector<simd::uint3> _cachedTriangleIndices;
+  std::vector<TextureInfo> _cachedTextureInfos;
+  std::vector<simd::float4> _cachedTextureData;
   std::vector<uint32_t> _cachedLightIndices;
   std::vector<float> _cachedLightCdf;
 
@@ -335,6 +346,8 @@ private:
   size_t _sphereMaterialBufferCapacity = 0;
   size_t _triangleVertexBufferCapacity = 0;
   size_t _triangleIndexBufferCapacity = 0;
+  size_t _textureInfoBufferCapacity = 0;
+  size_t _textureDataBufferCapacity = 0;
   size_t _bvhBufferCapacity = 0;
   size_t _tlasBufferCapacity = 0;
   size_t _primitiveIndexBufferCapacity = 0;

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -19,6 +19,8 @@ kernel void pathTraceKernel(
     device const uint *primitiveRemap [[buffer(11)]],
     device atomic_uint *primitiveHitCounts [[buffer(12)]],
     device const InstanceRecord *instanceRecords [[buffer(13)]],
+    device const PackedTexture *textureInfos [[buffer(14)]],
+    device const float4 *textureData [[buffer(15)]],
     texture2d<half, access::read> lastFrame [[texture(0)]],
     texture2d<half, access::write> currentFrame [[texture(1)]],
     texture2d<half, access::read_write> sampleCount [[texture(2)]],
@@ -82,7 +84,8 @@ kernel void pathTraceKernel(
                                  activeMask, instanceRecords, lightIndices, lightCdf,
                                  primitiveRemap, primitiveHitCounts, seed, u.maxRayDepth,
                                  u.debugAS, u.blasNodeCount, u.lightCount,
-                                 u.lightTotalWeight, static_cast<uint>(u.totalPrimitiveCount));
+                                 u.lightTotalWeight, static_cast<uint>(u.totalPrimitiveCount),
+                                 textureInfos, textureData, u.textureCount);
   }
 
   float totalSamples = previousSampleCount + float(samplesThisFrame);

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -9,6 +9,7 @@
 using namespace metal;
 
 constant uint kMaterialFloat4Count = 5;
+constant uint kPrimitiveFloat4Count = 4;
 
 struct Ray {
   float3 origin;
@@ -82,6 +83,44 @@ inline MaterialPayload decodeMaterial(int baseIndex,
   }
 
   return payload;
+}
+
+inline float4 samplePackedTexture(int index, float2 uv,
+                                  device const PackedTexture *textures,
+                                  device const float4 *textureData,
+                                  uint textureCount) {
+  if (index < 0 || textures == nullptr || textureData == nullptr)
+    return float4(1.0f);
+  uint texIndex = uint(index);
+  if (texIndex >= textureCount)
+    return float4(1.0f);
+
+  PackedTexture tex = textures[texIndex];
+  if (tex.width == 0 || tex.height == 0)
+    return float4(1.0f);
+
+  float2 coord = float2(uv.x - floor(uv.x), uv.y - floor(uv.y));
+  float sx = coord.x * (float(tex.width) - 1.0f);
+  float sy = coord.y * (float(tex.height) - 1.0f);
+  int x0 = clamp(int(floor(sx)), 0, int(tex.width - 1));
+  int y0 = clamp(int(floor(sy)), 0, int(tex.height - 1));
+  int x1 = min(x0 + 1, int(tex.width - 1));
+  int y1 = min(y0 + 1, int(tex.height - 1));
+  float fx = sx - float(x0);
+  float fy = sy - float(y0);
+
+  auto texelAt = [&](int x, int y) -> float4 {
+    uint offset = tex.offset + uint(y) * tex.width + uint(x);
+    return textureData[offset];
+  };
+
+  float4 c00 = texelAt(x0, y0);
+  float4 c10 = texelAt(x1, y0);
+  float4 c01 = texelAt(x0, y1);
+  float4 c11 = texelAt(x1, y1);
+  float4 c0 = mix(c00, c10, fx);
+  float4 c1 = mix(c01, c11, fx);
+  return mix(c0, c1, fy);
 }
 
 inline uint selectLightOffset(float xi, device const float *lightCdf,
@@ -195,6 +234,8 @@ inline intersection firstHitBVH(thread const Ray &r,
   in.primitiveId = -1;
   in.isTriangle = 0;
   in.nodeIndex = -1;
+  in.uv = float2(0.0f);
+  in.barycentric = float2(0.0f);
 
   constexpr int stackSize = 64;
   int stack[stackSize];
@@ -220,16 +261,20 @@ inline intersection firstHitBVH(thread const Ray &r,
         int primIdx = primitiveIndices[leftFirst + i];
         if (!activeMask[primIdx])
           continue;
-        int base = primIdx * 3;
+        int base = primIdx * int(kPrimitiveFloat4Count);
         float4 p0 = primitives[base + 0];
         float4 p1 = primitives[base + 1];
         float4 p2 = primitives[base + 2];
+        float4 p3 = primitives[base + 3];
 
         int primitiveType = int(p0.w);
         float tHit = INFINITY;
         float3 n = float3(0);
         float3 hit = float3(0);
         bool hitThis = false;
+
+        float2 localUV = float2(0.0f);
+        float2 bary = float2(0.0f);
 
         if (primitiveType == 0) {
           float3 center = p0.xyz;
@@ -274,6 +319,7 @@ inline intersection firstHitBVH(thread const Ray &r,
                   n = normalize(cross(edge1, edge2));
                   hitThis = true;
                   in.isTriangle = 1;
+                  bary = float2(u, v);
                 }
               }
             }
@@ -296,6 +342,7 @@ inline intersection firstHitBVH(thread const Ray &r,
                 hit = hitPoint;
                 n = normal;
                 hitThis = true;
+                localUV = float2(0.5f * (u + 1.0f), 0.5f * (v + 1.0f));
               }
             }
           }
@@ -308,6 +355,8 @@ inline intersection firstHitBVH(thread const Ray &r,
           in.point = hit;
           in.isTriangle = primitiveType;
           in.nodeIndex = nodeIdx;
+          in.barycentric = bary;
+          in.uv = localUV;
         }
       }
     } else {
@@ -434,7 +483,10 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
                        device atomic_uint *primitiveHitCounts,
                        thread uint32_t &seed, uint maxRayDepth,
                        uint debugAS, uint blasNodeCount, uint lightCount,
-                       float lightTotalWeight, uint totalPrimitiveCount) {
+                       float lightTotalWeight, uint totalPrimitiveCount,
+                       device const PackedTexture *textures,
+                       device const float4 *textureData,
+                       uint textureCount) {
   float footprint = length(cross(rayDx, rayDy));
   float lodAtten = 1.0 / (1.0 + footprint);
   if (debugAS == 1) {
@@ -491,6 +543,55 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
 
     MaterialPayload material = decodeMaterial(matBase, materials, lodAtten);
 
+    float2 surfaceUV = float2(0.0f);
+    bool haveUV = false;
+    int primBase = bestHit.primitiveId * int(kPrimitiveFloat4Count);
+    int primEntries = int(primitiveCount) * int(kPrimitiveFloat4Count);
+    if (primBase + int(kPrimitiveFloat4Count) <= primEntries && primBase >= 0) {
+      float4 gp0 = primitives[primBase + 0];
+      float4 gp1 = primitives[primBase + 1];
+      float4 gp2 = primitives[primBase + 2];
+      float4 gp3 = primitives[primBase + 3];
+      int primitiveType = int(gp0.w);
+      if (primitiveType == 1) {
+        float2 uv0 = float2(gp1.w, gp2.w);
+        float2 uv1 = gp3.xy;
+        float2 uv2 = gp3.zw;
+        float2 bary = bestHit.barycentric;
+        float w = 1.0f - bary.x - bary.y;
+        surfaceUV = uv0 * w + uv1 * bary.x + uv2 * bary.y;
+        haveUV = true;
+      } else if (primitiveType == 2) {
+        surfaceUV = bestHit.uv;
+        haveUV = true;
+      } else if (primitiveType == 0) {
+        float3 center = gp0.xyz;
+        float3 dir = normalize(bestHit.point - center);
+        if (all(isfinite(dir))) {
+          float u = 0.5f + atan2(dir.z, dir.x) / (2.0f * M_PI);
+          float v = 0.5f - asin(clamp(dir.y, -1.0f, 1.0f)) / M_PI;
+          surfaceUV = float2(u, v);
+          haveUV = true;
+        }
+      }
+    }
+
+    if (haveUV) {
+      if (material.diffuseTextureIndex >= 0) {
+        float4 sample = samplePackedTexture(material.diffuseTextureIndex,
+                                            surfaceUV, textures, textureData,
+                                            textureCount);
+        material.diffuseColor *= sample.xyz;
+        material.opacity *= clamp(sample.w, 0.0f, 1.0f);
+      }
+      if (material.specularTextureIndex >= 0) {
+        float4 sample = samplePackedTexture(material.specularTextureIndex,
+                                            surfaceUV, textures, textureData,
+                                            textureCount);
+        material.specularColor *= sample.xyz;
+      }
+    }
+
     float emissionStrength = material.emissionPower *
                              luminance(material.emissionColor);
     if (emissionStrength > 0.0f) {
@@ -510,7 +611,7 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
       if (selectedOffset < lightCount) {
         uint lightPrimIndex = lightIndices[selectedOffset];
         if (int(lightPrimIndex) != bestHit.primitiveId) {
-          int base = int(lightPrimIndex) * 3;
+          int base = int(lightPrimIndex) * int(kPrimitiveFloat4Count);
           float4 lp0 = primitives[base + 0];
           float4 lp1 = primitives[base + 1];
           float4 lp2 = primitives[base + 2];

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -20,6 +20,8 @@ struct intersection
     int primitiveId = -1;
     int isTriangle = 0;
     int nodeIndex = -1; // BLAS leaf node index
+    float2 uv = float2(0.0f);
+    float2 barycentric = float2(0.0f);
 };
 
 struct InstanceRecord
@@ -71,6 +73,15 @@ struct UniformsData
     uint sampleImportanceTextureIndex;
     uint minSamplesPerPixel;
     uint maxSamplesPerPixel;
+    uint textureCount;
+};
+
+struct PackedTexture
+{
+    uint offset;
+    uint width;
+    uint height;
+    uint flags;
 };
 
 

--- a/MetalCpp Path Tracer/Scene/Primitive.h
+++ b/MetalCpp Path Tracer/Scene/Primitive.h
@@ -8,6 +8,8 @@
 
 namespace MetalCppPathTracer {
 
+inline constexpr size_t kPrimitiveFloat4Count = 4;
+
 enum class PrimitiveType {
     Sphere = 0,
     Triangle = 1,

--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <limits>
 #include <numeric>
+#include <utility>
 #include <vector>
 
 namespace MetalCppPathTracer {
@@ -20,6 +21,9 @@ void Scene::clear() {
   objects.clear();
   objectIndices.clear();
   tlasNodes.clear();
+  textures.clear();
+  texturePaths.clear();
+  textureLookup.clear();
   cameraPath.clear();
   screenSize = {1280.f, 720.f};
   maxRayDepth = 32;
@@ -112,6 +116,24 @@ const std::vector<size_t> &Scene::getPrimitiveIndices() const {
 }
 
 const std::vector<SceneObject> &Scene::getObjects() const { return objects; }
+
+const std::vector<Texture> &Scene::getTextures() const { return textures; }
+
+const std::vector<std::string> &Scene::getTexturePaths() const {
+  return texturePaths;
+}
+
+int Scene::registerTexture(const std::string &path, Texture texture) {
+  auto it = textureLookup.find(path);
+  if (it != textureLookup.end())
+    return it->second;
+
+  int index = static_cast<int>(textures.size());
+  textures.push_back(std::move(texture));
+  texturePaths.push_back(path);
+  textureLookup.emplace(path, index);
+  return index;
+}
 
 ResidencyStrategy Scene::getResidencyStrategy() const {
   return residencyStrategy;
@@ -220,25 +242,31 @@ size_t Scene::getBVHNodeCount() const { return bvhNodes.size(); }
 const std::vector<BVHNode> &Scene::getBVHNodes() const { return bvhNodes; }
 
 simd::float4 *Scene::createTransformsBuffer() const {
-  simd::float4 *buffer = new simd::float4[primitives.size() * 3];
+  simd::float4 *buffer =
+      new simd::float4[kPrimitiveFloat4Count * primitives.size()];
   for (size_t i = 0; i < primitives.size(); ++i) {
     const auto &p = primitives[i];
+    size_t base = kPrimitiveFloat4Count * i;
     if (p.type == PrimitiveType::Sphere) {
-      buffer[3 * i + 0] =
+      buffer[base + 0] =
           simd::make_float4(p.sphere.center, static_cast<float>(p.type));
-      buffer[3 * i + 1] =
+      buffer[base + 1] =
           simd::make_float4(simd::make_float3(p.sphere.radius, 0, 0), 0);
-      buffer[3 * i + 2] = simd::make_float4(simd::float3(0), 0);
+      buffer[base + 2] = simd::make_float4(simd::float3(0), 0);
+      buffer[base + 3] = simd::make_float4(simd::float3(0), 0);
     } else if (p.type == PrimitiveType::Rectangle) {
-      buffer[3 * i + 0] =
+      buffer[base + 0] =
           simd::make_float4(p.rectangle.center, static_cast<float>(p.type));
-      buffer[3 * i + 1] = simd::make_float4(p.rectangle.u, 0);
-      buffer[3 * i + 2] = simd::make_float4(p.rectangle.v, 0);
+      buffer[base + 1] = simd::make_float4(p.rectangle.u, 0);
+      buffer[base + 2] = simd::make_float4(p.rectangle.v, 0);
+      buffer[base + 3] = simd::make_float4(simd::float3(0), 0);
     } else {
-      buffer[3 * i + 0] =
+      buffer[base + 0] =
           simd::make_float4(p.triangle.v0, static_cast<float>(p.type));
-      buffer[3 * i + 1] = simd::make_float4(p.triangle.v1, 0);
-      buffer[3 * i + 2] = simd::make_float4(p.triangle.v2, 0);
+      buffer[base + 1] = simd::make_float4(p.triangle.v1, p.triangle.uv0.x);
+      buffer[base + 2] = simd::make_float4(p.triangle.v2, p.triangle.uv0.y);
+      buffer[base + 3] = simd::make_float4(p.triangle.uv1.x, p.triangle.uv1.y,
+                                           p.triangle.uv2.x, p.triangle.uv2.y);
     }
   }
   return buffer;

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -5,6 +5,8 @@
 #include "Primitive.h"
 #include <cstdint>
 #include <simd/simd.h>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace MetalCppPathTracer {
@@ -71,6 +73,12 @@ struct ObserverCamera {
   float verticalFov = 60.0f;
 };
 
+struct Texture {
+  uint32_t width = 0;
+  uint32_t height = 0;
+  std::vector<float> pixels; // RGBA
+};
+
 class Scene {
 public:
   Scene();
@@ -90,6 +98,10 @@ public:
   const std::vector<Primitive> &getPrimitives() const;
   const std::vector<size_t> &getPrimitiveIndices() const;
   const std::vector<SceneObject> &getObjects() const;
+
+  const std::vector<Texture> &getTextures() const;
+  const std::vector<std::string> &getTexturePaths() const;
+  int registerTexture(const std::string &path, Texture texture);
 
   ResidencyStrategy getResidencyStrategy() const;
   void setResidencyStrategy(ResidencyStrategy strategy);
@@ -140,6 +152,9 @@ private:
   std::vector<SceneObject> objects;
   std::vector<size_t> objectIndices;
   std::vector<TLASNode> tlasNodes;
+  std::vector<Texture> textures;
+  std::vector<std::string> texturePaths;
+  std::unordered_map<std::string, int> textureLookup;
   ResidencyStrategy residencyStrategy;
   ResidencyParameters residencyParams;
   bool startCompacted;

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -4,6 +4,7 @@
 #include <simd/simd.h>
 #include <simd/quaternion.h>
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <cstdio>
 #include <fstream>
@@ -16,6 +17,7 @@
 #include <limits>
 #include <cmath>
 #include "tiny_obj_loader.h"
+#include "TextureLoader.h"
 
 using namespace tinyxml2;
 
@@ -77,7 +79,53 @@ static float computeRoughness(float shininess, float explicitRoughness) {
     return clamp01(converted);
 }
 
-static Material ConvertTinyMaterial(const tinyobj::material_t& src) {
+using TextureCache = std::unordered_map<std::string, int>;
+
+TextureCache& GetTextureCache() {
+    static TextureCache cache;
+    return cache;
+}
+
+static int ResolveTextureIndex(const std::string& texName,
+                               const std::string& baseDir,
+                               Scene* scene,
+                               TextureCache& cache) {
+    if (!scene || texName.empty()) {
+        return -1;
+    }
+
+    std::filesystem::path resolved(texName);
+    if (resolved.is_relative()) {
+        resolved = std::filesystem::path(baseDir) / resolved;
+    }
+    resolved = resolved.lexically_normal();
+
+    std::string key = resolved.string();
+    auto it = cache.find(key);
+    if (it != cache.end()) {
+        return it->second;
+    }
+
+    LoadedTextureImage image;
+    if (!LoadTextureImage(key, image)) {
+        cache.emplace(key, -1);
+        return -1;
+    }
+
+    Texture texture;
+    texture.width = static_cast<uint32_t>(image.width);
+    texture.height = static_cast<uint32_t>(image.height);
+    texture.pixels = std::move(image.pixels);
+
+    int index = scene->registerTexture(key, std::move(texture));
+    cache.emplace(key, index);
+    return index;
+}
+
+static Material ConvertTinyMaterial(const tinyobj::material_t& src,
+                                    Scene* scene,
+                                    TextureCache& textureCache,
+                                    const std::string& baseDir) {
     Material material{};
     material.diffuseColor = toFloat3(src.diffuse);
     material.specularColor = toFloat3(src.specular);
@@ -98,6 +146,18 @@ static Material ConvertTinyMaterial(const tinyobj::material_t& src) {
         float trans = 1.0f - material.opacity;
         material.transmissionColor = simd::make_float3(trans, trans, trans);
     }
+
+    material.diffuseTextureIndex = ResolveTextureIndex(src.diffuse_texname,
+                                                       baseDir, scene,
+                                                       textureCache);
+    material.specularTextureIndex = ResolveTextureIndex(src.specular_texname,
+                                                        baseDir, scene,
+                                                        textureCache);
+    std::string normalTex = src.normal_texname.empty() ? src.bump_texname
+                                                       : src.normal_texname;
+    material.normalTextureIndex = ResolveTextureIndex(normalTex,
+                                                      baseDir, scene,
+                                                      textureCache);
 
     return material;
 }
@@ -320,6 +380,7 @@ struct CachedMesh {
     std::vector<simd::uint3> indices;
     std::vector<int> faceMaterialIndices;
     std::vector<Material> materials;
+    std::vector<std::array<simd::float2, 3>> triangleUVs;
 };
 
 using MeshCache = std::unordered_map<std::string, CachedMesh>;
@@ -329,7 +390,7 @@ MeshCache& GetMeshCache() {
     return cache;
 }
 
-static void LoadOBJ(const std::string& path, CachedMesh& mesh) {
+static void LoadOBJ(const std::string& path, CachedMesh& mesh, Scene* scene) {
     tinyobj::attrib_t attrib;
     std::vector<tinyobj::shape_t> shapes;
     std::vector<tinyobj::material_t> objMaterials;
@@ -363,6 +424,7 @@ static void LoadOBJ(const std::string& path, CachedMesh& mesh) {
     mesh.indices.clear();
     mesh.faceMaterialIndices.clear();
     mesh.materials.clear();
+    mesh.triangleUVs.clear();
 
     mesh.vertices.reserve(attrib.vertices.size() / 3);
     for (size_t v = 0; v < attrib.vertices.size(); v += 3) {
@@ -374,8 +436,10 @@ static void LoadOBJ(const std::string& path, CachedMesh& mesh) {
     }
 
     mesh.materials.reserve(objMaterials.size());
+    TextureCache& textureCache = GetTextureCache();
     for (const auto& srcMat : objMaterials) {
-        mesh.materials.push_back(ConvertTinyMaterial(srcMat));
+        mesh.materials.push_back(
+            ConvertTinyMaterial(srcMat, scene, textureCache, mtlSearchPath));
     }
 
     for (const auto& shape : shapes) {
@@ -400,6 +464,27 @@ static void LoadOBJ(const std::string& path, CachedMesh& mesh) {
 
             mesh.indices.push_back(simd::make_uint3(idx0, idx1, idx2));
 
+            auto getTexcoord = [&](int texIndex) {
+                if (texIndex >= 0 &&
+                    static_cast<size_t>(texIndex * 2 + 1) < attrib.texcoords.size()) {
+                    return simd::make_float2(
+                        static_cast<float>(attrib.texcoords[texIndex * 2 + 0]),
+                        static_cast<float>(attrib.texcoords[texIndex * 2 + 1]));
+                }
+                return simd::make_float2(0.0f, 0.0f);
+            };
+
+            int t0 = shape.mesh.indices[indexOffset + 0].texcoord_index;
+            int t1 = shape.mesh.indices[indexOffset + 1].texcoord_index;
+            int t2 = shape.mesh.indices[indexOffset + 2].texcoord_index;
+
+            std::array<simd::float2, 3> uvs = {
+                getTexcoord(t0),
+                getTexcoord(t1),
+                getTexcoord(t2)
+            };
+            mesh.triangleUVs.push_back(uvs);
+
             int materialId = -1;
             if (f < shape.mesh.material_ids.size()) {
                 materialId = shape.mesh.material_ids[f];
@@ -422,6 +507,7 @@ static void LoadOBJ(const std::string& path, CachedMesh& mesh) {
 
 void SceneLoader::ClearCache() {
     GetMeshCache().clear();
+    GetTextureCache().clear();
 }
 
 bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
@@ -568,7 +654,7 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             if (it == cache.end()) {
                 // First time encountering this mesh path in the current load.
                 CachedMesh entry;
-                LoadOBJ(normalizedPath, entry);
+                LoadOBJ(normalizedPath, entry, scene);
                 it = cache.emplace(normalizedPath, std::move(entry)).first;
             }
 
@@ -623,6 +709,13 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
                 p.triangle.v0 = transformVertex(meshData.vertices[tri.x]);
                 p.triangle.v1 = transformVertex(meshData.vertices[tri.y]);
                 p.triangle.v2 = transformVertex(meshData.vertices[tri.z]);
+
+                if (triIndex < meshData.triangleUVs.size()) {
+                    const auto& triUVs = meshData.triangleUVs[triIndex];
+                    p.triangle.uv0 = triUVs[0];
+                    p.triangle.uv1 = triUVs[1];
+                    p.triangle.uv2 = triUVs[2];
+                }
 
                 const Material* chosenMaterial = &overrideMaterial;
                 if (triIndex < meshData.faceMaterialIndices.size()) {

--- a/MetalCpp Path Tracer/Scene/TextureLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/TextureLoader.cpp
@@ -1,0 +1,93 @@
+#include "TextureLoader.h"
+
+#include <CoreGraphics/CoreGraphics.h>
+#include <ImageIO/ImageIO.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <cstdio>
+#include <vector>
+
+namespace MetalCppPathTracer {
+
+namespace {
+
+CFURLRef CreateFileURL(const std::string &path) {
+    return CFURLCreateFromFileSystemRepresentation(
+        nullptr, reinterpret_cast<const UInt8 *>(path.c_str()), path.size(), false);
+}
+
+} // namespace
+
+bool LoadTextureImage(const std::string &path, LoadedTextureImage &outImage) {
+    CFURLRef url = CreateFileURL(path);
+    if (!url) {
+        std::printf("Failed to create URL for texture '%s'\n", path.c_str());
+        return false;
+    }
+
+    CGImageSourceRef source = CGImageSourceCreateWithURL(url, nullptr);
+    if (!source) {
+        std::printf("Failed to create image source for texture '%s'\n", path.c_str());
+        CFRelease(url);
+        return false;
+    }
+
+    CGImageRef image = CGImageSourceCreateImageAtIndex(source, 0, nullptr);
+    if (!image) {
+        std::printf("Failed to decode texture '%s'\n", path.c_str());
+        CFRelease(source);
+        CFRelease(url);
+        return false;
+    }
+
+    size_t width = CGImageGetWidth(image);
+    size_t height = CGImageGetHeight(image);
+    if (width == 0 || height == 0) {
+        std::printf("Texture '%s' has zero size\n", path.c_str());
+        CGImageRelease(image);
+        CFRelease(source);
+        CFRelease(url);
+        return false;
+    }
+
+    std::vector<uint8_t> rawData(width * height * 4);
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    CGContextRef context = CGBitmapContextCreate(
+        rawData.data(), width, height, 8, width * 4, colorSpace,
+        kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
+
+    if (!context) {
+        std::printf("Failed to create bitmap context for texture '%s'\n", path.c_str());
+        CGColorSpaceRelease(colorSpace);
+        CGImageRelease(image);
+        CFRelease(source);
+        CFRelease(url);
+        return false;
+    }
+
+    CGRect rect = CGRectMake(0, 0, static_cast<double>(width),
+                             static_cast<double>(height));
+    CGContextDrawImage(context, rect, image);
+
+    CGColorSpaceRelease(colorSpace);
+    CGContextRelease(context);
+    CGImageRelease(image);
+    CFRelease(source);
+    CFRelease(url);
+
+    outImage.width = static_cast<int>(width);
+    outImage.height = static_cast<int>(height);
+    outImage.pixels.resize(width * height * 4);
+
+    const float inv255 = 1.0f / 255.0f;
+    for (size_t i = 0; i < width * height; ++i) {
+        outImage.pixels[4 * i + 0] = rawData[4 * i + 0] * inv255;
+        outImage.pixels[4 * i + 1] = rawData[4 * i + 1] * inv255;
+        outImage.pixels[4 * i + 2] = rawData[4 * i + 2] * inv255;
+        outImage.pixels[4 * i + 3] = rawData[4 * i + 3] * inv255;
+    }
+
+    return true;
+}
+
+} // namespace MetalCppPathTracer

--- a/MetalCpp Path Tracer/Scene/TextureLoader.h
+++ b/MetalCpp Path Tracer/Scene/TextureLoader.h
@@ -1,0 +1,19 @@
+#ifndef TEXTURE_LOADER_H
+#define TEXTURE_LOADER_H
+
+#include <string>
+#include <vector>
+
+namespace MetalCppPathTracer {
+
+struct LoadedTextureImage {
+    int width = 0;
+    int height = 0;
+    std::vector<float> pixels; // RGBA, linear [0,1]
+};
+
+bool LoadTextureImage(const std::string &path, LoadedTextureImage &outImage);
+
+} // namespace MetalCppPathTracer
+
+#endif

--- a/MetalCpp Path Tracer/Scene/Triangle.h
+++ b/MetalCpp Path Tracer/Scene/Triangle.h
@@ -9,6 +9,9 @@ struct Triangle {
     simd::float3 v0;
     simd::float3 v1;
     simd::float3 v2;
+    simd::float2 uv0 = simd::make_float2(0.0f, 0.0f);
+    simd::float2 uv1 = simd::make_float2(0.0f, 0.0f);
+    simd::float2 uv2 = simd::make_float2(0.0f, 0.0f);
 };
 
 }


### PR DESCRIPTION
## Summary
- load texture images via Core Graphics and store textures in the scene for GPU upload
- propagate UV coordinates and texture indices from OBJ/MTL loading through geometry buffers
- bind textures in the renderer and add shader sampling for textured materials

## Testing
- not run (renderer changes require manual validation)

------
https://chatgpt.com/codex/tasks/task_e_68ef66a75d80832d97a90dce92eb218e