### PR TITLE
Ensure dirty resident objects rebuild BLAS resources

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -3092,9 +3092,18 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     auto &instanceRecord = _instanceRecords[objectIndex];
 
     if (shouldBeResident) {
+      bool requiresRebuild = needFullUpload;
+      if (!requiresRebuild) {
+        requiresRebuild =
+            std::binary_search(_dirtyResidentObjects.begin(),
+                                _dirtyResidentObjects.end(), objectIndex);
+      }
+      if (!requiresRebuild && !gpuResident.geometryValid)
+        requiresRebuild = true;
+
       bool built = gpuResident.ensureResident(
           *this, objectIndex, sceneObjects[objectIndex], instanceRecord,
-          needFullUpload);
+          requiresRebuild);
       if (!built) {
         shouldBeResident = false;
         objectShouldBeResident[objectIndex] = false;


### PR DESCRIPTION
## Summary
- rebuild a resident object's BLAS when it is marked dirty, even if a full resource upload is unnecessary
- prevent reuse of stale acceleration structures by considering geometry validity and dirty state when deciding to rebuild

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fab6600744832d969d703db930dd03