### PR TITLE
Fix node residency console logging

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -6154,9 +6154,9 @@ void Renderer::completeFrameMetrics(MTL::CommandBuffer *pCmd) {
   size_t offloaded = _totalNodeCount > _residentNodeCount ?
                          _totalNodeCount - _residentNodeCount :
                          0;
-  printf("Resident nodes: %zu offloaded: %zu CPU: %.3f ms GPU: %.3f ms Rays/s: %.2f\n",
-         _activeNodeCount, offloaded, _lastCPUTime * 1000.0,
-         _lastGPUTime * 1000.0, _lastRaysPerSecond);
+  printf("Active nodes: %zu resident: %zu offloaded: %zu CPU: %.3f ms GPU: %.3f ms Rays/s: %.2f\n",
+         _activeNodeCount, _residentNodeCount, offloaded,
+         _lastCPUTime * 1000.0, _lastGPUTime * 1000.0, _lastRaysPerSecond);
 
   const auto &profile = _residencyProfiling;
   if (profile.lodSortCount > 0 || profile.lodScratchResizes > 0 ||


### PR DESCRIPTION
## Summary
- correct the console output of node residency stats so that the resident count reflects the tracked resident nodes
- include the active node count in the log message for clarity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f951affb70832d878006be3beda4e3