### PR TITLE
Handle shader build failures gracefully

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -29,6 +29,7 @@
 #include <numeric>
 #include <simd/simd.h>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <tuple>
@@ -1242,6 +1243,7 @@ void Renderer::setDeltaTime(double deltaSeconds) {
 void Renderer::buildShaders() {
   using NS::StringEncoding::UTF8StringEncoding;
 
+  _shadersReady = false;
   if (_pPSO) {
     _pPSO->release();
     _pPSO = nullptr;
@@ -1263,8 +1265,9 @@ void Renderer::buildShaders() {
   MTL::Library *pLibrary = _pDevice->newDefaultLibrary();
 
   if (!pLibrary) {
-    __builtin_printf("Failed to load Metal library\n");
-    assert(false);
+    const char *message = "Failed to load Metal library";
+    __builtin_printf("%s\n", message);
+    throw std::runtime_error(message);
   }
 
   MTL::Function *pVertexFn = pLibrary->newFunction(
@@ -1274,6 +1277,33 @@ void Renderer::buildShaders() {
 
   MTL::RenderPipelineDescriptor *pDesc =
       MTL::RenderPipelineDescriptor::alloc()->init();
+
+  auto cleanupLibraryResources = [&]() {
+    if (pVertexFn) {
+      pVertexFn->release();
+      pVertexFn = nullptr;
+    }
+    if (pFragFn) {
+      pFragFn->release();
+      pFragFn = nullptr;
+    }
+    if (pDesc) {
+      pDesc->release();
+      pDesc = nullptr;
+    }
+    if (pLibrary) {
+      pLibrary->release();
+      pLibrary = nullptr;
+    }
+  };
+
+  if (!pVertexFn || !pFragFn || !pDesc) {
+    const char *message = "Failed to create shader functions";
+    __builtin_printf("%s\n", message);
+    cleanupLibraryResources();
+    throw std::runtime_error(message);
+  }
+
   pDesc->setVertexFunction(pVertexFn);
   pDesc->setFragmentFunction(pFragFn);
   pDesc->colorAttachments()->object(0)->setPixelFormat(
@@ -1281,9 +1311,28 @@ void Renderer::buildShaders() {
 
   _pPSO = _pDevice->newRenderPipelineState(pDesc, &pError);
   if (!_pPSO) {
-    __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
-    assert(false);
+    std::string message = "Failed to create present pipeline state";
+    if (pError && pError->localizedDescription()) {
+      const char *errorText = pError->localizedDescription()->utf8String();
+      if (errorText) {
+        __builtin_printf("%s\n", errorText);
+        message += ": ";
+        message += errorText;
+      }
+    }
+    cleanupLibraryResources();
+    throw std::runtime_error(message);
   }
+
+  if (pVertexFn)
+    pVertexFn->release();
+  pVertexFn = nullptr;
+  if (pFragFn)
+    pFragFn->release();
+  pFragFn = nullptr;
+  if (pDesc)
+    pDesc->release();
+  pDesc = nullptr;
 
   pError = nullptr;
   MTL::Function *pOverlayVertexFn = pLibrary->newFunction(
@@ -1304,7 +1353,8 @@ void Renderer::buildShaders() {
     if (!_pOverlayPSO && pError) {
       __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
     }
-    pOverlayDesc->release();
+    if (pOverlayDesc)
+      pOverlayDesc->release();
   }
   if (pOverlayVertexFn)
     pOverlayVertexFn->release();
@@ -1353,7 +1403,11 @@ void Renderer::buildShaders() {
         }
       }
     }
-    pPathTraceFn->release();
+    if (pPathTraceFn)
+      pPathTraceFn->release();
+  } else {
+    cleanupLibraryResources();
+    throw std::runtime_error("Failed to load path tracing kernel function");
   }
 
   pError = nullptr;
@@ -1365,13 +1419,17 @@ void Renderer::buildShaders() {
     if (!_pAdaptiveSamplingPSO && pError) {
       __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
     }
-    pAdaptiveFn->release();
+    if (pAdaptiveFn)
+      pAdaptiveFn->release();
   }
 
-  pVertexFn->release();
-  pFragFn->release();
-  pDesc->release();
-  pLibrary->release();
+  if (!_pPathTracePSO) {
+    cleanupLibraryResources();
+    throw std::runtime_error("Failed to create path tracing pipeline state");
+  }
+
+  _shadersReady = _pPSO && _pPathTracePSO;
+  cleanupLibraryResources();
 }
 
 void Renderer::updateVisibleScene() {
@@ -4463,6 +4521,13 @@ void Renderer::draw(MTK::View *pView) {
     } else {
       completeFrameMetrics(nullptr);
     }
+    ++_renderedFrameCount;
+    pPool->release();
+    return;
+  }
+
+  if (!_shadersReady) {
+    completeFrameMetrics(nullptr);
     ++_renderedFrameCount;
     pPool->release();
     return;

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -190,6 +190,7 @@ private:
   MTL::RenderPipelineState *_pOverlayPSO = nullptr;
   MTL::ComputePipelineState *_pPathTracePSO = nullptr;
   MTL::ComputePipelineState *_pAdaptiveSamplingPSO = nullptr;
+  bool _shadersReady = false;
 
   // Core scene and geometry data
   Scene *_pScene = nullptr;


### PR DESCRIPTION
## Summary
- stop shader setup once library or pipeline creation fails and surface the failure to callers
- guard Metal resource releases while tracking shader readiness to avoid using invalid pipeline states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8c4225044832dba7fab96766560f2