### PR TITLE
Defer BLAS/TLAS builds to shared command buffers

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -77,22 +77,46 @@ void ResidentObjectGpuResources::transitionToCold(
 
 bool ResidentObjectGpuResources::ensureResident(
     Renderer &renderer, size_t objectIndex, const SceneObject &object,
-    BlasInstanceRecord &instanceRecord, bool forceRebuild) {
+    BlasInstanceRecord &instanceRecord, bool forceRebuild,
+    MTL::CommandBuffer *&commandBuffer) {
+  if (pendingCommand) {
+    auto status = pendingCommand->status();
+    using Status = MTL::CommandBufferStatus;
+    if (status == Status::CommandBufferStatusCompleted) {
+      clearPendingCommand();
+      state = ResidencyState::Resident;
+      geometryValid = true;
+      lastStateChange = std::chrono::steady_clock::now();
+    } else if (status == Status::CommandBufferStatusError) {
+      clearPendingCommand();
+      transitionToCold(instanceRecord);
+      return false;
+    } else {
+      state = ResidencyState::Streaming;
+      return true;
+    }
+  }
+
   if (isResident() && !forceRebuild) {
     lastStateChange = std::chrono::steady_clock::now();
     return true;
   }
 
-  transitionToStreaming();
-  bool built = renderer.buildObjectBlas(objectIndex, object, *this);
+  if (!renderer._pCommandQueue)
+    return false;
+
+  if (!commandBuffer)
+    commandBuffer = renderer._pCommandQueue->commandBuffer();
+
+  if (!commandBuffer)
+    return false;
+
+  bool built = renderer.buildObjectBlas(objectIndex, object, *this, commandBuffer);
   if (!built) {
     transitionToCold(instanceRecord);
     return false;
   }
 
-  clearPendingCommand();
-  state = ResidencyState::Resident;
-  lastStateChange = std::chrono::steady_clock::now();
   return true;
 }
 
@@ -758,6 +782,12 @@ Renderer::~Renderer() {
   _cachedInstancedAccelerationStructures.clear();
   _pTlasInstanceDescriptorBuffer = nullptr;
   _pTlasStructure = nullptr;
+  if (_pPendingTlasStructure)
+    _pPendingTlasStructure->release();
+  _pPendingTlasStructure = nullptr;
+  if (_pPendingTlasCommand)
+    _pPendingTlasCommand->release();
+  _pPendingTlasCommand = nullptr;
   _pDummyBlas = nullptr;
 
   _tlasHeap.destroy();
@@ -1660,8 +1690,12 @@ void Renderer::recalculateViewport() {
 }
 
 bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
-                               ResidentObjectGpuResources &resident) {
+                               ResidentObjectGpuResources &resident,
+                               MTL::CommandBuffer *commandBuffer) {
   if (!_pDevice || !_pCommandQueue)
+    return false;
+
+  if (!commandBuffer)
     return false;
 
   NS::AutoreleasePool *pool = NS::AutoreleasePool::alloc()->init();
@@ -1699,6 +1733,8 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
 
   size_t triangleCount = indices.size() / 3;
 
+  resident.geometryValid = false;
+
   if (triangleCount == 0) {
     resident.resources.ensureAccelerationStructure(0, nullptr);
     resident.byteSize = 0;
@@ -1707,6 +1743,9 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
     resident.vertexBufferOffset = 0;
     resident.indexBufferOffset = 0;
     resident.geometryValid = false;
+    resident.clearPendingCommand();
+    resident.state = ResidentObjectGpuResources::ResidencyState::Resident;
+    resident.lastStateChange = std::chrono::steady_clock::now();
     cleanupPool();
     return true;
   }
@@ -1866,22 +1905,6 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
     scratchBuffer =
         _pDevice->newBuffer(scratchSize, MTL::ResourceStorageModePrivate);
 
-  MTL::CommandBuffer *commandBuffer = _pCommandQueue->commandBuffer();
-  if (!commandBuffer) {
-    if (scratchBuffer)
-      scratchBuffer->release();
-    if (indexStaging)
-      indexStaging->release();
-    if (vertexStaging)
-      vertexStaging->release();
-    if (geometryArray)
-      geometryArray->release();
-    geometryDesc->release();
-    accelDesc->release();
-    cleanupPool();
-    return false;
-  }
-
   MTL::BlitCommandEncoder *blitEncoder = nullptr;
   auto ensureBlitEncoder = [&]() -> MTL::BlitCommandEncoder * {
     if (!blitEncoder)
@@ -1920,9 +1943,6 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
                                         scratchBuffer, 0);
   asEncoder->endEncoding();
 
-  commandBuffer->commit();
-  commandBuffer->waitUntilCompleted();
-
   if (scratchBuffer)
     scratchBuffer->release();
   if (indexStaging)
@@ -1939,7 +1959,25 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
   resident.vertexCount = vertices.size();
   resident.vertexBufferOffset = 0;
   resident.indexBufferOffset = 0;
-  resident.geometryValid = true;
+  resident.transitionToStreaming(commandBuffer);
+
+  ResidentObjectGpuResources *residentPtr = &resident;
+  commandBuffer->addCompletedHandler(^void(MTL::CommandBuffer *cmd) {
+    auto status = cmd->status();
+    auto now = std::chrono::steady_clock::now();
+    using Status = MTL::CommandBufferStatus;
+    if (status == Status::CommandBufferStatusCompleted) {
+      residentPtr->geometryValid = true;
+      residentPtr->state =
+          ResidentObjectGpuResources::ResidencyState::Resident;
+    } else {
+      residentPtr->geometryValid = false;
+      residentPtr->state =
+          ResidentObjectGpuResources::ResidencyState::Cold;
+    }
+    residentPtr->lastStateChange = now;
+    residentPtr->clearPendingCommand();
+  });
 
   cleanupPool();
   return true;
@@ -2132,11 +2170,15 @@ bool Renderer::ensureDummyBlas() {
 
 void Renderer::updateTopLevelAccelerationStructure(
     const std::vector<MTL::AccelerationStructureInstanceDescriptor> &descriptors,
-    const std::vector<MTL::AccelerationStructure *> &structures) {
+    const std::vector<MTL::AccelerationStructure *> &structures,
+    MTL::CommandBuffer *&commandBuffer) {
   if (!_pDevice || !_pCommandQueue)
     return;
 
   if (!ensureDummyBlas())
+    return;
+
+  if (_pPendingTlasStructure)
     return;
 
   _tlasHeap.initialize(_pDevice);
@@ -2225,17 +2267,29 @@ void Renderer::updateTopLevelAccelerationStructure(
   MTL::AccelerationStructureSizes sizes =
       _pDevice->accelerationStructureSizes(instanceDesc);
 
+  MTL::AccelerationStructure *retainedActive = nullptr;
+  if (needsRebuild && _pTlasStructure) {
+    retainedActive = _pTlasStructure;
+    retainedActive->retain();
+  }
+
+  MTL::AccelerationStructure *targetStructure = _pTlasStructure;
   if (needsRebuild) {
     MTL::AccelerationStructure *structure =
         _tlasHeap.ensureAccelerationStructure(
             sizes.accelerationStructureSize, "SceneTLAS");
     if (!structure) {
+      if (retainedActive) {
+        retainedActive->release();
+        retainedActive = nullptr;
+      }
       instanceDesc->release();
       if (stagingBuffer)
         stagingBuffer->release();
       return;
     }
-    _pTlasStructure = structure;
+    targetStructure = structure;
+    _pPendingTlasStructure = structure;
   }
 
   NS::UInteger scratchSize = needsRebuild ? sizes.buildScratchBufferSize
@@ -2245,12 +2299,22 @@ void Renderer::updateTopLevelAccelerationStructure(
     scratchBuffer =
         _pDevice->newBuffer(scratchSize, MTL::ResourceStorageModePrivate);
 
-  MTL::CommandBuffer *commandBuffer = _pCommandQueue->commandBuffer();
+  if (!commandBuffer && _pCommandQueue)
+    commandBuffer = _pCommandQueue->commandBuffer();
+
   if (!commandBuffer) {
     if (scratchBuffer)
       scratchBuffer->release();
     if (stagingBuffer)
       stagingBuffer->release();
+    if (_pPendingTlasStructure) {
+      _pPendingTlasStructure->release();
+      _pPendingTlasStructure = nullptr;
+    }
+    if (retainedActive) {
+      retainedActive->release();
+      retainedActive = nullptr;
+    }
     instanceDesc->release();
     return;
   }
@@ -2268,6 +2332,14 @@ void Renderer::updateTopLevelAccelerationStructure(
       if (scratchBuffer)
         scratchBuffer->release();
       stagingBuffer->release();
+      if (_pPendingTlasStructure) {
+        _pPendingTlasStructure->release();
+        _pPendingTlasStructure = nullptr;
+      }
+      if (retainedActive) {
+        retainedActive->release();
+        retainedActive = nullptr;
+      }
       instanceDesc->release();
       return;
     }
@@ -2280,6 +2352,14 @@ void Renderer::updateTopLevelAccelerationStructure(
         scratchBuffer->release();
       if (stagingBuffer)
         stagingBuffer->release();
+      if (_pPendingTlasStructure) {
+        _pPendingTlasStructure->release();
+        _pPendingTlasStructure = nullptr;
+      }
+      if (retainedActive) {
+        retainedActive->release();
+        retainedActive = nullptr;
+      }
       instanceDesc->release();
       return;
     }
@@ -2297,21 +2377,62 @@ void Renderer::updateTopLevelAccelerationStructure(
       scratchBuffer->release();
     if (stagingBuffer)
       stagingBuffer->release();
+    if (_pPendingTlasStructure) {
+      _pPendingTlasStructure->release();
+      _pPendingTlasStructure = nullptr;
+    }
+    if (retainedActive) {
+      retainedActive->release();
+      retainedActive = nullptr;
+    }
     instanceDesc->release();
     return;
   }
 
   if (needsRebuild) {
-    encoder->buildAccelerationStructure(_pTlasStructure, instanceDesc,
+    encoder->buildAccelerationStructure(targetStructure, instanceDesc,
                                         scratchBuffer, 0);
   } else {
-    encoder->refitAccelerationStructure(_pTlasStructure, instanceDesc,
-                                        _pTlasStructure, scratchBuffer, 0);
+    encoder->refitAccelerationStructure(targetStructure, instanceDesc,
+                                        targetStructure, scratchBuffer, 0);
   }
   encoder->endEncoding();
 
-  commandBuffer->commit();
-  commandBuffer->waitUntilCompleted();
+  if (needsRebuild) {
+    if (_pPendingTlasCommand)
+      _pPendingTlasCommand->release();
+    _pPendingTlasCommand = commandBuffer;
+    _pPendingTlasCommand->retain();
+
+    Renderer *self = this;
+    MTL::AccelerationStructure *pendingStructure = _pPendingTlasStructure;
+    MTL::AccelerationStructure *previousStructure = retainedActive;
+    commandBuffer->addCompletedHandler(^void(MTL::CommandBuffer *cmd) {
+      using Status = MTL::CommandBufferStatus;
+      Status status = cmd->status();
+      if (pendingStructure) {
+        if (status == Status::CommandBufferStatusCompleted) {
+          if (self->_pTlasStructure &&
+              self->_pTlasStructure != pendingStructure)
+            self->_pTlasStructure->release();
+          self->_pTlasStructure = pendingStructure;
+        } else {
+          pendingStructure->release();
+        }
+      }
+      if (previousStructure)
+        previousStructure->release();
+      if (self->_pPendingTlasCommand == cmd) {
+        self->_pPendingTlasCommand->release();
+        self->_pPendingTlasCommand = nullptr;
+        if (self->_pPendingTlasStructure == pendingStructure)
+          self->_pPendingTlasStructure = nullptr;
+      }
+    });
+  } else if (retainedActive) {
+    retainedActive->release();
+    retainedActive = nullptr;
+  }
 
   if (scratchBuffer)
     scratchBuffer->release();
@@ -3004,6 +3125,8 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     _lightCount = _cachedLightIndices.size();
   }
 
+  MTL::CommandBuffer *residencyCommandBuffer = nullptr;
+
   for (size_t objectIndex = 0; objectIndex < sceneObjects.size(); ++objectIndex) {
     bool shouldBeResident = objectShouldBeResident[objectIndex];
     auto &gpuResident = _residentObjectGpuResources[objectIndex];
@@ -3012,7 +3135,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     if (shouldBeResident) {
       bool built = gpuResident.ensureResident(
           *this, objectIndex, sceneObjects[objectIndex], instanceRecord,
-          needFullUpload);
+          needFullUpload, residencyCommandBuffer);
       if (!built) {
         shouldBeResident = false;
         objectShouldBeResident[objectIndex] = false;
@@ -3087,7 +3210,11 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     geometryHandles[objectIndex + 1] = handle;
   }
 
-  updateTopLevelAccelerationStructure(instanceDescriptors, instancedStructures);
+  updateTopLevelAccelerationStructure(instanceDescriptors, instancedStructures,
+                                      residencyCommandBuffer);
+
+  if (residencyCommandBuffer)
+    residencyCommandBuffer->commit();
 
   _residentRemap = remapUpload;
 

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -51,8 +51,8 @@ struct ResidentObjectGpuResources {
 
   bool ensureResident(Renderer &renderer, size_t objectIndex,
                       const SceneObject &object,
-                      BlasInstanceRecord &instanceRecord,
-                      bool forceRebuild);
+                      BlasInstanceRecord &instanceRecord, bool forceRebuild,
+                      MTL::CommandBuffer *&commandBuffer);
   void transitionToStreaming(MTL::CommandBuffer *pending = nullptr);
   void transitionToCold(BlasInstanceRecord &instanceRecord);
   void clearPendingCommand();
@@ -147,12 +147,14 @@ private:
   bool rayHitCopyReady() const;
   void processRayHitCounters();
   bool buildObjectBlas(size_t objectIndex, const SceneObject &object,
-                       ResidentObjectGpuResources &residentResources);
+                       ResidentObjectGpuResources &residentResources,
+                       MTL::CommandBuffer *commandBuffer);
   bool ensureDummyBlas();
   void updateTopLevelAccelerationStructure(
       const std::vector<MTL::AccelerationStructureInstanceDescriptor>
           &descriptors,
-      const std::vector<MTL::AccelerationStructure *> &structures);
+      const std::vector<MTL::AccelerationStructure *> &structures,
+      MTL::CommandBuffer *&commandBuffer);
   void updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd);
   bool resetAccumulationTargets(MTL::CommandBuffer *cmd);
   void initializeBenchmarking();
@@ -304,6 +306,8 @@ private:
   GpuHeapResources _tlasHeap;
   GpuHeapResources _dummyBlasResources;
   MTL::AccelerationStructure *_pTlasStructure = nullptr;
+  MTL::AccelerationStructure *_pPendingTlasStructure = nullptr;
+  MTL::CommandBuffer *_pPendingTlasCommand = nullptr;
   MTL::AccelerationStructure *_pDummyBlas = nullptr;
   std::vector<MTL::AccelerationStructureInstanceDescriptor>
       _cachedInstanceDescriptors;


### PR DESCRIPTION
## Summary
- share a single command buffer for BLAS and TLAS rebuilds and drive residency transitions from completion handlers
- double-buffer the TLAS handle while builds are in flight and only swap active structures once the GPU finishes
- keep acceleration-structure bindings and residency checks resilient to streaming resources

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f8b753ea08832db80a63ec57261765