### PR TITLE
Handle shader build failures gracefully

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -185,6 +185,51 @@ size_t alignTo(size_t value, size_t alignment) {
   return (value + alignment - 1) & ~(alignment - 1);
 }
 
+std::string nsStringToStd(NS::String *string) {
+  if (!string)
+    return {};
+  const char *utf8 = string->utf8String();
+  if (!utf8)
+    return {};
+  return std::string(utf8);
+}
+
+std::string describeError(NS::Error *error) {
+  if (!error)
+    return {};
+  return nsStringToStd(error->localizedDescription());
+}
+
+void writeToStderr(const std::string &text) {
+  if (text.empty())
+    return;
+  std::fprintf(stderr, "%s\n", text.c_str());
+  std::fflush(stderr);
+}
+
+void logShaderDiagnostic(const char *message, NS::Error *error = nullptr) {
+  if (message && *message)
+    writeToStderr(message);
+  std::string description = describeError(error);
+  if (!description.empty())
+    writeToStderr(description);
+}
+
+std::string logShaderFailure(const char *message, NS::Error *error = nullptr) {
+  std::string combined = message ? std::string(message) : std::string();
+  std::string description = describeError(error);
+  if (!combined.empty())
+    writeToStderr(combined);
+  if (!description.empty())
+    writeToStderr(description);
+  if (!description.empty()) {
+    if (!combined.empty())
+      combined += ": ";
+    combined += description;
+  }
+  return combined;
+}
+
 constexpr size_t kTextureResidencyPrimitiveBudget = 1;
 constexpr double kDefaultTextureResidencyMemoryCapMB = 2048.0;
 constexpr float kFrustumDebugNear = 0.1f;
@@ -764,7 +809,9 @@ Renderer::Renderer(MTL::Device *pDevice)
   _observerCameraState = _primaryCameraState;
 
   updateVisibleScene();
-  buildShaders();
+  ShaderBuildResult shaderStatus = buildShaders();
+  if (!shaderStatus.success && shaderStatus.message.empty())
+    writeToStderr("Renderer shader build failed with no diagnostic message.");
   buildTextures();
 
   recalculateViewport();
@@ -1240,8 +1287,10 @@ void Renderer::setDeltaTime(double deltaSeconds) {
   Camera::deltaTime = static_cast<float>(_deltaTimeSeconds);
 }
 
-void Renderer::buildShaders() {
+Renderer::ShaderBuildResult Renderer::buildShaders() {
   using NS::StringEncoding::UTF8StringEncoding;
+
+  ShaderBuildResult result{};
 
   _shadersReady = false;
   if (_pPSO) {
@@ -1263,20 +1312,14 @@ void Renderer::buildShaders() {
 
   NS::Error *pError = nullptr;
   MTL::Library *pLibrary = _pDevice->newDefaultLibrary();
-
-  if (!pLibrary) {
-    const char *message = "Failed to load Metal library";
-    __builtin_printf("%s\n", message);
-    throw std::runtime_error(message);
-  }
-
-  MTL::Function *pVertexFn = pLibrary->newFunction(
-      NS::String::string("vertexMain", UTF8StringEncoding));
-  MTL::Function *pFragFn = pLibrary->newFunction(
-      NS::String::string("presentMain", UTF8StringEncoding));
-
-  MTL::RenderPipelineDescriptor *pDesc =
-      MTL::RenderPipelineDescriptor::alloc()->init();
+  MTL::Function *pVertexFn = nullptr;
+  MTL::Function *pFragFn = nullptr;
+  MTL::RenderPipelineDescriptor *pDesc = nullptr;
+  MTL::Function *pOverlayVertexFn = nullptr;
+  MTL::Function *pOverlayFragmentFn = nullptr;
+  MTL::RenderPipelineDescriptor *pOverlayDesc = nullptr;
+  MTL::Function *pPathTraceFn = nullptr;
+  MTL::Function *pAdaptiveFn = nullptr;
 
   auto cleanupLibraryResources = [&]() {
     if (pVertexFn) {
@@ -1291,17 +1334,48 @@ void Renderer::buildShaders() {
       pDesc->release();
       pDesc = nullptr;
     }
+    if (pOverlayVertexFn) {
+      pOverlayVertexFn->release();
+      pOverlayVertexFn = nullptr;
+    }
+    if (pOverlayFragmentFn) {
+      pOverlayFragmentFn->release();
+      pOverlayFragmentFn = nullptr;
+    }
+    if (pOverlayDesc) {
+      pOverlayDesc->release();
+      pOverlayDesc = nullptr;
+    }
+    if (pPathTraceFn) {
+      pPathTraceFn->release();
+      pPathTraceFn = nullptr;
+    }
+    if (pAdaptiveFn) {
+      pAdaptiveFn->release();
+      pAdaptiveFn = nullptr;
+    }
     if (pLibrary) {
       pLibrary->release();
       pLibrary = nullptr;
     }
   };
 
-  if (!pVertexFn || !pFragFn || !pDesc) {
-    const char *message = "Failed to create shader functions";
-    __builtin_printf("%s\n", message);
+  if (!pLibrary) {
+    result.message = logShaderFailure("Failed to load Metal library");
     cleanupLibraryResources();
-    throw std::runtime_error(message);
+    return result;
+  }
+
+  pVertexFn = pLibrary->newFunction(
+      NS::String::string("vertexMain", UTF8StringEncoding));
+  pFragFn = pLibrary->newFunction(
+      NS::String::string("presentMain", UTF8StringEncoding));
+  pDesc = MTL::RenderPipelineDescriptor::alloc()->init();
+
+  if (!pVertexFn || !pFragFn || !pDesc) {
+    result.message = logShaderFailure("Failed to create shader functions");
+    cleanupLibraryResources();
+    return result;
   }
 
   pDesc->setVertexFunction(pVertexFn);
@@ -1311,125 +1385,138 @@ void Renderer::buildShaders() {
 
   _pPSO = _pDevice->newRenderPipelineState(pDesc, &pError);
   if (!_pPSO) {
-    std::string message = "Failed to create present pipeline state";
-    if (pError && pError->localizedDescription()) {
-      const char *errorText = pError->localizedDescription()->utf8String();
-      if (errorText) {
-        __builtin_printf("%s\n", errorText);
-        message += ": ";
-        message += errorText;
-      }
-    }
+    result.message =
+        logShaderFailure("Failed to create present pipeline state", pError);
+    pError = nullptr;
     cleanupLibraryResources();
-    throw std::runtime_error(message);
+    return result;
   }
 
-  if (pVertexFn)
+  if (pVertexFn) {
     pVertexFn->release();
-  pVertexFn = nullptr;
-  if (pFragFn)
+    pVertexFn = nullptr;
+  }
+  if (pFragFn) {
     pFragFn->release();
-  pFragFn = nullptr;
-  if (pDesc)
+    pFragFn = nullptr;
+  }
+  if (pDesc) {
     pDesc->release();
-  pDesc = nullptr;
+    pDesc = nullptr;
+  }
 
   pError = nullptr;
-  MTL::Function *pOverlayVertexFn = pLibrary->newFunction(
+  pOverlayVertexFn = pLibrary->newFunction(
       NS::String::string("frustumDebugVertexMain", UTF8StringEncoding));
-  MTL::Function *pOverlayFragmentFn = pLibrary->newFunction(
+  pOverlayFragmentFn = pLibrary->newFunction(
       NS::String::string("frustumDebugFragmentMain", UTF8StringEncoding));
   if (pOverlayVertexFn && pOverlayFragmentFn) {
-    MTL::RenderPipelineDescriptor *pOverlayDesc =
-        MTL::RenderPipelineDescriptor::alloc()->init();
-    pOverlayDesc->setVertexFunction(pOverlayVertexFn);
-    pOverlayDesc->setFragmentFunction(pOverlayFragmentFn);
-    pOverlayDesc->colorAttachments()->object(0)->setPixelFormat(
-        MTL::PixelFormat::PixelFormatRGBA16Float);
-    pOverlayDesc->setInputPrimitiveTopology(
-        MTL::PrimitiveTopologyClass::PrimitiveTopologyClassLine);
+    pOverlayDesc = MTL::RenderPipelineDescriptor::alloc()->init();
+    if (pOverlayDesc) {
+      pOverlayDesc->setVertexFunction(pOverlayVertexFn);
+      pOverlayDesc->setFragmentFunction(pOverlayFragmentFn);
+      pOverlayDesc->colorAttachments()->object(0)->setPixelFormat(
+          MTL::PixelFormat::PixelFormatRGBA16Float);
+      pOverlayDesc->setInputPrimitiveTopology(
+          MTL::PrimitiveTopologyClass::PrimitiveTopologyClassLine);
 
-    _pOverlayPSO = _pDevice->newRenderPipelineState(pOverlayDesc, &pError);
-    if (!_pOverlayPSO && pError) {
-      __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
-    }
-    if (pOverlayDesc)
+      _pOverlayPSO = _pDevice->newRenderPipelineState(pOverlayDesc, &pError);
+      if (!_pOverlayPSO && pError) {
+        logShaderDiagnostic("Failed to create overlay pipeline state", pError);
+      }
       pOverlayDesc->release();
+      pOverlayDesc = nullptr;
+    }
   }
-  if (pOverlayVertexFn)
+  if (pOverlayVertexFn) {
     pOverlayVertexFn->release();
-  if (pOverlayFragmentFn)
+    pOverlayVertexFn = nullptr;
+  }
+  if (pOverlayFragmentFn) {
     pOverlayFragmentFn->release();
+    pOverlayFragmentFn = nullptr;
+  }
 
   pError = nullptr;
   _useAccelerationStructureBindings = false;
-  MTL::Function *pPathTraceFn = pLibrary->newFunction(
+  pPathTraceFn = pLibrary->newFunction(
       NS::String::string("pathTraceKernel", UTF8StringEncoding));
-  if (pPathTraceFn) {
-    MTL::AutoreleasedComputePipelineReflection reflection = nullptr;
-    _pPathTracePSO = _pDevice->newComputePipelineState(
-        pPathTraceFn, MTL::PipelineOptionArgumentInfo, &reflection, &pError);
-    if (!_pPathTracePSO) {
-      if (pError) {
-        __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
-      }
-      pError = nullptr;
-      reflection = nullptr;
-      _pPathTracePSO =
-          _pDevice->newComputePipelineState(pPathTraceFn, &pError);
-      if (!_pPathTracePSO && pError) {
-        __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
-      }
+  if (!pPathTraceFn) {
+    result.message =
+        logShaderFailure("Failed to load path tracing kernel function");
+    cleanupLibraryResources();
+    return result;
+  }
+
+  MTL::AutoreleasedComputePipelineReflection reflection = nullptr;
+  _pPathTracePSO = _pDevice->newComputePipelineState(
+      pPathTraceFn, MTL::PipelineOptionArgumentInfo, &reflection, &pError);
+  if (!_pPathTracePSO) {
+    if (pError) {
+      logShaderDiagnostic(
+          "Failed to create path tracing pipeline with argument reflection",
+          pError);
     }
-    if (_pPathTracePSO && reflection) {
-      NS::Array *arguments = reflection->arguments();
-      if (arguments) {
-        for (NS::UInteger i = 0; i < arguments->count(); ++i) {
-          auto *argument =
-              static_cast<MTL::Argument *>(arguments->object(i));
-          if (!argument)
-            continue;
-          if (argument->type() ==
-              MTL::ArgumentType::ArgumentTypeInstanceAccelerationStructure) {
-            _useAccelerationStructureBindings = true;
-            break;
-          }
-          if (argument->type() == MTL::ArgumentType::ArgumentTypeBuffer &&
-              argument->bufferDataType() ==
-                  MTL::DataType::DataTypeInstanceAccelerationStructure) {
-            _useAccelerationStructureBindings = true;
-            break;
-          }
+    pError = nullptr;
+    reflection = nullptr;
+    _pPathTracePSO = _pDevice->newComputePipelineState(pPathTraceFn, &pError);
+    if (!_pPathTracePSO && pError) {
+      logShaderDiagnostic("Failed to create path tracing pipeline state",
+                          pError);
+    }
+  }
+
+  if (!_pPathTracePSO) {
+    result.message =
+        logShaderFailure("Failed to create path tracing pipeline state", pError);
+    cleanupLibraryResources();
+    return result;
+  }
+
+  if (_pPathTracePSO && reflection) {
+    NS::Array *arguments = reflection->arguments();
+    if (arguments) {
+      for (NS::UInteger i = 0; i < arguments->count(); ++i) {
+        auto *argument = static_cast<MTL::Argument *>(arguments->object(i));
+        if (!argument)
+          continue;
+        if (argument->type() ==
+            MTL::ArgumentType::ArgumentTypeInstanceAccelerationStructure) {
+          _useAccelerationStructureBindings = true;
+          break;
+        }
+        if (argument->type() == MTL::ArgumentType::ArgumentTypeBuffer &&
+            argument->bufferDataType() ==
+                MTL::DataType::DataTypeInstanceAccelerationStructure) {
+          _useAccelerationStructureBindings = true;
+          break;
         }
       }
     }
-    if (pPathTraceFn)
-      pPathTraceFn->release();
-  } else {
-    cleanupLibraryResources();
-    throw std::runtime_error("Failed to load path tracing kernel function");
+  }
+  if (pPathTraceFn) {
+    pPathTraceFn->release();
+    pPathTraceFn = nullptr;
   }
 
   pError = nullptr;
-  MTL::Function *pAdaptiveFn = pLibrary->newFunction(
+  pAdaptiveFn = pLibrary->newFunction(
       NS::String::string("adaptiveSamplingMain", UTF8StringEncoding));
   if (pAdaptiveFn) {
     _pAdaptiveSamplingPSO =
         _pDevice->newComputePipelineState(pAdaptiveFn, &pError);
     if (!_pAdaptiveSamplingPSO && pError) {
-      __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
+      logShaderDiagnostic("Failed to create adaptive sampling pipeline state",
+                          pError);
     }
-    if (pAdaptiveFn)
-      pAdaptiveFn->release();
-  }
-
-  if (!_pPathTracePSO) {
-    cleanupLibraryResources();
-    throw std::runtime_error("Failed to create path tracing pipeline state");
+    pAdaptiveFn->release();
+    pAdaptiveFn = nullptr;
   }
 
   _shadersReady = _pPSO && _pPathTracePSO;
+  result.success = _shadersReady;
   cleanupLibraryResources();
+  return result;
 }
 
 void Renderer::updateVisibleScene() {

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -86,11 +86,16 @@ class Renderer {
   friend struct ResidentObjectGpuResources;
 
 public:
+  struct ShaderBuildResult {
+    bool success = false;
+    std::string message;
+  };
+
   Renderer(MTL::Device *pDevice);
   ~Renderer();
 
   void updateVisibleScene();
-  void buildShaders();
+  ShaderBuildResult buildShaders();
   void buildTextures();
 
   void recalculateViewport();


### PR DESCRIPTION
## Summary
- route shader build diagnostics through stderr and flush immediately
- return structured shader build status instead of throwing exceptions and clean up temporary resources
- ensure renderer initialization observes shader build failures without touching invalid pipelines

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f8ce9be9d0832d86b1761fddf18834