### PR TITLE
Remove front wall from glass bunny scene

### DIFF
--- a/MetalCpp Path Tracer/scene_glass_bunny.xml
+++ b/MetalCpp Path Tracer/scene_glass_bunny.xml
@@ -11,8 +11,9 @@
     <Rectangle position="0,4,0" u="4,0,0" v="0,0,-4" rotation="180,0,0" albedo="0.78,0.78,0.8"
                emission="0,0,0" materialType="0" emissionPower="0" />
 
-    <Rectangle position="0,2,2" u="4,0,0" v="0,4,0" rotation="0,0,0" albedo="0.8,0.8,0.83"
-               emission="0,0,0" materialType="0" emissionPower="0" />
+    <!-- Front wall removed to keep the bunny visible from the camera -->
+    <!-- <Rectangle position="0,2,2" u="4,0,0" v="0,4,0" rotation="0,0,0" albedo="0.8,0.8,0.83"
+               emission="0,0,0" materialType="0" emissionPower="0" /> -->
     <Rectangle position="0,2,-2" u="4,0,0" v="0,4,0" rotation="0,180,0" albedo="0.8,0.8,0.83"
                emission="0,0,0" materialType="0" emissionPower="0" />
     <Rectangle position="-2,2,0" u="4,0,0" v="0,4,0" rotation="0,90,0" albedo="0.75,0.78,0.82"


### PR DESCRIPTION
## Summary
- comment out the front wall rectangle in the glass bunny scene so the camera has an unobstructed view

## Testing
- not run (Metal renderer requires macOS GPU environment)

------
https://chatgpt.com/codex/tasks/task_e_68ef7e8e94fc832d9721a2d57a136202