### PR TITLE
Mark surfaceArea helper const

### DIFF
--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -900,7 +900,7 @@ Scene::SAHSplitResult Scene::evaluateSAHSplit(
   return result;
 }
 
-float Scene::surfaceArea(const simd::float3 &bmin, const simd::float3 &bmax) {
+float Scene::surfaceArea(const simd::float3 &bmin, const simd::float3 &bmax) const {
   simd::float3 d = bmax - bmin;
   return 2.0f * (d.x * d.y + d.y * d.z + d.z * d.x);
 }

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -188,7 +188,7 @@ private:
                                   const simd::float3 *boundsMax,
                                   const simd::float3 *centroids,
                                   size_t count, float parentArea) const;
-  float surfaceArea(const simd::float3 &bmin, const simd::float3 &bmax);
+  float surfaceArea(const simd::float3 &bmin, const simd::float3 &bmax) const;
   float primitiveAxisValue(const Primitive &p, int axis) const;
   simd::float3 primitiveCentroid(const Primitive &p) const;
   float objectAxisValue(size_t objectIndex, int axis) const;


### PR DESCRIPTION
## Summary
- mark Scene::surfaceArea as a const helper so it can be invoked from const methods

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f15c8d36b4832d855d4c1e1435bc06