### PR TITLE
Handle shader initialization failures cleanly

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -809,8 +809,9 @@ Renderer::Renderer(MTL::Device *pDevice)
   _observerCameraState = _primaryCameraState;
 
   updateVisibleScene();
-  ShaderBuildResult shaderStatus = buildShaders();
-  if (!shaderStatus.success && shaderStatus.message.empty())
+  _lastShaderBuildResult = buildShaders();
+  if (!_lastShaderBuildResult.success &&
+      _lastShaderBuildResult.message.empty())
     writeToStderr("Renderer shader build failed with no diagnostic message.");
   buildTextures();
 
@@ -909,6 +910,9 @@ Renderer::~Renderer() {
 }
 
 void Renderer::setBenchmarkMode(bool enabled) {
+  if (!_lastShaderBuildResult.success)
+    return;
+
   if (enabled == _benchmarkEnabled)
     return;
 
@@ -947,6 +951,9 @@ void Renderer::setFrameCaptureInterval(size_t interval) {
 }
 
 void Renderer::initializeBenchmarking() {
+  if (!_lastShaderBuildResult.success)
+    return;
+
   const char *primaryEnv = std::getenv("METALPT_BENCH");
   const char *legacyEnv = std::getenv("METALAPT_BENCH");
   const char *env = primaryEnv ? primaryEnv : legacyEnv;
@@ -966,6 +973,9 @@ void Renderer::initializeBenchmarking() {
 }
 
 void Renderer::ensureBenchmarkStream() {
+  if (!_lastShaderBuildResult.success)
+    return;
+
   if (!_benchmarkEnabled)
     return;
   if (_benchmarkStream.is_open())
@@ -996,6 +1006,9 @@ void Renderer::ensureBenchmarkStream() {
 }
 
 void Renderer::writeBenchmarkHeader() {
+  if (!_lastShaderBuildResult.success)
+    return;
+
   if (!_benchmarkStream.is_open())
     return;
   if (_benchmarkHeaderWritten)
@@ -1026,6 +1039,9 @@ static std::string formatFixed(double value, int precision) {
 }
 
 void Renderer::writeBenchmarkRow(const BenchmarkSample &sample) {
+  if (!_lastShaderBuildResult.success)
+    return;
+
   if (!_benchmarkStream.is_open())
     return;
 
@@ -1363,7 +1379,8 @@ Renderer::ShaderBuildResult Renderer::buildShaders() {
   if (!pLibrary) {
     result.message = logShaderFailure("Failed to load Metal library");
     cleanupLibraryResources();
-    return result;
+    _lastShaderBuildResult = result;
+    return _lastShaderBuildResult;
   }
 
   pVertexFn = pLibrary->newFunction(
@@ -1375,7 +1392,8 @@ Renderer::ShaderBuildResult Renderer::buildShaders() {
   if (!pVertexFn || !pFragFn || !pDesc) {
     result.message = logShaderFailure("Failed to create shader functions");
     cleanupLibraryResources();
-    return result;
+    _lastShaderBuildResult = result;
+    return _lastShaderBuildResult;
   }
 
   pDesc->setVertexFunction(pVertexFn);
@@ -1389,7 +1407,8 @@ Renderer::ShaderBuildResult Renderer::buildShaders() {
         logShaderFailure("Failed to create present pipeline state", pError);
     pError = nullptr;
     cleanupLibraryResources();
-    return result;
+    _lastShaderBuildResult = result;
+    return _lastShaderBuildResult;
   }
 
   if (pVertexFn) {
@@ -1445,7 +1464,8 @@ Renderer::ShaderBuildResult Renderer::buildShaders() {
     result.message =
         logShaderFailure("Failed to load path tracing kernel function");
     cleanupLibraryResources();
-    return result;
+    _lastShaderBuildResult = result;
+    return _lastShaderBuildResult;
   }
 
   MTL::AutoreleasedComputePipelineReflection reflection = nullptr;
@@ -1470,7 +1490,8 @@ Renderer::ShaderBuildResult Renderer::buildShaders() {
     result.message =
         logShaderFailure("Failed to create path tracing pipeline state", pError);
     cleanupLibraryResources();
-    return result;
+    _lastShaderBuildResult = result;
+    return _lastShaderBuildResult;
   }
 
   if (_pPathTracePSO && reflection) {
@@ -1516,7 +1537,12 @@ Renderer::ShaderBuildResult Renderer::buildShaders() {
   _shadersReady = _pPSO && _pPathTracePSO;
   result.success = _shadersReady;
   cleanupLibraryResources();
-  return result;
+  _lastShaderBuildResult = result;
+  return _lastShaderBuildResult;
+}
+
+const Renderer::ShaderBuildResult &Renderer::shaderBuildStatus() const {
+  return _lastShaderBuildResult;
 }
 
 void Renderer::updateVisibleScene() {

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -96,6 +96,7 @@ public:
 
   void updateVisibleScene();
   ShaderBuildResult buildShaders();
+  const ShaderBuildResult &shaderBuildStatus() const;
   void buildTextures();
 
   void recalculateViewport();
@@ -196,6 +197,7 @@ private:
   MTL::ComputePipelineState *_pPathTracePSO = nullptr;
   MTL::ComputePipelineState *_pAdaptiveSamplingPSO = nullptr;
   bool _shadersReady = false;
+  ShaderBuildResult _lastShaderBuildResult{};
 
   // Core scene and geometry data
   Scene *_pScene = nullptr;

--- a/MetalCpp Path Tracer/Window/ViewDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.cpp
@@ -14,6 +14,19 @@ using namespace MetalCppPathTracer;
 ViewDelegate::ViewDelegate(MTL::Device *pDevice)
     : MTK::ViewDelegate(), _pRenderer(new Renderer(pDevice)),
       _lastTime(std::chrono::steady_clock::now()) {
+  if (_pRenderer) {
+    const Renderer::ShaderBuildResult &status =
+        _pRenderer->shaderBuildStatus();
+    _rendererReady = status.success;
+    if (!_rendererReady) {
+      std::string message = status.message;
+      if (message.empty())
+        message = "Renderer shader build failed without a diagnostic message.";
+      std::fprintf(stderr, "Renderer initialization failed: %s\n", message.c_str());
+      std::fflush(stderr);
+    }
+  }
+
   if (const char *env = std::getenv("MPT_MAX_FRAMES"))
     _maxFrames = std::strtoul(env, nullptr, 10);
   if (const char *runs = std::getenv("MPT_RUNS_PATH")) {
@@ -54,8 +67,10 @@ ViewDelegate::ViewDelegate(MTL::Device *pDevice)
       captureInterval = parsed;
   }
 
-  _pRenderer->setFrameCaptureEnabled(captureEnabled);
-  _pRenderer->setFrameCaptureInterval(captureInterval);
+  if (_rendererReady && _pRenderer) {
+    _pRenderer->setFrameCaptureEnabled(captureEnabled);
+    _pRenderer->setFrameCaptureInterval(captureInterval);
+  }
 }
 
 ViewDelegate::~ViewDelegate() {
@@ -72,8 +87,11 @@ void ViewDelegate::drawInMTKView(MTK::View *pView) {
       std::chrono::duration<double>(current - _lastTime).count();
   if (deltaSeconds <= 0.0)
     deltaSeconds = std::numeric_limits<double>::min();
-  double fps = 1.0 / deltaSeconds;
   _lastTime = current;
+  if (!_rendererReady || !_pRenderer)
+    return;
+
+  double fps = 1.0 / deltaSeconds;
   updateFPS(fps);
   updateMemoryUsage(_pRenderer->currentGPUMemoryMB());
   _pRenderer->setDeltaTime(deltaSeconds);
@@ -108,5 +126,7 @@ void ViewDelegate::drawInMTKView(MTK::View *pView) {
 }
 
 void ViewDelegate::drawableSizeWillChange(MTK::View *pView, CGSize size) {
+  if (!_rendererReady || !_pRenderer)
+    return;
   _pRenderer->drawableSizeWillChange(pView, size);
 }

--- a/MetalCpp Path Tracer/Window/ViewDelegate.h
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.h
@@ -27,6 +27,7 @@ private:
   std::string _dumpPath;
   std::ofstream _gpuMemLog;
   std::ofstream _perfLog;
+  bool _rendererReady = false;
 };
 
 }; // namespace MetalCppPathTracer


### PR DESCRIPTION
## Summary
- persist the last shader build result in `Renderer` and expose it via a const accessor for other subsystems
- gate benchmark-related setup on successful shader compilation and keep the most recent build status available for diagnostics
- have `ViewDelegate` detect renderer initialization failures, log them, and skip rendering callbacks until shaders are usable

## Testing
- not run (macOS tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f8d7d99974832d95fe23d7504c2b72