### PR TITLE
Add tangent frames to triangle primitives

### DIFF
--- a/MetalCpp Path Tracer/Renderer/GpuHeapResources.h
+++ b/MetalCpp Path Tracer/Renderer/GpuHeapResources.h
@@ -59,6 +59,8 @@ public:
     return _accelerationSize;
   }
 
+  static NS::UInteger primitiveDataSize(size_t primitiveCount);
+
 private:
   struct BufferInfo {
     MTL::Buffer *buffer = nullptr;

--- a/MetalCpp Path Tracer/Renderer/GpuHeapResources.mm
+++ b/MetalCpp Path Tracer/Renderer/GpuHeapResources.mm
@@ -3,6 +3,8 @@
 #include <Foundation/Foundation.hpp>
 #include <algorithm>
 
+#include "../Scene/Primitive.h"
+
 namespace MetalCppPathTracer {
 
 namespace {
@@ -287,6 +289,15 @@ void GpuHeapResources::tryDestroyHeap() {
   _heap->release();
   _heap = nullptr;
   _heapSize = 0;
+}
+
+NS::UInteger GpuHeapResources::primitiveDataSize(size_t primitiveCount) {
+  if (primitiveCount == 0)
+    return 0;
+  size_t float4Count = primitiveCount * kPrimitiveFloat4Count;
+  const size_t kFloat4Size = sizeof(float) * 4;
+  size_t byteCount = float4Count * kFloat4Size;
+  return static_cast<NS::UInteger>(byteCount);
 }
 
 } // namespace MetalCppPathTracer

--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -2716,6 +2716,10 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       simd::float4 *matBase =
           &_cachedMaterialData[kMaterialFloat4Count * i];
 
+      primBase[4] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+      primBase[5] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+      primBase[6] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+
       switch (p.type) {
       case PrimitiveType::Sphere: {
         primBase[0] =
@@ -2741,6 +2745,9 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         primBase[2] = simd::make_float4(p.triangle.v2, p.triangle.uv0.y);
         primBase[3] = simd::make_float4(p.triangle.uv1.x, p.triangle.uv1.y,
                                         p.triangle.uv2.x, p.triangle.uv2.y);
+        primBase[4] = simd::make_float4(p.triangle.tangent, 0.0f);
+        primBase[5] = simd::make_float4(p.triangle.bitangent, 0.0f);
+        primBase[6] = simd::make_float4(p.triangle.normal, 0.0f);
         break;
       }
       }
@@ -3067,6 +3074,9 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
           simd::float4 prim1;
           simd::float4 prim2;
           simd::float4 prim3 = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+          simd::float4 prim4 = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+          simd::float4 prim5 = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+          simd::float4 prim6 = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
           switch (p.type) {
           case PrimitiveType::Sphere: {
             prim0 =
@@ -3090,6 +3100,9 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
             prim2 = simd::make_float4(p.triangle.v2, p.triangle.uv0.y);
             prim3 = simd::make_float4(p.triangle.uv1.x, p.triangle.uv1.y,
                                       p.triangle.uv2.x, p.triangle.uv2.y);
+            prim4 = simd::make_float4(p.triangle.tangent, 0.0f);
+            prim5 = simd::make_float4(p.triangle.bitangent, 0.0f);
+            prim6 = simd::make_float4(p.triangle.normal, 0.0f);
             size_t baseVertex = compactTriangleVertices.size();
             compactTriangleVertices.push_back(p.triangle.v0);
             compactTriangleVertices.push_back(p.triangle.v1);
@@ -3106,6 +3119,9 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
           compactPrimitiveData.push_back(prim1);
           compactPrimitiveData.push_back(prim2);
           compactPrimitiveData.push_back(prim3);
+          compactPrimitiveData.push_back(prim4);
+          compactPrimitiveData.push_back(prim5);
+          compactPrimitiveData.push_back(prim6);
 
           const Material &m = p.material;
           auto packedMaterial = encodeMaterial(m);
@@ -3284,6 +3300,9 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         simd::float4 prim1;
         simd::float4 prim2;
         simd::float4 prim3 = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+        simd::float4 prim4 = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+        simd::float4 prim5 = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+        simd::float4 prim6 = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
         switch (p.type) {
         case PrimitiveType::Sphere: {
           prim0 = simd::make_float4(p.sphere.center, static_cast<float>(p.type));
@@ -3304,6 +3323,9 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
           prim2 = simd::make_float4(p.triangle.v2, p.triangle.uv0.y);
           prim3 = simd::make_float4(p.triangle.uv1.x, p.triangle.uv1.y,
                                     p.triangle.uv2.x, p.triangle.uv2.y);
+          prim4 = simd::make_float4(p.triangle.tangent, 0.0f);
+          prim5 = simd::make_float4(p.triangle.bitangent, 0.0f);
+          prim6 = simd::make_float4(p.triangle.normal, 0.0f);
           size_t baseVertex = compactTriangleVertices.size();
           compactTriangleVertices.push_back(p.triangle.v0);
           compactTriangleVertices.push_back(p.triangle.v1);
@@ -3320,6 +3342,9 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         compactPrimitiveData.push_back(prim1);
         compactPrimitiveData.push_back(prim2);
         compactPrimitiveData.push_back(prim3);
+        compactPrimitiveData.push_back(prim4);
+        compactPrimitiveData.push_back(prim5);
+        compactPrimitiveData.push_back(prim6);
 
         const Material &m = p.material;
         auto packedMaterial = encodeMaterial(m);
@@ -3491,20 +3516,29 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
 
   if (uploadAll) {
     size_t primitiveFloat4Count = primitiveSource->size();
-    size_t primitiveBytes =
-        std::max<size_t>(primitiveFloat4Count, size_t(1)) *
-        sizeof(simd::float4);
+    size_t primitiveCount =
+        (kPrimitiveFloat4Count > 0)
+            ? ((primitiveFloat4Count + kPrimitiveFloat4Count - 1) /
+               kPrimitiveFloat4Count)
+            : 0;
+    size_t primitiveBytes = static_cast<size_t>(
+        GpuHeapResources::primitiveDataSize(primitiveCount));
+    if (primitiveBytes == 0)
+      primitiveBytes = sizeof(simd::float4);
     ensureBufferCapacity(_pSphereBuffer, primitiveBytes, _sphereBufferCapacity,
                          allowShrink);
     if (_pSphereBuffer) {
       simd::float4 *dst =
           static_cast<simd::float4 *>(_pSphereBuffer->contents());
+      size_t modifiedBytes = primitiveBytes;
       if (primitiveFloat4Count > 0)
         std::memcpy(dst, primitiveSource->data(),
                     primitiveFloat4Count * sizeof(simd::float4));
       else
         dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-      markBufferModified(_pSphereBuffer, NS::Range::Make(0, primitiveBytes));
+      if (primitiveFloat4Count > 0)
+        modifiedBytes = primitiveFloat4Count * sizeof(simd::float4);
+      markBufferModified(_pSphereBuffer, NS::Range::Make(0, modifiedBytes));
     }
 
     size_t materialFloat4Count = materialSource->size();

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -9,7 +9,7 @@
 using namespace metal;
 
 constant uint kMaterialFloat4Count = 5;
-constant uint kPrimitiveFloat4Count = 4;
+constant uint kPrimitiveFloat4Count = 7;
 constant uint kMaxMaterialTextures = 64;
 
 constexpr sampler kMaterialTextureSampler(address::repeat, filter::linear);
@@ -275,6 +275,8 @@ inline intersection firstHitBVH(thread const Ray &r,
 
         float2 localUV = float2(0.0f);
         float2 bary = float2(0.0f);
+        float3 candidateTangent = float3(0.0f);
+        float3 candidateBitangent = float3(0.0f);
 
         if (primitiveType == 0) {
           float3 center = p0.xyz;
@@ -302,6 +304,17 @@ inline intersection firstHitBVH(thread const Ray &r,
 
           float3 edge1 = v1 - v0;
           float3 edge2 = v2 - v0;
+          float3 storedTangent = primitives[base + 4].xyz;
+          float3 storedBitangent = primitives[base + 5].xyz;
+          float3 storedNormal = primitives[base + 6].xyz;
+
+          float3 fallbackNormal = cross(edge1, edge2);
+          float fallbackLenSq = dot(fallbackNormal, fallbackNormal);
+          if (fallbackLenSq > 0.0f)
+            fallbackNormal = normalize(fallbackNormal);
+          else
+            fallbackNormal = float3(0.0f, 1.0f, 0.0f);
+
           float3 h = cross(r.direction, edge2);
           float a = dot(edge1, h);
           if (abs(a) > 1e-5) {
@@ -316,7 +329,38 @@ inline intersection firstHitBVH(thread const Ray &r,
                 if (tt > 0.0001 && tt < in.t) {
                   tHit = tt;
                   hit = r.origin + tHit * r.direction;
-                  n = normalize(cross(edge1, edge2));
+                  float storedLenSq = dot(storedNormal, storedNormal);
+                  if (storedLenSq > 1e-6f && all(isfinite(storedNormal)))
+                    n = normalize(storedNormal);
+                  else
+                    n = fallbackNormal;
+                  if (!all(isfinite(n)) || dot(n, n) <= 1e-6f)
+                    n = fallbackNormal;
+                  float tanLenSq = dot(storedTangent, storedTangent);
+                  if (tanLenSq > 1e-6f && all(isfinite(storedTangent)))
+                    candidateTangent = normalize(storedTangent);
+                  float bitLenSq = dot(storedBitangent, storedBitangent);
+                  if (bitLenSq > 1e-6f && all(isfinite(storedBitangent)))
+                    candidateBitangent = normalize(storedBitangent);
+                  if (dot(candidateTangent, candidateTangent) <= 1e-6f ||
+                      !all(isfinite(candidateTangent))) {
+                    float3 refAxis = (abs(fallbackNormal.y) < 0.999f)
+                                         ? float3(0.0f, 1.0f, 0.0f)
+                                         : float3(1.0f, 0.0f, 0.0f);
+                    candidateTangent = normalize(cross(refAxis, fallbackNormal));
+                  }
+                  if (dot(candidateBitangent, candidateBitangent) <= 1e-6f ||
+                      !all(isfinite(candidateBitangent)))
+                    candidateBitangent = normalize(cross(fallbackNormal,
+                                                          candidateTangent));
+                  if (dot(candidateTangent, candidateTangent) > 1e-6f &&
+                      all(isfinite(candidateTangent))) {
+                    candidateTangent = normalize(candidateTangent);
+                    float3 orthBitangent = cross(n, candidateTangent);
+                    if (dot(orthBitangent, orthBitangent) > 1e-6f &&
+                        all(isfinite(orthBitangent)))
+                      candidateBitangent = normalize(orthBitangent);
+                  }
                   hitThis = true;
                   in.isTriangle = 1;
                   bary = float2(u, v);
@@ -357,6 +401,8 @@ inline intersection firstHitBVH(thread const Ray &r,
           in.nodeIndex = nodeIdx;
           in.barycentric = bary;
           in.uv = localUV;
+          in.tangent = candidateTangent;
+          in.bitangent = candidateBitangent;
         }
       }
     } else {
@@ -376,8 +422,15 @@ inline intersection firstHitBVH(thread const Ray &r,
 
   if (in.primitiveId != -1) {
     in.frontFace = dot(in.normal, r.direction) < 0.0;
-    if (!in.frontFace)
+    if (!in.frontFace) {
       in.normal = -in.normal;
+      if (dot(in.tangent, in.tangent) > 1e-6f && all(isfinite(in.tangent)))
+        in.tangent = -in.tangent;
+      float3 adjustedBitangent = cross(in.normal, in.tangent);
+      if (dot(adjustedBitangent, adjustedBitangent) > 1e-6f &&
+          all(isfinite(adjustedBitangent)))
+        in.bitangent = normalize(adjustedBitangent);
+    }
   }
 
   return in;

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -16,6 +16,8 @@ struct intersection
     float t = INFINITY;
     float3 point;
     float3 normal;
+    float3 tangent = float3(0.0f);
+    float3 bitangent = float3(0.0f);
     bool frontFace;
     int primitiveId = -1;
     int isTriangle = 0;

--- a/MetalCpp Path Tracer/Scene/Primitive.h
+++ b/MetalCpp Path Tracer/Scene/Primitive.h
@@ -8,7 +8,7 @@
 
 namespace MetalCppPathTracer {
 
-inline constexpr size_t kPrimitiveFloat4Count = 4;
+inline constexpr size_t kPrimitiveFloat4Count = 7;
 
 enum class PrimitiveType {
     Sphere = 0,

--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -99,6 +99,13 @@ size_t Scene::addObjectInternal(const Primitive *prims, size_t count,
   size_t start = primitives.size();
   primitives.insert(primitives.end(), prims, prims + count);
 
+  for (size_t i = 0; i < count; ++i) {
+    Primitive &stored = primitives[start + i];
+    if (stored.type == PrimitiveType::Triangle) {
+      stored.triangle.computeFrame();
+    }
+  }
+
   SceneObject object;
   object.firstPrimitive = start;
   object.primitiveCount = count;
@@ -305,6 +312,10 @@ simd::float4 *Scene::createTransformsBuffer() const {
   for (size_t i = 0; i < primitives.size(); ++i) {
     const auto &p = primitives[i];
     size_t base = kPrimitiveFloat4Count * i;
+    buffer[base + 4] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+    buffer[base + 5] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+    buffer[base + 6] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+
     if (p.type == PrimitiveType::Sphere) {
       buffer[base + 0] =
           simd::make_float4(p.sphere.center, static_cast<float>(p.type));
@@ -325,6 +336,9 @@ simd::float4 *Scene::createTransformsBuffer() const {
       buffer[base + 2] = simd::make_float4(p.triangle.v2, p.triangle.uv0.y);
       buffer[base + 3] = simd::make_float4(p.triangle.uv1.x, p.triangle.uv1.y,
                                            p.triangle.uv2.x, p.triangle.uv2.y);
+      buffer[base + 4] = simd::make_float4(p.triangle.tangent, 0.0f);
+      buffer[base + 5] = simd::make_float4(p.triangle.bitangent, 0.0f);
+      buffer[base + 6] = simd::make_float4(p.triangle.normal, 0.0f);
     }
   }
   return buffer;

--- a/MetalCpp Path Tracer/Scene/Triangle.h
+++ b/MetalCpp Path Tracer/Scene/Triangle.h
@@ -2,6 +2,7 @@
 #define TRIANGLE_H
 
 #include <simd/simd.h>
+#include <cmath>
 
 namespace MetalCppPathTracer {
 
@@ -12,6 +13,98 @@ struct Triangle {
     simd::float2 uv0 = simd::make_float2(0.0f, 0.0f);
     simd::float2 uv1 = simd::make_float2(0.0f, 0.0f);
     simd::float2 uv2 = simd::make_float2(0.0f, 0.0f);
+    simd::float3 tangent = simd::make_float3(1.0f, 0.0f, 0.0f);
+    simd::float3 bitangent = simd::make_float3(0.0f, 1.0f, 0.0f);
+    simd::float3 normal = simd::make_float3(0.0f, 0.0f, 1.0f);
+
+    void computeFrame() {
+        constexpr float kEpsilon = 1.0e-6f;
+
+        auto isFinite = [](const simd::float3& v) {
+            return std::isfinite(v.x) && std::isfinite(v.y) && std::isfinite(v.z);
+        };
+
+        auto safeNormalize = [&](const simd::float3& v) {
+            float len = simd::length(v);
+            if (len > kEpsilon && isFinite(v))
+                return v / len;
+            return simd::make_float3(0.0f, 0.0f, 0.0f);
+        };
+
+        simd::float3 edge1 = v1 - v0;
+        simd::float3 edge2 = v2 - v0;
+
+        simd::float3 computedNormal = simd::cross(edge1, edge2);
+        computedNormal = safeNormalize(computedNormal);
+        if (simd::length(computedNormal) <= kEpsilon || !isFinite(computedNormal)) {
+            computedNormal = simd::make_float3(0.0f, 1.0f, 0.0f);
+        }
+
+        simd::float2 duv1 = uv1 - uv0;
+        simd::float2 duv2 = uv2 - uv0;
+        float det = duv1.x * duv2.y - duv1.y * duv2.x;
+
+        simd::float3 computedTangent = simd::make_float3(0.0f, 0.0f, 0.0f);
+        simd::float3 computedBitangent = simd::make_float3(0.0f, 0.0f, 0.0f);
+
+        if (std::fabs(det) > kEpsilon) {
+            float invDet = 1.0f / det;
+            computedTangent = safeNormalize((edge1 * duv2.y - edge2 * duv1.y) * invDet);
+            computedBitangent = safeNormalize((edge2 * duv1.x - edge1 * duv2.x) * invDet);
+        }
+
+        bool tangentValid = simd::length(computedTangent) > kEpsilon &&
+                            isFinite(computedTangent);
+        bool bitangentValid = simd::length(computedBitangent) > kEpsilon &&
+                              isFinite(computedBitangent);
+
+        if (!tangentValid || !bitangentValid) {
+            computedTangent = safeNormalize(edge1);
+            if (simd::length(computedTangent) <= kEpsilon ||
+                !isFinite(computedTangent)) {
+                computedTangent = safeNormalize(edge2);
+            }
+
+            if (simd::length(computedTangent) <= kEpsilon ||
+                !isFinite(computedTangent)) {
+                simd::float3 up = std::fabs(computedNormal.y) < 0.999f
+                                      ? simd::make_float3(0.0f, 1.0f, 0.0f)
+                                      : simd::make_float3(1.0f, 0.0f, 0.0f);
+                computedTangent = safeNormalize(simd::cross(up, computedNormal));
+            }
+
+            if (simd::length(computedTangent) <= kEpsilon ||
+                !isFinite(computedTangent)) {
+                computedTangent = simd::make_float3(1.0f, 0.0f, 0.0f);
+            }
+
+            computedBitangent = safeNormalize(simd::cross(computedNormal, computedTangent));
+            if (simd::length(computedBitangent) <= kEpsilon ||
+                !isFinite(computedBitangent)) {
+                computedBitangent = safeNormalize(simd::cross(computedTangent, computedNormal));
+            }
+        } else {
+            computedTangent = safeNormalize(
+                computedTangent - computedNormal * simd::dot(computedNormal, computedTangent));
+            computedBitangent = safeNormalize(
+                computedBitangent - computedNormal * simd::dot(computedNormal, computedBitangent));
+        }
+
+        if (simd::length(computedBitangent) <= kEpsilon || !isFinite(computedBitangent)) {
+            computedBitangent = safeNormalize(simd::cross(computedNormal, computedTangent));
+        }
+
+        if (simd::length(computedBitangent) <= kEpsilon || !isFinite(computedBitangent)) {
+            computedBitangent = simd::make_float3(0.0f, 1.0f, 0.0f);
+        }
+
+        tangent = computedTangent;
+        bitangent = computedBitangent;
+        normal = safeNormalize(computedNormal);
+        if (simd::length(normal) <= kEpsilon || !isFinite(normal)) {
+            normal = simd::make_float3(0.0f, 0.0f, 1.0f);
+        }
+    }
 };
 
 }


### PR DESCRIPTION
## Summary
- compute tangent, bitangent, and normal frames for triangle primitives during scene construction
- extend packed primitive buffers and GPU resource helpers to carry the tangent frame data
- expose the tangent frame to Metal shaders so intersections retain TBN information

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff53e873f4832d91dc3a888cf88aaf