### PR TITLE
Handle bundled miniz header in tinyexr include

### DIFF
--- a/MetalCpp Path Tracer/tinyexr.h
+++ b/MetalCpp Path Tracer/tinyexr.h
@@ -698,7 +698,15 @@ extern int LoadEXRFromMemory(float **out_rgba, int *width, int *height,
 #endif
 
 #if defined(TINYEXR_USE_MINIZ) && (TINYEXR_USE_MINIZ==1)
+#if defined(__has_include)
+#if __has_include(<miniz.h>)
 #include <miniz.h>
+#else
+#include "miniz.h"
+#endif
+#else
+#include "miniz.h"
+#endif
 #else
 //  Issue #46. Please include your own zlib-compatible API header before
 //  including `tinyexr.h`


### PR DESCRIPTION
## Summary
- allow tinyexr to fall back to including the bundled miniz header when the system header is unavailable

## Testing
- g++ -std=c++17 compare_exr_ssim.cpp -o compare_exr_ssim *(fails: missing miniz symbols when miniz.c is not linked)*

------
https://chatgpt.com/codex/tasks/task_e_68fb3c1f7ccc832da56722d57e285181