### PR TITLE
Consolidate path tracing command buffer usage

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -4173,75 +4173,74 @@ void Renderer::draw(MTK::View *pView) {
     MTL::Size threadsPerThreadgroup =
         MTL::Size::Make(tgWidth, tgHeight, 1);
 
-    for (const TileDispatchRegion &tile : tiles) {
-      MTL::CommandBuffer *tileCmd = _pCommandQueue->commandBuffer();
-      if (!tileCmd)
-        continue;
-
+    MTL::CommandBuffer *tileCmd = _pCommandQueue->commandBuffer();
+    if (tileCmd) {
       MTL::ComputeCommandEncoder *pCompute = tileCmd->computeCommandEncoder();
-      if (!pCompute) {
-        tileCmd->commit();
-        continue;
+
+      if (pCompute) {
+        pCompute->setComputePipelineState(_pPathTracePSO);
+
+        bool useAccelerationStructureLayout =
+            _useAccelerationStructureBindings && _pTlasStructure &&
+            _pGeometryHandleBuffer;
+
+        if (useAccelerationStructureLayout) {
+          pCompute->setAccelerationStructure(_pTlasStructure, 0);
+          pCompute->setBuffer(_pGeometryHandleBuffer, 0, 1);
+          pCompute->setBuffer(_pSphereBuffer, 0, 2);
+          pCompute->setBuffer(_pSphereMaterialBuffer, 0, 3);
+          pCompute->setBuffer(_pUniformsBuffer, 0, 4);
+          pCompute->setBuffer(_pActiveBuffer, 0, 5);
+          pCompute->setBuffer(_pLightIndexBuffer, 0, 6);
+          pCompute->setBuffer(_pLightCdfBuffer, 0, 7);
+          pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 8);
+          pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 9);
+          pCompute->setBuffer(_pInstanceBuffer, 0, 10);
+          pCompute->setBuffer(_pTextureInfoBuffer, 0, 14);
+          pCompute->setBuffer(_pTextureDataBuffer, 0, 15);
+        } else {
+          pCompute->setBuffer(_pBVHBuffer, 0, 0);
+          pCompute->setBuffer(_pSphereBuffer, 0, 1);
+          pCompute->setBuffer(_pSphereMaterialBuffer, 0, 2);
+          pCompute->setBuffer(_pUniformsBuffer, 0, 3);
+          pCompute->setBuffer(_pTriangleVertexBuffer, 0, 4);
+          pCompute->setBuffer(_pTriangleIndexBuffer, 0, 5);
+          pCompute->setBuffer(_pPrimitiveIndexBuffer, 0, 6);
+          pCompute->setBuffer(_pTLASBuffer, 0, 7);
+          pCompute->setBuffer(_pActiveBuffer, 0, 8);
+          pCompute->setBuffer(_pLightIndexBuffer, 0, 9);
+          pCompute->setBuffer(_pLightCdfBuffer, 0, 10);
+          pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
+          pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
+          pCompute->setBuffer(_pInstanceBuffer, 0, 13);
+          pCompute->setBuffer(_pTextureInfoBuffer, 0, 14);
+          pCompute->setBuffer(_pTextureDataBuffer, 0, 15);
+        }
+
+        pCompute->setTexture(accum0, 0);
+        pCompute->setTexture(accum1, 1);
+        pCompute->setTexture(sampleCount, 2);
+        pCompute->setTexture(sampleImportance, 3);
+
+        for (const TileDispatchRegion &tile : tiles) {
+          TileDispatchRegion tileParams = tile;
+          pCompute->setBytes(&tileParams, sizeof(TileDispatchRegion), 16);
+
+          NS::UInteger localWidth = static_cast<NS::UInteger>(tile.width);
+          NS::UInteger localHeight = static_cast<NS::UInteger>(tile.height);
+          MTL::Size threadgroups = MTL::Size::Make(
+              (localWidth + threadsPerThreadgroup.width - 1) /
+                  threadsPerThreadgroup.width,
+              (localHeight + threadsPerThreadgroup.height - 1) /
+                  threadsPerThreadgroup.height,
+              1);
+
+          pCompute->dispatchThreadgroups(threadgroups, threadsPerThreadgroup);
+        }
+
+        pCompute->endEncoding();
       }
 
-      pCompute->setComputePipelineState(_pPathTracePSO);
-
-      bool useAccelerationStructureLayout =
-          _useAccelerationStructureBindings && _pTlasStructure &&
-          _pGeometryHandleBuffer;
-
-      if (useAccelerationStructureLayout) {
-        pCompute->setAccelerationStructure(_pTlasStructure, 0);
-        pCompute->setBuffer(_pGeometryHandleBuffer, 0, 1);
-        pCompute->setBuffer(_pSphereBuffer, 0, 2);
-        pCompute->setBuffer(_pSphereMaterialBuffer, 0, 3);
-        pCompute->setBuffer(_pUniformsBuffer, 0, 4);
-        pCompute->setBuffer(_pActiveBuffer, 0, 5);
-        pCompute->setBuffer(_pLightIndexBuffer, 0, 6);
-        pCompute->setBuffer(_pLightCdfBuffer, 0, 7);
-        pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 8);
-        pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 9);
-        pCompute->setBuffer(_pInstanceBuffer, 0, 10);
-        pCompute->setBuffer(_pTextureInfoBuffer, 0, 14);
-        pCompute->setBuffer(_pTextureDataBuffer, 0, 15);
-      } else {
-        pCompute->setBuffer(_pBVHBuffer, 0, 0);
-        pCompute->setBuffer(_pSphereBuffer, 0, 1);
-        pCompute->setBuffer(_pSphereMaterialBuffer, 0, 2);
-        pCompute->setBuffer(_pUniformsBuffer, 0, 3);
-        pCompute->setBuffer(_pTriangleVertexBuffer, 0, 4);
-        pCompute->setBuffer(_pTriangleIndexBuffer, 0, 5);
-        pCompute->setBuffer(_pPrimitiveIndexBuffer, 0, 6);
-        pCompute->setBuffer(_pTLASBuffer, 0, 7);
-        pCompute->setBuffer(_pActiveBuffer, 0, 8);
-        pCompute->setBuffer(_pLightIndexBuffer, 0, 9);
-        pCompute->setBuffer(_pLightCdfBuffer, 0, 10);
-        pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
-        pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
-        pCompute->setBuffer(_pInstanceBuffer, 0, 13);
-        pCompute->setBuffer(_pTextureInfoBuffer, 0, 14);
-        pCompute->setBuffer(_pTextureDataBuffer, 0, 15);
-      }
-
-      pCompute->setTexture(accum0, 0);
-      pCompute->setTexture(accum1, 1);
-      pCompute->setTexture(sampleCount, 2);
-      pCompute->setTexture(sampleImportance, 3);
-
-      TileDispatchRegion tileParams = tile;
-      pCompute->setBytes(&tileParams, sizeof(TileDispatchRegion), 16);
-
-      NS::UInteger localWidth = static_cast<NS::UInteger>(tile.width);
-      NS::UInteger localHeight = static_cast<NS::UInteger>(tile.height);
-      MTL::Size threadgroups = MTL::Size::Make(
-          (localWidth + threadsPerThreadgroup.width - 1) /
-              threadsPerThreadgroup.width,
-          (localHeight + threadsPerThreadgroup.height - 1) /
-              threadsPerThreadgroup.height,
-          1);
-
-      pCompute->dispatchThreadgroups(threadgroups, threadsPerThreadgroup);
-      pCompute->endEncoding();
       tileCmd->commit();
     }
   }


### PR DESCRIPTION
## Summary
- create a single command buffer for the tiled path tracing dispatch
- reuse one compute command encoder across all tiles while only updating per-tile arguments
- commit the compute work once before submitting the presentation buffer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f8bd4e7b8c832d9d4491c159524885