### PR TITLE
Add residency flag to control cached BLAS construction

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1352,6 +1352,12 @@ void Renderer::updateVisibleScene() {
          _pScene->getTriangleCount(), _pScene->getRectangleCount());
 
   _residencyConfig = _pScene->getResidencyParameters();
+  bool requiresCachedBlas =
+      _pScene->getResidencyStrategy() != ResidencyStrategy::AlwaysResident;
+  if (_residencyConfig.buildCachedBlas != requiresCachedBlas) {
+    _residencyConfig.buildCachedBlas = requiresCachedBlas;
+    _pScene->setResidencyParameters(_residencyConfig);
+  }
   _textureResidencyMemoryCapMB =
       std::max(_pScene->getTextureResidencyMemoryCapMB(), 0.0);
   if (_textureResidencyMemoryCapMB <= 0.0)

--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -244,7 +244,7 @@ void Scene::buildBVH() {
       obj.boundsMax = rootNode.boundsMax;
       objectIndices.push_back(i);
 
-      if (nodeEnd > nodeStart) {
+      if (residencyParams.buildCachedBlas && nodeEnd > nodeStart) {
         obj.cachedBlasNodes.reserve(nodeEnd - nodeStart);
         for (size_t nodeIdx = nodeStart; nodeIdx < nodeEnd; ++nodeIdx) {
           BVHNode node = bvhNodes[nodeIdx];

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -53,6 +53,11 @@ struct ResidencyParameters {
   float screenFootprintMinPixelCoverage = 32.0f;
   size_t screenFootprintMinActivePrimitives = 16;
   size_t screenFootprintMaxTogglesPerFrame = 10;
+
+  // Controls whether per-object BLAS caches should be precomputed during BVH
+  // construction. Disabling this reduces build time at the cost of on-demand
+  // rebuilds when residency streaming requires the data.
+  bool buildCachedBlas = true;
 };
 
 struct TLASNode {

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -602,6 +602,8 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
     params.screenFootprintMaxTogglesPerFrame = static_cast<size_t>(root->Unsigned64Attribute(
         "screenToggleBudget",
         static_cast<uint64_t>(params.screenFootprintMaxTogglesPerFrame)));
+    params.buildCachedBlas = root->BoolAttribute(
+        "buildCachedBlas", params.buildCachedBlas);
 
     scene->setResidencyParameters(params);
 


### PR DESCRIPTION
## Summary
- add a residency parameter that controls whether per-object BLAS caches are constructed during BVH builds
- skip cached BLAS population when the new flag is disabled and expose XML support for configuring it
- have the renderer toggle the flag based on residency strategy so streaming still benefits from caches while always-resident scenes avoid extra work

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f162353760832d8c7c12ad9e6de262