### PR TITLE
Refine casa cinematic layout for residency testing

### DIFF
--- a/MetalCpp Path Tracer/scene_casa_cinematic.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic.xml
@@ -4,12 +4,13 @@
     <ObserverCamera position="18,12,18" lookAt="0,4,0" verticalFov="45" />
 
     <CameraPath>
-        <Keyframe frame="0" position="12,4,16" lookAt="0,3,0" />
-        <Keyframe frame="80" position="8,3,6" lookAt="0,3,0" />
-        <Keyframe frame="160" position="-6,4,6" lookAt="0,3,0" />
-        <Keyframe frame="240" position="-12,5,-6" lookAt="0,3,0" />
-        <Keyframe frame="320" position="6,3,-12" lookAt="0,3,0" />
-        <Keyframe frame="400" position="10,4,14" lookAt="0,3,0" />
+        <Keyframe frame="0" position="16,6,22" lookAt="0,4,0" />
+        <Keyframe frame="80" position="8,4,8" lookAt="0,3,0" />
+        <Keyframe frame="160" position="-6,3,10" lookAt="-2,1.5,8" />
+        <Keyframe frame="240" position="-16,5,18" lookAt="-14,3,20" />
+        <Keyframe frame="320" position="-20,5,-4" lookAt="-18,3,-8" />
+        <Keyframe frame="400" position="18,4,2" lookAt="18,3,10" />
+        <Keyframe frame="480" position="10,5,-14" lookAt="0,3,0" />
     </CameraPath>
 
     <Sphere position="0,-1000,0" radius="1000" albedo="0.75,0.78,0.82"
@@ -28,30 +29,30 @@
           rotation="0,45,0" albedo="0.82,0.78,0.74" emission="0,0,0"
           materialType="0" emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-8,0,14" scale="6"
-          rotation="0,-20,0" albedo="0.9,0.9,0.9" emission="0,0,0"
+    <Mesh file="assets/Tree.obj" position="-14,0,20" scale="6"
+          rotation="0,-25,0" albedo="0.9,0.9,0.9" emission="0,0,0"
           materialType="0" emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="12,0,18" scale="5.5"
-          rotation="0,30,0" albedo="0.9,0.9,0.9" emission="0,0,0"
+    <Mesh file="assets/Tree.obj" position="18,0,8" scale="5.5"
+          rotation="0,20,0" albedo="0.9,0.9,0.9" emission="0,0,0"
           materialType="0" emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-14,0,-2" scale="5.8"
-          rotation="0,-45,0" albedo="0.9,0.9,0.9" emission="0,0,0"
+    <Mesh file="assets/Tree.obj" position="-18,0,-6" scale="5.8"
+          rotation="0,-35,0" albedo="0.9,0.9,0.9" emission="0,0,0"
           materialType="0" emissionPower="0" />
 
-    <Mesh file="assets/bunny.obj" position="2.5,0.1,4.5" scale="0.8"
-          rotation="0,15,0" albedo="0.98,0.99,1.0" emission="0,0,0"
+    <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.8"
+          rotation="0,5,0" albedo="0.98,0.99,1.0" emission="0,0,0"
           materialType="1.48" transmission="1,1,1" roughness="0.05"
           emissionPower="0" />
 
-    <Mesh file="assets/bunny.obj" position="-0.5,0.1,6.5" scale="0.65"
-          rotation="0,-20,0" albedo="0.98,0.99,1.0" emission="0,0,0"
+    <Mesh file="assets/bunny.obj" position="3.5,0.1,2.5" scale="0.65"
+          rotation="0,-15,0" albedo="0.98,0.99,1.0" emission="0,0,0"
           materialType="1.48" transmission="1,1,1" roughness="0.08"
           emissionPower="0" />
 
-    <Mesh file="assets/bunny.obj" position="-3,0.1,5" scale="0.7"
-          rotation="0,45,0" albedo="0.98,0.99,1.0" emission="0,0,0"
+    <Mesh file="assets/bunny.obj" position="-6,0.1,4" scale="0.7"
+          rotation="0,35,0" albedo="0.98,0.99,1.0" emission="0,0,0"
           materialType="1.48" transmission="1,1,1" roughness="0.06"
           emissionPower="0" />
 </Scene>


### PR DESCRIPTION
## Summary
- reposition casa_cinematic props to better separate residency test cases
- extend and retarget the camera path so each major object is highlighted

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8a9e29794832d9dce1ea32d729395