### PR TITLE
Rename sample loop counter in path tracing kernel

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -72,7 +72,7 @@ kernel void pathTraceKernel(
   float3 rayDx = u.rayDx;
   float3 rayDy = u.rayDy;
 
-  for (uint sample = 0; sample < samplesThisFrame; ++sample) {
+  for (uint sampleIdx = 0; sampleIdx < samplesThisFrame; ++sampleIdx) {
     float xOff = (randomFloat(seed) - 0.5f) / screenSize.x;
     seed = random(seed);
     float yOff = (randomFloat(seed) - 0.5f) / screenSize.y;


### PR DESCRIPTION
## Summary
- rename the sample accumulation loop counter in `pathTraceKernel`

## Testing
- `xcodebuild -project 'MetalCpp Path Tracer.xcodeproj' -target PathTraceKernel -quiet` *(fails: `xcodebuild` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ff4ecc646c832daa4ec08ed7e6e0b7