### PR TITLE
Use Metal textures for material sampling

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -139,6 +139,7 @@ struct TileDispatchRegion {
 
 constexpr uint32_t kPathTraceTileWidth = 128;
 constexpr uint32_t kPathTraceTileHeight = 128;
+constexpr uint32_t kMaxMaterialTextureSlots = 64;
 
 inline uint32_t bitm_random() {
   static uint32_t current_seed = 92407235;
@@ -749,10 +750,7 @@ Renderer::~Renderer() {
     _pGeometryHandleBuffer->release();
   if (_pFrustumVertexBuffer)
     _pFrustumVertexBuffer->release();
-  if (_pTextureInfoBuffer)
-    _pTextureInfoBuffer->release();
-  if (_pTextureDataBuffer)
-    _pTextureDataBuffer->release();
+  clearMaterialTextures();
 
   _cachedInstanceDescriptors.clear();
   _cachedInstancedAccelerationStructures.clear();
@@ -2425,6 +2423,8 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       }
     }
 
+    rebuildMaterialTextures();
+
     _pScene->createTriangleBuffers(_cachedTriangleVertices,
                                    _cachedTriangleIndices);
 
@@ -2570,9 +2570,6 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       &_cachedTriangleVertices;
   const std::vector<simd::uint3> *triangleIndexSource =
       &_cachedTriangleIndices;
-  const std::vector<TextureInfo> *textureInfoSource = &_cachedTextureInfos;
-  const std::vector<simd::float4> *textureDataSource = &_cachedTextureData;
-
   if (!useCompaction) {
     remapUpload.resize(totalPrimitiveCount);
     for (size_t i = 0; i < totalPrimitiveCount; ++i) {
@@ -3239,44 +3236,6 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
                          NS::Range::Make(0, indexBytes));
     }
 
-    size_t textureInfoCount = std::max<size_t>(textureInfoSource->size(),
-                                               size_t(1));
-    size_t textureInfoBytes = textureInfoCount * sizeof(TextureInfo);
-    ensureBufferCapacity(_pTextureInfoBuffer, textureInfoBytes,
-                         _textureInfoBufferCapacity, allowShrink);
-    if (_pTextureInfoBuffer) {
-      auto *dst = static_cast<TextureInfo *>(_pTextureInfoBuffer->contents());
-      if (textureInfoSource->empty()) {
-        dst[0] = TextureInfo{};
-      } else {
-        std::memcpy(dst, textureInfoSource->data(),
-                    textureInfoSource->size() * sizeof(TextureInfo));
-        if (textureInfoSource->size() < textureInfoCount)
-          dst[textureInfoSource->size()] = TextureInfo{};
-      }
-      markBufferModified(_pTextureInfoBuffer,
-                         NS::Range::Make(0, textureInfoBytes));
-    }
-
-    size_t textureDataCount = std::max<size_t>(textureDataSource->size(),
-                                               size_t(1));
-    size_t textureDataBytes = textureDataCount * sizeof(simd::float4);
-    ensureBufferCapacity(_pTextureDataBuffer, textureDataBytes,
-                         _textureDataBufferCapacity, allowShrink);
-    if (_pTextureDataBuffer) {
-      auto *dst = static_cast<simd::float4 *>(_pTextureDataBuffer->contents());
-      if (textureDataSource->empty()) {
-        dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 1.0f};
-      } else {
-        std::memcpy(dst, textureDataSource->data(),
-                    textureDataSource->size() * sizeof(simd::float4));
-        if (textureDataSource->size() < textureDataCount)
-          dst[textureDataSource->size()] = simd::float4{0.0f, 0.0f, 0.0f, 1.0f};
-      }
-      markBufferModified(_pTextureDataBuffer,
-                         NS::Range::Make(0, textureDataBytes));
-    }
-
     _residentBuffersInitialized = true;
   }
 
@@ -3649,6 +3608,98 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
     blit->endEncoding();
 }
 
+void Renderer::clearMaterialTextures() {
+  for (MTL::Texture *texture : _materialTextures) {
+    if (texture)
+      texture->release();
+  }
+  _materialTextures.clear();
+}
+
+void Renderer::rebuildMaterialTextures() {
+  clearMaterialTextures();
+
+  if (!_pDevice)
+    return;
+
+  size_t availableSlots = static_cast<size_t>(kMaxMaterialTextureSlots);
+  size_t requestedTextures = _cachedTextureInfos.size();
+  if (requestedTextures > availableSlots) {
+    std::printf(
+        "[Renderer] Truncating material textures from %zu to %u to fit shader "
+        "bind slots.\n",
+        requestedTextures, kMaxMaterialTextureSlots);
+  }
+
+  size_t maxTextures = std::min(requestedTextures, availableSlots);
+  size_t totalTexels = _cachedTextureData.size();
+  _materialTextures.reserve(maxTextures);
+
+  auto createFallbackTexture = [&]() -> MTL::Texture * {
+    MTL::TextureDescriptor *descriptor = MTL::TextureDescriptor::alloc()->init();
+    descriptor->setTextureType(MTL::TextureType::TextureType2D);
+    descriptor->setPixelFormat(MTL::PixelFormat::PixelFormatRGBA32Float);
+    descriptor->setWidth(1);
+    descriptor->setHeight(1);
+    descriptor->setUsage(MTL::TextureUsage::TextureUsageShaderRead);
+    descriptor->setStorageMode(MTL::StorageMode::StorageModeManaged);
+
+    MTL::Texture *texture = _pDevice->newTexture(descriptor);
+    descriptor->release();
+    if (!texture)
+      return nullptr;
+
+    simd::float4 pixel = simd::float4{1.0f, 1.0f, 1.0f, 1.0f};
+    NS::UInteger bytesPerRow = sizeof(simd::float4);
+    MTL::Region region = MTL::Region::Make2D(0, 0, 1, 1);
+    texture->replaceRegion(region, 0, &pixel, bytesPerRow);
+    return texture;
+  };
+
+  for (size_t texIndex = 0; texIndex < maxTextures; ++texIndex) {
+    const TextureInfo &info = _cachedTextureInfos[texIndex];
+    size_t texelCount = static_cast<size_t>(info.width) * info.height;
+    bool hasValidDimensions = info.width > 0 && info.height > 0;
+    bool hasValidRange = info.offset < totalTexels &&
+                         texelCount > 0 &&
+                         info.offset + texelCount <= totalTexels;
+
+    if (!hasValidDimensions || !hasValidRange) {
+      MTL::Texture *fallback = createFallbackTexture();
+      _materialTextures.push_back(fallback);
+      continue;
+    }
+
+    MTL::TextureDescriptor *descriptor = MTL::TextureDescriptor::alloc()->init();
+    descriptor->setTextureType(MTL::TextureType::TextureType2D);
+    descriptor->setPixelFormat(MTL::PixelFormat::PixelFormatRGBA32Float);
+    descriptor->setWidth(info.width);
+    descriptor->setHeight(info.height);
+    descriptor->setUsage(MTL::TextureUsage::TextureUsageShaderRead);
+    descriptor->setStorageMode(MTL::StorageMode::StorageModeManaged);
+
+    MTL::Texture *texture = _pDevice->newTexture(descriptor);
+    descriptor->release();
+
+    if (!texture) {
+      std::printf(
+          "[Renderer] Failed to allocate material texture %zu (%ux%u).\n",
+          texIndex, info.width, info.height);
+      MTL::Texture *fallback = createFallbackTexture();
+      _materialTextures.push_back(fallback);
+      continue;
+    }
+
+    const simd::float4 *src = _cachedTextureData.data() + info.offset;
+    NS::UInteger bytesPerRow =
+        static_cast<NS::UInteger>(info.width * sizeof(simd::float4));
+    MTL::Region region = MTL::Region::Make2D(0, 0, info.width, info.height);
+    texture->replaceRegion(region, 0, src, bytesPerRow);
+
+    _materialTextures.push_back(texture);
+  }
+}
+
 void Renderer::buildTextures() {
   NS::UInteger width = std::max<NS::UInteger>(
       1, static_cast<NS::UInteger>(Camera::screenSize.x));
@@ -3874,7 +3925,9 @@ void Renderer::updateUniforms(bool cameraChanged) {
   u.sampleImportanceTextureIndex = 3;
   u.minSamplesPerPixel = minSamples;
   u.maxSamplesPerPixel = maxSamples;
-  u.textureCount = static_cast<uint32_t>(_cachedTextureInfos.size());
+  size_t boundTextureCount = std::min(
+      _materialTextures.size(), static_cast<size_t>(kMaxMaterialTextureSlots));
+  u.textureCount = static_cast<uint32_t>(boundTextureCount);
 
   uint64_t residentPrimitiveCount = _residentPrimitiveCount;
   uint64_t residentTriangleCount = _residentTriangleCount;
@@ -4075,8 +4128,6 @@ void Renderer::draw(MTK::View *pView) {
         pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 8);
         pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 9);
         pCompute->setBuffer(_pInstanceBuffer, 0, 10);
-        pCompute->setBuffer(_pTextureInfoBuffer, 0, 14);
-        pCompute->setBuffer(_pTextureDataBuffer, 0, 15);
       } else {
         pCompute->setBuffer(_pBVHBuffer, 0, 0);
         pCompute->setBuffer(_pSphereBuffer, 0, 1);
@@ -4092,14 +4143,19 @@ void Renderer::draw(MTK::View *pView) {
         pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
         pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
         pCompute->setBuffer(_pInstanceBuffer, 0, 13);
-        pCompute->setBuffer(_pTextureInfoBuffer, 0, 14);
-        pCompute->setBuffer(_pTextureDataBuffer, 0, 15);
       }
 
       pCompute->setTexture(accum0, 0);
       pCompute->setTexture(accum1, 1);
       pCompute->setTexture(sampleCount, 2);
       pCompute->setTexture(sampleImportance, 3);
+
+      for (uint32_t texIdx = 0; texIdx < kMaxMaterialTextureSlots; ++texIdx) {
+        MTL::Texture *materialTex =
+            (texIdx < _materialTextures.size()) ? _materialTextures[texIdx]
+                                                : nullptr;
+        pCompute->setTexture(materialTex, 4 + texIdx);
+      }
 
       TileDispatchRegion tileParams = tile;
       pCompute->setBytes(&tileParams, sizeof(TileDispatchRegion), 16);

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -155,6 +155,8 @@ private:
       const std::vector<MTL::AccelerationStructure *> &structures);
   void updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd);
   bool resetAccumulationTargets(MTL::CommandBuffer *cmd);
+  void rebuildMaterialTextures();
+  void clearMaterialTextures();
   void initializeBenchmarking();
   void ensureBenchmarkStream();
   void writeBenchmarkHeader();
@@ -200,8 +202,6 @@ private:
   MTL::Buffer *_pTlasInstanceDescriptorBuffer = nullptr;
   MTL::Buffer *_pGeometryHandleBuffer = nullptr;
   MTL::Buffer *_pFrustumVertexBuffer = nullptr;
-  MTL::Buffer *_pTextureInfoBuffer = nullptr;
-  MTL::Buffer *_pTextureDataBuffer = nullptr;
   size_t _blasNodeCount = 0;
   size_t _tlasNodeCount = 0;
   size_t _activeNodeCount = 0;
@@ -333,6 +333,7 @@ private:
   std::vector<simd::uint3> _cachedTriangleIndices;
   std::vector<TextureInfo> _cachedTextureInfos;
   std::vector<simd::float4> _cachedTextureData;
+  std::vector<MTL::Texture *> _materialTextures;
   std::vector<uint32_t> _cachedLightIndices;
   std::vector<float> _cachedLightCdf;
 
@@ -356,8 +357,6 @@ private:
   size_t _sphereMaterialBufferCapacity = 0;
   size_t _triangleVertexBufferCapacity = 0;
   size_t _triangleIndexBufferCapacity = 0;
-  size_t _textureInfoBufferCapacity = 0;
-  size_t _textureDataBufferCapacity = 0;
   size_t _bvhBufferCapacity = 0;
   size_t _tlasBufferCapacity = 0;
   size_t _primitiveIndexBufferCapacity = 0;

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -19,12 +19,12 @@ kernel void pathTraceKernel(
     device const uint *primitiveRemap [[buffer(11)]],
     device atomic_uint *primitiveHitCounts [[buffer(12)]],
     device const InstanceRecord *instanceRecords [[buffer(13)]],
-    device const PackedTexture *textureInfos [[buffer(14)]],
-    device const float4 *textureData [[buffer(15)]],
     texture2d<half, access::read> lastFrame [[texture(0)]],
     texture2d<half, access::write> currentFrame [[texture(1)]],
     texture2d<half, access::read_write> sampleCount [[texture(2)]],
     texture2d<half, access::read> sampleImportance [[texture(3)]],
+    array<texture2d<float, access::sample>, kMaxMaterialTextures>
+        materialTextures [[texture(4)]],
     constant TileRegion &tile [[buffer(16)]],
     uint2 gid [[thread_position_in_grid]]) {
   if (!uniforms)
@@ -90,7 +90,7 @@ kernel void pathTraceKernel(
                                  primitiveRemap, primitiveHitCounts, seed, u.maxRayDepth,
                                  u.debugAS, u.blasNodeCount, u.lightCount,
                                  u.lightTotalWeight, static_cast<uint>(u.totalPrimitiveCount),
-                                 textureInfos, textureData, u.textureCount);
+                                 materialTextures, u.textureCount);
   }
 
   float totalSamples = previousSampleCount + float(samplesThisFrame);

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -10,6 +10,9 @@ using namespace metal;
 
 constant uint kMaterialFloat4Count = 5;
 constant uint kPrimitiveFloat4Count = 4;
+constant uint kMaxMaterialTextures = 64;
+
+constexpr sampler kMaterialTextureSampler(address::repeat, filter::linear);
 
 struct Ray {
   float3 origin;
@@ -93,42 +96,25 @@ inline MaterialPayload decodeMaterial(int baseIndex,
   return payload;
 }
 
+template <typename TextureArray>
 inline float4 samplePackedTexture(int index, float2 uv,
-                                  device const PackedTexture *textures,
-                                  device const float4 *textureData,
+                                  thread const TextureArray &textures,
                                   uint textureCount) {
-  if (index < 0 || textures == nullptr || textureData == nullptr)
+  if (index < 0)
     return float4(1.0f);
+
   uint texIndex = uint(index);
   if (texIndex >= textureCount)
     return float4(1.0f);
 
-  PackedTexture tex = textures[texIndex];
-  if (tex.width == 0 || tex.height == 0)
+  texture2d<float, access::sample> tex = textures[texIndex];
+  uint width = tex.get_width();
+  uint height = tex.get_height();
+  if (width == 0 || height == 0)
     return float4(1.0f);
 
   float2 coord = float2(uv.x - floor(uv.x), uv.y - floor(uv.y));
-  float sx = coord.x * (float(tex.width) - 1.0f);
-  float sy = coord.y * (float(tex.height) - 1.0f);
-  int x0 = clamp(int(floor(sx)), 0, int(tex.width - 1));
-  int y0 = clamp(int(floor(sy)), 0, int(tex.height - 1));
-  int x1 = min(x0 + 1, int(tex.width - 1));
-  int y1 = min(y0 + 1, int(tex.height - 1));
-  float fx = sx - float(x0);
-  float fy = sy - float(y0);
-
-  auto texelAt = [&](int x, int y) -> float4 {
-    uint offset = tex.offset + uint(y) * tex.width + uint(x);
-    return textureData[offset];
-  };
-
-  float4 c00 = texelAt(x0, y0);
-  float4 c10 = texelAt(x1, y0);
-  float4 c01 = texelAt(x0, y1);
-  float4 c11 = texelAt(x1, y1);
-  float4 c0 = mix(c00, c10, fx);
-  float4 c1 = mix(c01, c11, fx);
-  return mix(c0, c1, fy);
+  return tex.sample(kMaterialTextureSampler, coord, level(0.0f));
 }
 
 inline uint selectLightOffset(float xi, device const float *lightCdf,
@@ -494,6 +480,7 @@ inline intersection firstHitTLAS(
   return bestHit;
 }
 
+template <typename TextureArray>
 inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
                        device const float4 *tlasNodes,
                        uint tlasNodeCount, device const float4 *bvhNodes,
@@ -509,8 +496,7 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
                        thread uint32_t &seed, uint maxRayDepth,
                        uint debugAS, uint blasNodeCount, uint lightCount,
                        float lightTotalWeight, uint totalPrimitiveCount,
-                       device const PackedTexture *textures,
-                       device const float4 *textureData,
+                       thread const TextureArray &textures,
                        uint textureCount) {
   float footprint = length(cross(rayDx, rayDy));
   float lodAtten = 1.0 / (1.0 + footprint);
@@ -607,15 +593,13 @@ inline float4 rayColor(Ray r, float3 rayDx, float3 rayDy,
     if (haveUV) {
       if (material.diffuseTextureIndex >= 0) {
         float4 sample = samplePackedTexture(material.diffuseTextureIndex,
-                                            surfaceUV, textures, textureData,
-                                            textureCount);
+                                            surfaceUV, textures, textureCount);
         material.diffuseColor *= sample.xyz;
         material.opacity *= clamp(sample.w, 0.0f, 1.0f);
       }
       if (material.specularTextureIndex >= 0) {
         float4 sample = samplePackedTexture(material.specularTextureIndex,
-                                            surfaceUV, textures, textureData,
-                                            textureCount);
+                                            surfaceUV, textures, textureCount);
         material.specularColor *= sample.xyz;
       }
     }


### PR DESCRIPTION
## Summary
- replace the packed texture sampling helpers with hardware-filtered Metal textures
- upload scene material atlases into `MTLTexture` objects and bind them to the path tracing kernel

## Testing
- not run (requires macOS Metal runtime)

------
https://chatgpt.com/codex/tasks/task_e_68f92d931b98832d80472745bc0f8b34