### PR TITLE
Optimize always-resident residency toggles

### DIFF
--- a/MetalCpp Path Tracer/Renderer/AlwaysResidentCache.h
+++ b/MetalCpp Path Tracer/Renderer/AlwaysResidentCache.h
@@ -1,0 +1,45 @@
+#ifndef ALWAYS_RESIDENT_CACHE_H
+#define ALWAYS_RESIDENT_CACHE_H
+
+#include <cstddef>
+
+namespace MetalCppPathTracer {
+
+struct AlwaysResidentCache {
+  bool dirty = true;
+  size_t lastPrimitiveCount = 0;
+  size_t lastObjectCount = 0;
+
+  void reset() {
+    dirty = true;
+    lastPrimitiveCount = 0;
+    lastObjectCount = 0;
+  }
+
+  void markDirty() { dirty = true; }
+
+  bool needsUpdate(bool forceAllToggles, size_t primitiveCount,
+                   size_t objectCount, bool hasRecentChanges) const {
+    if (forceAllToggles)
+      return true;
+    if (dirty)
+      return true;
+    if (primitiveCount != lastPrimitiveCount ||
+        objectCount != lastObjectCount)
+      return true;
+    if (hasRecentChanges)
+      return true;
+    return false;
+  }
+
+  void markUpdated(size_t primitiveCount, size_t objectCount) {
+    dirty = false;
+    lastPrimitiveCount = primitiveCount;
+    lastObjectCount = objectCount;
+  }
+};
+
+} // namespace MetalCppPathTracer
+
+#endif // ALWAYS_RESIDENT_CACHE_H
+

--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1392,6 +1392,8 @@ void Renderer::updateVisibleScene() {
   }
   printf("Active primitive residency strategy: %s\n", strategyName);
 
+  _alwaysResidentCache.reset();
+
   // Store full primitive list and initialize tracking
   _allPrimitives = _pScene->getPrimitives();
   size_t primCount = _allPrimitives.size();
@@ -4307,7 +4309,13 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   _framePrimitiveDeactivations = 0;
   _frameObjectActivations = 0;
   _frameObjectDeactivations = 0;
-  _frameStrategy = _pScene->getResidencyStrategy();
+  ResidencyStrategy strategy = _pScene->getResidencyStrategy();
+  if (strategy != _lastResidencyStrategy) {
+    if (strategy == ResidencyStrategy::AlwaysResident)
+      _alwaysResidentCache.markDirty();
+    _lastResidencyStrategy = strategy;
+  }
+  _frameStrategy = strategy;
 
   for (uint32_t &cooldown : _primitiveCooldown)
     if (cooldown > 0)
@@ -4319,7 +4327,7 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
     --_compactionCooldown;
 
   bool changed = false;
-  switch (_pScene->getResidencyStrategy()) {
+  switch (strategy) {
   case ResidencyStrategy::EnergyImportance:
     changed = updateEnergyImportance(forceAllToggles);
     break;
@@ -4342,18 +4350,28 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
     flushResidencyChanges(forceFullRebuild);
 }
 
-bool Renderer::updateAlwaysResident(bool /*forceAllToggles*/) {
+bool Renderer::updateAlwaysResident(bool forceAllToggles) {
+  size_t primitiveCount = _activePrimitive.size();
+  size_t objectCount = _allSceneObjects.size();
+  bool hasRecentChanges = !_recentlyActivated.empty() || !_recentlyDeactivated.empty();
+
   bool changed = false;
 
-  for (size_t objectIndex = 0; objectIndex < _allSceneObjects.size(); ++objectIndex) {
-    size_t toggled = setObjectActive(objectIndex, true);
-    if (toggled > 0)
-      changed = true;
-  }
+  if (_alwaysResidentCache.needsUpdate(forceAllToggles, primitiveCount,
+                                       objectCount, hasRecentChanges)) {
+    for (size_t objectIndex = 0; objectIndex < _allSceneObjects.size();
+         ++objectIndex) {
+      size_t toggled = setObjectActive(objectIndex, true);
+      if (toggled > 0)
+        changed = true;
+    }
 
-  for (size_t primIndex = 0; primIndex < _activePrimitive.size(); ++primIndex) {
-    if (setPrimitiveActive(primIndex, true))
-      changed = true;
+    for (size_t primIndex = 0; primIndex < _activePrimitive.size(); ++primIndex) {
+      if (setPrimitiveActive(primIndex, true))
+        changed = true;
+    }
+
+    _alwaysResidentCache.markUpdated(primitiveCount, objectCount);
   }
 
   bool anyInactivePrimitive =
@@ -5664,6 +5682,8 @@ bool Renderer::setPrimitiveActive(size_t index, bool active) {
     ++_framePrimitiveActivations;
   else
     ++_framePrimitiveDeactivations;
+  if (!active)
+    _alwaysResidentCache.markDirty();
   auto &cancelList = active ? _recentlyDeactivated : _recentlyActivated;
   cancelList.erase(
       std::remove(cancelList.begin(), cancelList.end(), index),

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <memory>
 
+#include "AlwaysResidentCache.h"
 #include "GpuHeapResources.h"
 #include "Camera.h"
 #include "Scene.h"
@@ -393,6 +394,8 @@ private:
   size_t _frameObjectActivations = 0;
   size_t _frameObjectDeactivations = 0;
   ResidencyStrategy _frameStrategy = ResidencyStrategy::DistanceLOD;
+  ResidencyStrategy _lastResidencyStrategy = ResidencyStrategy::DistanceLOD;
+  AlwaysResidentCache _alwaysResidentCache;
   bool _frameCaptureEnabled = false;
   size_t _frameCaptureInterval = 4;
   uint64_t _renderedFrameCount = 0;

--- a/tests/AlwaysResidentCacheTests.cpp
+++ b/tests/AlwaysResidentCacheTests.cpp
@@ -1,0 +1,32 @@
+#include "MetalCpp Path Tracer/Renderer/AlwaysResidentCache.h"
+
+#include <cassert>
+
+using MetalCppPathTracer::AlwaysResidentCache;
+
+int main() {
+  AlwaysResidentCache cache;
+
+  assert(cache.needsUpdate(false, 0, 0, false));
+
+  cache.markUpdated(5, 3);
+  assert(!cache.needsUpdate(false, 5, 3, false));
+
+  assert(cache.needsUpdate(false, 6, 3, false));
+  cache.markUpdated(6, 3);
+
+  assert(cache.needsUpdate(false, 6, 2, false));
+  cache.markUpdated(6, 2);
+
+  cache.markDirty();
+  assert(cache.needsUpdate(false, 6, 2, false));
+  cache.markUpdated(6, 2);
+
+  assert(cache.needsUpdate(false, 6, 2, true));
+  cache.markUpdated(6, 2);
+
+  assert(cache.needsUpdate(true, 6, 2, false));
+
+  return 0;
+}
+


### PR DESCRIPTION
## Summary
- add an AlwaysResidentCache helper to track when the always-resident residency pass needs to re-run
- integrate the cache with the renderer to avoid redundant activation loops while still reacting to strategy or scene changes
- add a lightweight unit test covering the cache invalidation logic

## Testing
- g++ tests/AlwaysResidentCacheTests.cpp -std=c++17 -I. -o tests/always_resident_cache_tests
- ./tests/always_resident_cache_tests


------
https://chatgpt.com/codex/tasks/task_e_68f93785338c832d9fb81144fd4b29c4