### PR TITLE
Fix accumulation buffer reads in path trace kernel

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -108,8 +108,10 @@ kernel void pathTraceKernel(
   float3 averaged = (totalSamples > 0.0f) ? combinedSum / totalSamples : float3(0.0f);
   averaged = clamp(averaged, 0.0f, 1.0f);
 
-  float3 previousAlbedo = float3(albedoAccum.read(pixel));
-  float3 previousNormal = float3(normalAccum.read(pixel));
+  float3 previousAlbedo =
+      float3(float4(albedoAccum.read(pixel)).xyz);
+  float3 previousNormal =
+      float3(float4(normalAccum.read(pixel)).xyz);
   float3 albedoSum = previousAlbedo * previousSampleCount + accumulatedAlbedo;
   float3 normalSum = previousNormal * previousSampleCount + accumulatedNormal;
   float3 averagedAlbedo =


### PR DESCRIPTION
## Summary
- explicitly convert albedo and normal accumulation texture reads to float3

## Testing
- not run (Metal compiler unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ff4fc28458832d9e5404d3dce1b72f