### PR TITLE
Add bunnies to casa scene and expose per-scene sampling controls

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1265,6 +1265,12 @@ void Renderer::updateVisibleScene() {
          _pScene->getPrimitiveCount(), _pScene->getSphereCount(),
          _pScene->getTriangleCount(), _pScene->getRectangleCount());
 
+  _minSamplesPerPixel = _pScene->getMinSamplesPerPixel();
+  _maxSamplesPerPixel = _pScene->getMaxSamplesPerPixel();
+
+  printf("Sampling range: %u-%u samples per pixel\n", _minSamplesPerPixel,
+         _maxSamplesPerPixel);
+
   _residencyConfig = _pScene->getResidencyParameters();
   _textureResidencyMemoryCapMB =
       std::max(_pScene->getTextureResidencyMemoryCapMB(), 0.0);

--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -33,6 +33,8 @@ void Scene::clear() {
   textureResidencyMemoryCapMB = 2048.0;
   observerCameraValid = false;
   observerCamera = ObserverCamera{};
+  minSamplesPerPixel = 1;
+  maxSamplesPerPixel = 4;
 }
 
 size_t Scene::addPrimitive(const Primitive &p) {
@@ -161,6 +163,17 @@ double Scene::getTextureResidencyMemoryCapMB() const {
 
 void Scene::setTextureResidencyMemoryCapMB(double capMB) {
   textureResidencyMemoryCapMB = capMB;
+}
+
+uint32_t Scene::getMinSamplesPerPixel() const { return minSamplesPerPixel; }
+
+uint32_t Scene::getMaxSamplesPerPixel() const { return maxSamplesPerPixel; }
+
+void Scene::setSamplesPerPixelRange(uint32_t minSamples, uint32_t maxSamples) {
+  uint32_t clampedMin = std::max<uint32_t>(minSamples, 1u);
+  uint32_t clampedMax = std::max<uint32_t>(maxSamples, clampedMin);
+  minSamplesPerPixel = clampedMin;
+  maxSamplesPerPixel = clampedMax;
 }
 
 void Scene::setObserverCamera(const ObserverCamera &camera) {

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -115,6 +115,10 @@ public:
   double getTextureResidencyMemoryCapMB() const;
   void setTextureResidencyMemoryCapMB(double capMB);
 
+  uint32_t getMinSamplesPerPixel() const;
+  uint32_t getMaxSamplesPerPixel() const;
+  void setSamplesPerPixelRange(uint32_t minSamples, uint32_t maxSamples);
+
   void buildBVH();
   size_t getBVHNodeCount() const;
   const std::vector<BVHNode> &getBVHNodes() const;
@@ -161,6 +165,8 @@ private:
   double textureResidencyMemoryCapMB;
   bool observerCameraValid;
   ObserverCamera observerCamera;
+  uint32_t minSamplesPerPixel;
+  uint32_t maxSamplesPerPixel;
 
   size_t addObjectInternal(const Primitive *prims, size_t count,
                           bool logPrimitives, int meshGroupId);

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -16,6 +16,7 @@
 #include <vector>
 #include <limits>
 #include <cmath>
+#include <cstdint>
 #include "tiny_obj_loader.h"
 #include "TextureLoader.h"
 
@@ -534,6 +535,12 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
     scene->screenSize.x = root->FloatAttribute("width", scene->screenSize.x);
     scene->screenSize.y = root->FloatAttribute("height", scene->screenSize.y);
     scene->maxRayDepth = root->UnsignedAttribute("maxRayDepth", scene->maxRayDepth);
+
+    uint32_t minSamples = root->UnsignedAttribute("minSamplesPerPixel",
+                                                 scene->getMinSamplesPerPixel());
+    uint32_t maxSamples = root->UnsignedAttribute("maxSamplesPerPixel",
+                                                 scene->getMaxSamplesPerPixel());
+    scene->setSamplesPerPixelRange(minSamples, maxSamples);
 
     if (const char* residencyAttr = root->Attribute("residencyStrategy")) {
         std::string value = residencyAttr;

--- a/MetalCpp Path Tracer/scene_casa_cinematic.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic.xml
@@ -1,5 +1,6 @@
 <Scene width="1280" height="720" maxRayDepth="8" startCompacted="true"
        residencyStrategy="distance" textureResidencyMemoryCapMB="256"
+       minSamplesPerPixel="4" maxSamplesPerPixel="16"
        lodEnterDistance="60" lodExitDistance="90" residencyCooldown="1" lodToggleBudget="12000">
     <ObserverCamera position="0,22,28" lookAt="0,4,0" verticalFov="45" />
 
@@ -23,5 +24,15 @@
 
     <Mesh file="assets/casa.obj" position="0,0,0" scale="10"
           rotation="0,45,0" albedo="0.82,0.78,0.74" emission="0,0,0"
+          materialType="0" emissionPower="0" />
+
+    <Mesh file="assets/bunny.obj" position="4.5,0.2,6" scale="0.9"
+          rotation="0,15,0" albedo="0.78,0.72,0.68" emission="0,0,0"
+          materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-3.5,0.2,3.5" scale="0.85"
+          rotation="0,-25,0" albedo="0.74,0.7,0.66" emission="0,0,0"
+          materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="1.5,0.2,-2" scale="0.8"
+          rotation="0,60,0" albedo="0.7,0.68,0.65" emission="0,0,0"
           materialType="0" emissionPower="0" />
 </Scene>


### PR DESCRIPTION
## Summary
- extend scene loading to accept per-scene sampling ranges and forward them to the renderer
- add three bunny meshes to the casa cinematic scene while increasing its sampling budget to reduce noise

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ef9877c9e8832daae5fde49d3d7d7e