### PR TITLE
Use shading normal for dielectric scattering

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/Scatter.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Scatter.h
@@ -74,6 +74,7 @@ inline float3 scatter(thread Ray &r, thread const intersection &i,
                       thread const MaterialPayload &material,
                       thread uint32_t &seed) {
     float3 normal = i.frontFace ? i.normal : -i.normal;
+    float3 shadingNormal = i.normal;
 
     float diffuseWeight = max(luminance(material.diffuseColor) * material.opacity,
                               0.0f);
@@ -135,15 +136,15 @@ inline float3 scatter(thread Ray &r, thread const intersection &i,
     float probability = max(dielectricWeight / totalWeight, 1e-4f);
     float eta = max(material.indexOfRefraction, 1e-3f);
     float etaRatio = i.frontFace ? (1.0f / eta) : eta;
-    bool reflectSample = mirrorAngle(etaRatio, normal, r.direction, seed);
+    bool reflectSample = mirrorAngle(etaRatio, shadingNormal, r.direction, seed);
     if (reflectSample) {
-        r.direction = reflect(r.direction, normal);
+        r.direction = reflect(r.direction, shadingNormal);
         return material.specularColor / probability;
     }
 
-    float3 refracted = refract(r.direction, normal, etaRatio);
+    float3 refracted = refract(r.direction, shadingNormal, etaRatio);
     if (!all(isfinite(refracted))) {
-        r.direction = reflect(r.direction, normal);
+        r.direction = reflect(r.direction, shadingNormal);
         return material.specularColor / probability;
     }
 


### PR DESCRIPTION
## Summary
- use the shading normal from the intersection alongside the geometric normal
- evaluate Fresnel, reflection, and refraction against the shading normal for dielectric materials so rays exit the medium correctly

## Testing
- not run (requires macOS/Metal build environment)


------
https://chatgpt.com/codex/tasks/task_e_68f7713593cc832d8db95fcae1b77693