### PR TITLE
Fix texture descriptor usage enum for Metal textures

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -3641,7 +3641,7 @@ void Renderer::rebuildMaterialTextures() {
     descriptor->setPixelFormat(MTL::PixelFormat::PixelFormatRGBA32Float);
     descriptor->setWidth(1);
     descriptor->setHeight(1);
-    descriptor->setUsage(MTL::TextureUsage::TextureUsageShaderRead);
+    descriptor->setUsage(MTL::TextureUsageShaderRead);
     descriptor->setStorageMode(MTL::StorageMode::StorageModeManaged);
 
     MTL::Texture *texture = _pDevice->newTexture(descriptor);
@@ -3675,7 +3675,7 @@ void Renderer::rebuildMaterialTextures() {
     descriptor->setPixelFormat(MTL::PixelFormat::PixelFormatRGBA32Float);
     descriptor->setWidth(info.width);
     descriptor->setHeight(info.height);
-    descriptor->setUsage(MTL::TextureUsage::TextureUsageShaderRead);
+    descriptor->setUsage(MTL::TextureUsageShaderRead);
     descriptor->setStorageMode(MTL::StorageMode::StorageModeManaged);
 
     MTL::Texture *texture = _pDevice->newTexture(descriptor);


### PR DESCRIPTION
## Summary
- fix texture descriptor usage flags in Renderer so they use the correct Metal namespace

## Testing
- xcodebuild -project 'MetalCpp Path Tracer.xcodeproj' -list

------
https://chatgpt.com/codex/tasks/task_e_68f9326f7928832db6dc3676c78bc423