### PR TITLE
Optimize compute dispatch by reusing encoder

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -4205,79 +4205,77 @@ void Renderer::draw(MTK::View *pView) {
     MTL::Size threadsPerThreadgroup =
         MTL::Size::Make(tgWidth, tgHeight, 1);
 
-    for (const TileDispatchRegion &tile : tiles) {
-      MTL::CommandBuffer *tileCmd = _pCommandQueue->commandBuffer();
-      if (!tileCmd)
-        continue;
+    MTL::CommandBuffer *computeCmd = _pCommandQueue->commandBuffer();
+    if (computeCmd) {
+      MTL::ComputeCommandEncoder *pCompute = computeCmd->computeCommandEncoder();
+      if (pCompute) {
+        pCompute->setComputePipelineState(_pPathTracePSO);
 
-      MTL::ComputeCommandEncoder *pCompute = tileCmd->computeCommandEncoder();
-      if (!pCompute) {
-        tileCmd->commit();
-        continue;
+        bool useAccelerationStructureLayout =
+            _useAccelerationStructureBindings && _pTlasStructure &&
+            _pGeometryHandleBuffer;
+
+        if (useAccelerationStructureLayout) {
+          pCompute->setAccelerationStructure(_pTlasStructure, 0);
+          pCompute->setBuffer(_pGeometryHandleBuffer, 0, 1);
+          pCompute->setBuffer(_pSphereBuffer, 0, 2);
+          pCompute->setBuffer(_pSphereMaterialBuffer, 0, 3);
+          pCompute->setBuffer(_pUniformsBuffer, 0, 4);
+          pCompute->setBuffer(_pActiveBuffer, 0, 5);
+          pCompute->setBuffer(_pLightIndexBuffer, 0, 6);
+          pCompute->setBuffer(_pLightCdfBuffer, 0, 7);
+          pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 8);
+          pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 9);
+          pCompute->setBuffer(_pInstanceBuffer, 0, 10);
+        } else {
+          pCompute->setBuffer(_pBVHBuffer, 0, 0);
+          pCompute->setBuffer(_pSphereBuffer, 0, 1);
+          pCompute->setBuffer(_pSphereMaterialBuffer, 0, 2);
+          pCompute->setBuffer(_pUniformsBuffer, 0, 3);
+          pCompute->setBuffer(_pTriangleVertexBuffer, 0, 4);
+          pCompute->setBuffer(_pTriangleIndexBuffer, 0, 5);
+          pCompute->setBuffer(_pPrimitiveIndexBuffer, 0, 6);
+          pCompute->setBuffer(_pTLASBuffer, 0, 7);
+          pCompute->setBuffer(_pActiveBuffer, 0, 8);
+          pCompute->setBuffer(_pLightIndexBuffer, 0, 9);
+          pCompute->setBuffer(_pLightCdfBuffer, 0, 10);
+          pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
+          pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
+          pCompute->setBuffer(_pInstanceBuffer, 0, 13);
+        }
+
+        pCompute->setTexture(accum0, 0);
+        pCompute->setTexture(accum1, 1);
+        pCompute->setTexture(sampleCount, 2);
+        pCompute->setTexture(sampleImportance, 3);
+
+        for (uint32_t texIdx = 0; texIdx < kMaxMaterialTextureSlots; ++texIdx) {
+          MTL::Texture *materialTex =
+              (texIdx < _materialTextures.size()) ? _materialTextures[texIdx]
+                                                  : nullptr;
+          pCompute->setTexture(materialTex, 4 + texIdx);
+        }
+
+        for (const TileDispatchRegion &tile : tiles) {
+          TileDispatchRegion tileParams = tile;
+          pCompute->setBytes(&tileParams, sizeof(TileDispatchRegion), 16);
+
+          NS::UInteger localWidth = static_cast<NS::UInteger>(tile.width);
+          NS::UInteger localHeight = static_cast<NS::UInteger>(tile.height);
+          MTL::Size threadgroups = MTL::Size::Make(
+              (localWidth + threadsPerThreadgroup.width - 1) /
+                  threadsPerThreadgroup.width,
+              (localHeight + threadsPerThreadgroup.height - 1) /
+                  threadsPerThreadgroup.height,
+              1);
+
+          pCompute->dispatchThreadgroups(threadgroups, threadsPerThreadgroup);
+        }
+
+        pCompute->endEncoding();
       }
 
-      pCompute->setComputePipelineState(_pPathTracePSO);
-
-      bool useAccelerationStructureLayout =
-          _useAccelerationStructureBindings && _pTlasStructure &&
-          _pGeometryHandleBuffer;
-
-      if (useAccelerationStructureLayout) {
-        pCompute->setAccelerationStructure(_pTlasStructure, 0);
-        pCompute->setBuffer(_pGeometryHandleBuffer, 0, 1);
-        pCompute->setBuffer(_pSphereBuffer, 0, 2);
-        pCompute->setBuffer(_pSphereMaterialBuffer, 0, 3);
-        pCompute->setBuffer(_pUniformsBuffer, 0, 4);
-        pCompute->setBuffer(_pActiveBuffer, 0, 5);
-        pCompute->setBuffer(_pLightIndexBuffer, 0, 6);
-        pCompute->setBuffer(_pLightCdfBuffer, 0, 7);
-        pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 8);
-        pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 9);
-        pCompute->setBuffer(_pInstanceBuffer, 0, 10);
-      } else {
-        pCompute->setBuffer(_pBVHBuffer, 0, 0);
-        pCompute->setBuffer(_pSphereBuffer, 0, 1);
-        pCompute->setBuffer(_pSphereMaterialBuffer, 0, 2);
-        pCompute->setBuffer(_pUniformsBuffer, 0, 3);
-        pCompute->setBuffer(_pTriangleVertexBuffer, 0, 4);
-        pCompute->setBuffer(_pTriangleIndexBuffer, 0, 5);
-        pCompute->setBuffer(_pPrimitiveIndexBuffer, 0, 6);
-        pCompute->setBuffer(_pTLASBuffer, 0, 7);
-        pCompute->setBuffer(_pActiveBuffer, 0, 8);
-        pCompute->setBuffer(_pLightIndexBuffer, 0, 9);
-        pCompute->setBuffer(_pLightCdfBuffer, 0, 10);
-        pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
-        pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
-        pCompute->setBuffer(_pInstanceBuffer, 0, 13);
-      }
-
-      pCompute->setTexture(accum0, 0);
-      pCompute->setTexture(accum1, 1);
-      pCompute->setTexture(sampleCount, 2);
-      pCompute->setTexture(sampleImportance, 3);
-
-      for (uint32_t texIdx = 0; texIdx < kMaxMaterialTextureSlots; ++texIdx) {
-        MTL::Texture *materialTex =
-            (texIdx < _materialTextures.size()) ? _materialTextures[texIdx]
-                                                : nullptr;
-        pCompute->setTexture(materialTex, 4 + texIdx);
-      }
-
-      TileDispatchRegion tileParams = tile;
-      pCompute->setBytes(&tileParams, sizeof(TileDispatchRegion), 16);
-
-      NS::UInteger localWidth = static_cast<NS::UInteger>(tile.width);
-      NS::UInteger localHeight = static_cast<NS::UInteger>(tile.height);
-      MTL::Size threadgroups = MTL::Size::Make(
-          (localWidth + threadsPerThreadgroup.width - 1) /
-              threadsPerThreadgroup.width,
-          (localHeight + threadsPerThreadgroup.height - 1) /
-              threadsPerThreadgroup.height,
-          1);
-
-      pCompute->dispatchThreadgroups(threadgroups, threadsPerThreadgroup);
-      pCompute->endEncoding();
-      tileCmd->commit();
+      computeCmd->commit();
     }
   }
 


### PR DESCRIPTION
## Summary
- reuse a single compute command buffer/encoder for all tile dispatches in `Renderer::draw`
- bind shared buffers and textures once per frame before issuing each tile dispatch

## Testing
- not run (interactive Metal renderer unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f95e803500832d809a526e46898fcd