### PR TITLE
Allow subset BVH builder to access SAH split

### DIFF
--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -80,6 +80,8 @@ struct Texture {
   std::vector<float> pixels; // RGBA
 };
 
+struct SubsetBVHScratchBuffers;
+
 class Scene {
 public:
   Scene();
@@ -147,6 +149,13 @@ public:
   const ObserverCamera &getObserverCamera() const;
 
 private:
+  friend int buildSubsetBVHRecursive(const Scene &scene,
+                                     const std::vector<Primitive> &primitives,
+                                     std::vector<int> &primitiveIndices,
+                                     std::vector<BVHNode> &nodes, size_t start,
+                                     size_t end,
+                                     SubsetBVHScratchBuffers *scratch);
+
   struct SAHSplitResult {
     int axis = -1;
     size_t leftCount = 0;


### PR DESCRIPTION
## Summary
- forward declare the subset BVH scratch structure so it can be referenced from the scene header
- grant buildSubsetBVHRecursive friend access to Scene so it can call evaluateSAHSplit

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f15fb41dcc832dbae2b0834d0f58e3