### PR TITLE
Fix scatter normal orientation for dielectric refraction

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/Scatter.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Scatter.h
@@ -73,7 +73,7 @@ inline float3 sampleCosineHemisphere(thread const float3 &normal,
 inline float3 scatter(thread Ray &r, thread const intersection &i,
                       thread const MaterialPayload &material,
                       thread uint32_t &seed) {
-    float3 normal = i.frontFace ? i.normal : -i.normal;
+    float3 normal = i.normal;
 
     float diffuseWeight = max(luminance(material.diffuseColor) * material.opacity,
                               0.0f);


### PR DESCRIPTION
## Summary
- use the intersection-provided normal directly in the scatter shader to avoid double flipping and preserve correct refraction behavior

## Testing
- not run (Metal/renderer build requires macOS/Metal tooling that is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f8a281fd8c832db5d684b870db4c17