### PR TITLE
Guard diffuse colors when textures are present

### DIFF
--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -150,6 +150,12 @@ static Material ConvertTinyMaterial(const tinyobj::material_t& src,
     material.diffuseTextureIndex = ResolveTextureIndex(src.diffuse_texname,
                                                        baseDir, scene,
                                                        textureCache);
+    if (material.diffuseTextureIndex >= 0) {
+        constexpr float kMinDiffuseLuminance = 1.0e-4f;
+        if (luminance(material.diffuseColor) <= kMinDiffuseLuminance) {
+            material.diffuseColor = simd::make_float3(1.0f, 1.0f, 1.0f);
+        }
+    }
     material.specularTextureIndex = ResolveTextureIndex(src.specular_texname,
                                                         baseDir, scene,
                                                         textureCache);


### PR DESCRIPTION
## Summary
- default OBJ diffuse colors to white whenever a diffuse texture is present but the material color is effectively black

## Testing
- not run (logic-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f765ae3288832dadb82bbdc16ddd03