### PR TITLE
Add tree and glass bunnies to casa cinematic scene

### DIFF
--- a/MetalCpp Path Tracer/scene_casa_cinematic.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic.xml
@@ -13,15 +13,45 @@
     </CameraPath>
 
     <Sphere position="0,-1000,0" radius="1000" albedo="0.75,0.78,0.82"
-            emission="0,0,0" materialType="0" emissionPower="0" />
+            emission="0.08,0.08,0.1" materialType="0" emissionPower="1.5" />
 
     <Rectangle position="0,0,0" u="20,0,0" v="0,0,-20" albedo="0.32,0.31,0.3"
                emission="0,0,0" materialType="0" emissionPower="0" />
 
     <Rectangle position="0,12,0" u="6,0,0" v="0,0,6" rotation="180,0,0"
-               albedo="1,1,1" emission="1,0.96,0.9" materialType="-1" emissionPower="25" />
+               albedo="1,1,1" emission="1.0,0.92,0.82" materialType="-1" emissionPower="18" />
+
+    <Rectangle position="-18,18,12" u="4,0,0" v="0,0,-8" rotation="140,35,0"
+               albedo="1,1,1" emission="1.0,0.95,0.85" materialType="-1" emissionPower="30" />
 
     <Mesh file="assets/casa.obj" position="0,0,0" scale="10"
           rotation="0,45,0" albedo="0.82,0.78,0.74" emission="0,0,0"
           materialType="0" emissionPower="0" />
+
+    <Mesh file="assets/Tree.obj" position="-8,0,14" scale="6"
+          rotation="0,-20,0" albedo="0.9,0.9,0.9" emission="0,0,0"
+          materialType="0" emissionPower="0" />
+
+    <Mesh file="assets/Tree.obj" position="12,0,18" scale="5.5"
+          rotation="0,30,0" albedo="0.9,0.9,0.9" emission="0,0,0"
+          materialType="0" emissionPower="0" />
+
+    <Mesh file="assets/Tree.obj" position="-14,0,-2" scale="5.8"
+          rotation="0,-45,0" albedo="0.9,0.9,0.9" emission="0,0,0"
+          materialType="0" emissionPower="0" />
+
+    <Mesh file="assets/bunny.obj" position="4,0.1,6" scale="0.8"
+          rotation="0,20,0" albedo="0.98,0.99,1.0" emission="0,0,0"
+          materialType="1.48" transmission="1,1,1" roughness="0.05"
+          emissionPower="0" />
+
+    <Mesh file="assets/bunny.obj" position="1.5,0.1,8" scale="0.65"
+          rotation="0,-35,0" albedo="0.98,0.99,1.0" emission="0,0,0"
+          materialType="1.48" transmission="1,1,1" roughness="0.08"
+          emissionPower="0" />
+
+    <Mesh file="assets/bunny.obj" position="-1,0.1,5.5" scale="0.7"
+          rotation="0,60,0" albedo="0.98,0.99,1.0" emission="0,0,0"
+          materialType="1.48" transmission="1,1,1" roughness="0.06"
+          emissionPower="0" />
 </Scene>


### PR DESCRIPTION
## Summary
- add ambient skylight and a warm key light to the casa cinematic scene
- place the newly provided tree mesh along the lawn and duplicate additional trees to frame the yard
- sprinkle three glass bunny accents across the grass to catch the new lighting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f76389a44c832db769565a3847a034