### PR TITLE
Add cinematic casa scene

### DIFF
--- a/MetalCpp Path Tracer/scene_casa_cinematic.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic.xml
@@ -1,0 +1,27 @@
+<Scene width="1280" height="720" maxRayDepth="8" startCompacted="true"
+       residencyStrategy="distance" textureResidencyMemoryCapMB="256"
+       lodEnterDistance="60" lodExitDistance="90" residencyCooldown="1" lodToggleBudget="12000">
+    <ObserverCamera position="0,22,28" lookAt="0,4,0" verticalFov="45" />
+
+    <CameraPath>
+        <Keyframe frame="0" position="12,4,16" lookAt="0,3,0" />
+        <Keyframe frame="80" position="8,3,6" lookAt="0,3,0" />
+        <Keyframe frame="160" position="-6,4,6" lookAt="0,3,0" />
+        <Keyframe frame="240" position="-12,5,-6" lookAt="0,3,0" />
+        <Keyframe frame="320" position="6,3,-12" lookAt="0,3,0" />
+        <Keyframe frame="400" position="10,4,14" lookAt="0,3,0" />
+    </CameraPath>
+
+    <Sphere position="0,-1000,0" radius="1000" albedo="0.75,0.78,0.82"
+            emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <Rectangle position="0,0,0" u="20,0,0" v="0,0,-20" albedo="0.32,0.31,0.3"
+               emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <Rectangle position="0,12,0" u="6,0,0" v="0,0,6" rotation="180,0,0"
+               albedo="1,1,1" emission="1,0.96,0.9" materialType="-1" emissionPower="25" />
+
+    <Mesh file="assets/casa.obj" position="0,0,0" scale="10"
+          rotation="0,45,0" albedo="0.82,0.78,0.74" emission="0,0,0"
+          materialType="0" emissionPower="0" />
+</Scene>


### PR DESCRIPTION
## Summary
- add a new `scene_casa_cinematic.xml` that features the casa.obj asset
- create a looping cinematic camera path that keeps the house in view
- configure an observer camera, ground plane, and lighting for the shot

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef915653f8832d9446bdd934315d12