### PR TITLE
Adjust Sponza observer camera

### DIFF
--- a/MetalCpp Path Tracer/scene_sponza_flythrough.xml
+++ b/MetalCpp Path Tracer/scene_sponza_flythrough.xml
@@ -2,7 +2,7 @@
 <Scene width="960" height="540" maxRayDepth="4" startCompacted="true"
        residencyStrategy="none" textureResidencyMemoryCapMB="2048"
        lodEnterDistance="35" lodExitDistance="55" residencyCooldown="1" lodToggleBudget="12000">
-    <ObserverCamera position="0,22,22" lookAt="0,6,0" verticalFov="38" />
+    <ObserverCamera position="0,5.0,12.0" lookAt="0,5.5,2.0" verticalFov="38" />
 
     <CameraPath>
         <!-- Slow walkthrough weaving through the Sponza atrium -->


### PR DESCRIPTION
## Summary
- move the observer camera inside the Sponza atrium so the interior details are visible when the scene loads

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ef72ca7768832da89534d5f3c04580