### PR TITLE
Use oriented surface normal for ray offsets

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -599,7 +599,7 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
                material.emissionPower;
     }
 
-    float3 offsetNormal = bestHit.frontFace ? bestHit.normal : -bestHit.normal;
+    float3 offsetNormal = bestHit.normal;
 
     float3 diffuseColor = material.diffuseColor * material.opacity;
     float diffuseLum = luminance(diffuseColor);


### PR DESCRIPTION
## Summary
- ensure the ray offset normal always uses the oriented surface normal to avoid flipping for back faces

## Testing
- not run (macOS Metal toolchain is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f8afd38eac832d852a56649db7c054