### PR TITLE
Adjust ray origin bias after scatter

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -683,11 +683,13 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
       }
     }
 
-    r.origin = bestHit.point + 0.0001 * offsetNormal;
     r.minDistance = 0.0001f;
     r.maxDistance = INFINITY;
     float3 scatterWeight = scatter(r, bestHit, material, seed);
     seed = random(seed);
+    float3 biasNormal =
+        (dot(r.direction, offsetNormal) < 0.0f) ? -offsetNormal : offsetNormal;
+    r.origin = bestHit.point + 0.0001f * biasNormal;
     absorption.xyz *= scatterWeight;
     absorption.w = 1.0f;
 


### PR DESCRIPTION
## Summary
- defer updating the primary ray origin until after scatter computes the outgoing direction
- bias the origin along the outgoing ray to keep reflection and transmission offsets consistent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f76aa59b98832da77606bccadf4ae4