### PR TITLE
Add standalone glass bunny scene

### DIFF
--- a/MetalCpp Path Tracer/scene_glass_bunny.xml
+++ b/MetalCpp Path Tracer/scene_glass_bunny.xml
@@ -1,0 +1,30 @@
+<Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="alwaysresident" textureResidencyMemoryCapMB="256"
+       lodEnterDistance="50" lodExitDistance="75" residencyCooldown="1" lodToggleBudget="10000">
+    <CameraPath>
+        <Keyframe frame="0" position="0,3,6" lookAt="0,1.5,0" />
+        <Keyframe frame="60" position="0,3,6" lookAt="0,1.5,0" />
+    </CameraPath>
+
+    <!-- Simple Cornell-box inspired room to showcase the glass bunny -->
+    <Rectangle position="0,0,0" u="4,0,0" v="0,0,-4" albedo="0.74,0.74,0.76"
+               emission="0,0,0" materialType="0" emissionPower="0" />
+    <Rectangle position="0,4,0" u="4,0,0" v="0,0,-4" rotation="180,0,0" albedo="0.78,0.78,0.8"
+               emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <Rectangle position="0,2,2" u="4,0,0" v="0,4,0" rotation="0,0,0" albedo="0.8,0.8,0.83"
+               emission="0,0,0" materialType="0" emissionPower="0" />
+    <Rectangle position="0,2,-2" u="4,0,0" v="0,4,0" rotation="0,180,0" albedo="0.8,0.8,0.83"
+               emission="0,0,0" materialType="0" emissionPower="0" />
+    <Rectangle position="-2,2,0" u="4,0,0" v="0,4,0" rotation="0,90,0" albedo="0.75,0.78,0.82"
+               emission="0,0,0" materialType="0" emissionPower="0" />
+    <Rectangle position="2,2,0" u="4,0,0" v="0,4,0" rotation="0,-90,0" albedo="0.78,0.75,0.72"
+               emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Ceiling light for crisp caustics through the glass bunny -->
+    <Rectangle position="0,3.95,0" u="0.8,0,0" v="0,0,-0.8" rotation="180,0,0"
+               albedo="1,1,1" emission="1.0,0.95,0.9" materialType="-1" emissionPower="40" />
+
+    <!-- Glass bunny centered on the floor -->
+    <Mesh file="assets/bunny.obj" position="0,0,-1" scale="1.0"
+          albedo="0.95,0.97,1.0" emission="0,0,0" materialType="1" emissionPower="0" />
+</Scene>

--- a/MetalCpp Path Tracer/scene_glass_bunny.xml
+++ b/MetalCpp Path Tracer/scene_glass_bunny.xml
@@ -26,5 +26,6 @@
 
     <!-- Glass bunny centered on the floor -->
     <Mesh file="assets/bunny.obj" position="0,0,-1" scale="1.0"
-          albedo="0.95,0.97,1.0" emission="0,0,0" materialType="1" emissionPower="0" />
+          albedo="0.95,0.97,1.0" emission="0,0,0" materialType="1.5"
+          transmission="1,1,1" roughness="0.02" emissionPower="0" />
 </Scene>


### PR DESCRIPTION
## Summary
- add a minimal Cornell-box inspired scene that focuses on a single glass bunny mesh
- include an overhead area light and surrounding walls to highlight refraction and caustics

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ef7c5caee8832d85e1da897b9b745b