### PR TITLE
Add tangent frame support to shading payload

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -2728,6 +2728,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
             simd::make_float3(p.sphere.radius, 0.0f, 0.0f), 0.0f);
         primBase[2] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
         primBase[3] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+        primBase[6] = simd::make_float4(0.0f, 0.0f, 1.0f, 0.0f);
         break;
       }
       case PrimitiveType::Rectangle: {
@@ -2736,6 +2737,11 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
         primBase[1] = simd::make_float4(p.rectangle.u, 0.0f);
         primBase[2] = simd::make_float4(p.rectangle.v, 0.0f);
         primBase[3] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+        primBase[4] = simd::make_float4(p.rectangle.tangent, 0.0f);
+        primBase[5] = simd::make_float4(p.rectangle.bitangent, 0.0f);
+        primBase[6] = simd::make_float4(p.rectangle.normal,
+                                        p.rectangle.supportsNormalMap ? 1.0f
+                                                                      : 0.0f);
         break;
       }
       case PrimitiveType::Triangle: {
@@ -2747,7 +2753,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
                                         p.triangle.uv2.x, p.triangle.uv2.y);
         primBase[4] = simd::make_float4(p.triangle.tangent, 0.0f);
         primBase[5] = simd::make_float4(p.triangle.bitangent, 0.0f);
-        primBase[6] = simd::make_float4(p.triangle.normal, 0.0f);
+        primBase[6] = simd::make_float4(p.triangle.normal, 1.0f);
         break;
       }
       }
@@ -3084,6 +3090,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
             prim1 = simd::make_float4(
                 simd::make_float3(p.sphere.radius, 0.0f, 0.0f), 0.0f);
             prim2 = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+            prim6 = simd::make_float4(0.0f, 0.0f, 1.0f, 0.0f);
             break;
           }
           case PrimitiveType::Rectangle: {
@@ -3091,6 +3098,11 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
                                       static_cast<float>(p.type));
             prim1 = simd::make_float4(p.rectangle.u, 0.0f);
             prim2 = simd::make_float4(p.rectangle.v, 0.0f);
+            prim4 = simd::make_float4(p.rectangle.tangent, 0.0f);
+            prim5 = simd::make_float4(p.rectangle.bitangent, 0.0f);
+            prim6 = simd::make_float4(p.rectangle.normal,
+                                      p.rectangle.supportsNormalMap ? 1.0f
+                                                                    : 0.0f);
             break;
           }
           case PrimitiveType::Triangle: {
@@ -3102,7 +3114,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
                                       p.triangle.uv2.x, p.triangle.uv2.y);
             prim4 = simd::make_float4(p.triangle.tangent, 0.0f);
             prim5 = simd::make_float4(p.triangle.bitangent, 0.0f);
-            prim6 = simd::make_float4(p.triangle.normal, 0.0f);
+            prim6 = simd::make_float4(p.triangle.normal, 1.0f);
             size_t baseVertex = compactTriangleVertices.size();
             compactTriangleVertices.push_back(p.triangle.v0);
             compactTriangleVertices.push_back(p.triangle.v1);
@@ -3309,12 +3321,18 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
           prim1 = simd::make_float4(
               simd::make_float3(p.sphere.radius, 0.0f, 0.0f), 0.0f);
           prim2 = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+          prim6 = simd::make_float4(0.0f, 0.0f, 1.0f, 0.0f);
           break;
         }
         case PrimitiveType::Rectangle: {
           prim0 = simd::make_float4(p.rectangle.center, static_cast<float>(p.type));
           prim1 = simd::make_float4(p.rectangle.u, 0.0f);
           prim2 = simd::make_float4(p.rectangle.v, 0.0f);
+          prim4 = simd::make_float4(p.rectangle.tangent, 0.0f);
+          prim5 = simd::make_float4(p.rectangle.bitangent, 0.0f);
+          prim6 = simd::make_float4(p.rectangle.normal,
+                                    p.rectangle.supportsNormalMap ? 1.0f
+                                                                  : 0.0f);
           break;
         }
         case PrimitiveType::Triangle: {
@@ -3325,7 +3343,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
                                     p.triangle.uv2.x, p.triangle.uv2.y);
           prim4 = simd::make_float4(p.triangle.tangent, 0.0f);
           prim5 = simd::make_float4(p.triangle.bitangent, 0.0f);
-          prim6 = simd::make_float4(p.triangle.normal, 0.0f);
+          prim6 = simd::make_float4(p.triangle.normal, 1.0f);
           size_t baseVertex = compactTriangleVertices.size();
           compactTriangleVertices.push_back(p.triangle.v0);
           compactTriangleVertices.push_back(p.triangle.v1);

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -278,6 +278,16 @@ inline intersection firstHitBVH(thread const Ray &r,
         float3 candidateTangent = float3(0.0f);
         float3 candidateBitangent = float3(0.0f);
 
+        float4 packedTangent = primitives[base + 4];
+        float4 packedBitangent = primitives[base + 5];
+        float4 packedNormal = primitives[base + 6];
+
+        float3 storedTangent = packedTangent.xyz;
+        float3 storedBitangent = packedBitangent.xyz;
+        float3 storedNormal = packedNormal.xyz;
+        int storedSupportsNormalMap = (packedNormal.w > 0.5f) ? 1 : 0;
+        int candidateSupportsNormalMap = 0;
+
         if (primitiveType == 0) {
           float3 center = p0.xyz;
           float radius = p1.x;
@@ -295,6 +305,7 @@ inline intersection firstHitBVH(thread const Ray &r,
               hit = r.origin + tHit * r.direction;
               n = normalize(hit - center);
               hitThis = true;
+              candidateSupportsNormalMap = storedSupportsNormalMap;
             }
           }
         } else if (primitiveType == 1) {
@@ -304,9 +315,6 @@ inline intersection firstHitBVH(thread const Ray &r,
 
           float3 edge1 = v1 - v0;
           float3 edge2 = v2 - v0;
-          float3 storedTangent = primitives[base + 4].xyz;
-          float3 storedBitangent = primitives[base + 5].xyz;
-          float3 storedNormal = primitives[base + 6].xyz;
 
           float3 fallbackNormal = cross(edge1, edge2);
           float fallbackLenSq = dot(fallbackNormal, fallbackNormal);
@@ -337,10 +345,14 @@ inline intersection firstHitBVH(thread const Ray &r,
                   if (!all(isfinite(n)) || dot(n, n) <= 1e-6f)
                     n = fallbackNormal;
                   float tanLenSq = dot(storedTangent, storedTangent);
-                  if (tanLenSq > 1e-6f && all(isfinite(storedTangent)))
+                  bool tangentValid =
+                      tanLenSq > 1e-6f && all(isfinite(storedTangent));
+                  if (tangentValid)
                     candidateTangent = normalize(storedTangent);
                   float bitLenSq = dot(storedBitangent, storedBitangent);
-                  if (bitLenSq > 1e-6f && all(isfinite(storedBitangent)))
+                  bool bitangentValid =
+                      bitLenSq > 1e-6f && all(isfinite(storedBitangent));
+                  if (bitangentValid)
                     candidateBitangent = normalize(storedBitangent);
                   if (dot(candidateTangent, candidateTangent) <= 1e-6f ||
                       !all(isfinite(candidateTangent))) {
@@ -361,6 +373,12 @@ inline intersection firstHitBVH(thread const Ray &r,
                         all(isfinite(orthBitangent)))
                       candidateBitangent = normalize(orthBitangent);
                   }
+                  candidateSupportsNormalMap =
+                      (storedSupportsNormalMap && tangentValid &&
+                       bitangentValid &&
+                       (dot(n, n) > 1e-6f))
+                          ? 1
+                          : 0;
                   hitThis = true;
                   in.isTriangle = 1;
                   bary = float2(u, v);
@@ -372,10 +390,20 @@ inline intersection firstHitBVH(thread const Ray &r,
           float3 center = p0.xyz;
           float3 e1 = p1.xyz;
           float3 e2 = p2.xyz;
-          float3 normal = normalize(cross(e1, e2));
-          float denom = dot(normal, r.direction);
+          float3 fallbackNormal = cross(e1, e2);
+          float fallbackLenSq = dot(fallbackNormal, fallbackNormal);
+          if (fallbackLenSq > 1e-6f && all(isfinite(fallbackNormal)))
+            fallbackNormal = normalize(fallbackNormal);
+          else
+            fallbackNormal = float3(0.0f, 1.0f, 0.0f);
+          float3 normalCandidate = fallbackNormal;
+          float normalLenSq = dot(storedNormal, storedNormal);
+          bool normalValid = normalLenSq > 1e-6f && all(isfinite(storedNormal));
+          if (normalValid)
+            normalCandidate = normalize(storedNormal);
+          float denom = dot(normalCandidate, r.direction);
           if (fabs(denom) > 1e-5) {
-            float tt = dot(center - r.origin, normal) / denom;
+            float tt = dot(center - r.origin, normalCandidate) / denom;
             if (tt > 0.0001 && tt < in.t) {
               float3 hitPoint = r.origin + tt * r.direction;
               float3 rel = hitPoint - center;
@@ -384,7 +412,40 @@ inline intersection firstHitBVH(thread const Ray &r,
               if (fabs(u) <= 1.0 && fabs(v) <= 1.0) {
                 tHit = tt;
                 hit = hitPoint;
-                n = normal;
+                n = normalCandidate;
+                bool tangentValid =
+                    dot(storedTangent, storedTangent) > 1e-6f &&
+                    all(isfinite(storedTangent));
+                bool bitangentValid =
+                    dot(storedBitangent, storedBitangent) > 1e-6f &&
+                    all(isfinite(storedBitangent));
+                if (tangentValid)
+                  candidateTangent = normalize(storedTangent);
+                if (bitangentValid)
+                  candidateBitangent = normalize(storedBitangent);
+                if (dot(candidateTangent, candidateTangent) <= 1e-6f ||
+                    !all(isfinite(candidateTangent))) {
+                  float3 refAxis = (abs(fallbackNormal.y) < 0.999f)
+                                       ? float3(0.0f, 1.0f, 0.0f)
+                                       : float3(1.0f, 0.0f, 0.0f);
+                  candidateTangent = normalize(cross(refAxis, fallbackNormal));
+                }
+                if (dot(candidateBitangent, candidateBitangent) <= 1e-6f ||
+                    !all(isfinite(candidateBitangent)))
+                  candidateBitangent = normalize(
+                      cross(fallbackNormal, candidateTangent));
+                if (dot(candidateTangent, candidateTangent) > 1e-6f &&
+                    all(isfinite(candidateTangent))) {
+                  float3 orthBitangent = cross(n, candidateTangent);
+                  if (dot(orthBitangent, orthBitangent) > 1e-6f &&
+                      all(isfinite(orthBitangent)))
+                    candidateBitangent = normalize(orthBitangent);
+                }
+                candidateSupportsNormalMap =
+                    (storedSupportsNormalMap && normalValid && tangentValid &&
+                     bitangentValid)
+                        ? 1
+                        : 0;
                 hitThis = true;
                 localUV = float2(0.5f * (u + 1.0f), 0.5f * (v + 1.0f));
               }
@@ -403,6 +464,7 @@ inline intersection firstHitBVH(thread const Ray &r,
           in.uv = localUV;
           in.tangent = candidateTangent;
           in.bitangent = candidateBitangent;
+          in.supportsNormalMap = candidateSupportsNormalMap;
         }
       }
     } else {
@@ -624,6 +686,8 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
       break;
 
     MaterialPayload material = decodeMaterial(matBase, materials, lodAtten);
+    if (!bestHit.supportsNormalMap)
+      material.normalTextureIndex = -1;
 
     float2 surfaceUV = float2(0.0f);
     bool haveUV = false;

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -18,6 +18,7 @@ struct intersection
     float3 normal;
     float3 tangent = float3(0.0f);
     float3 bitangent = float3(0.0f);
+    int supportsNormalMap = 0;
     bool frontFace;
     int primitiveId = -1;
     int isTriangle = 0;

--- a/MetalCpp Path Tracer/Scene/Rectangle.h
+++ b/MetalCpp Path Tracer/Scene/Rectangle.h
@@ -2,6 +2,7 @@
 #define RECTANGLE_H
 
 #include <simd/simd.h>
+#include <cmath>
 
 namespace MetalCppPathTracer {
 
@@ -9,6 +10,67 @@ struct Rectangle {
     simd::float3 center;
     simd::float3 u;
     simd::float3 v;
+    simd::float3 tangent = simd::make_float3(1.0f, 0.0f, 0.0f);
+    simd::float3 bitangent = simd::make_float3(0.0f, 1.0f, 0.0f);
+    simd::float3 normal = simd::make_float3(0.0f, 0.0f, 1.0f);
+    bool supportsNormalMap = false;
+
+    void computeFrame() {
+        constexpr float kEpsilon = 1.0e-6f;
+
+        auto isFinite = [](const simd::float3 &v) {
+            return std::isfinite(v.x) && std::isfinite(v.y) && std::isfinite(v.z);
+        };
+
+        auto safeNormalize = [&](const simd::float3 &v) {
+            float len = simd::length(v);
+            if (len > kEpsilon && isFinite(v))
+                return v / len;
+            return simd::make_float3(0.0f, 0.0f, 0.0f);
+        };
+
+        simd::float3 computedTangent = safeNormalize(u);
+        simd::float3 computedBitangent = safeNormalize(v);
+        simd::float3 computedNormal = safeNormalize(simd::cross(computedTangent, computedBitangent));
+
+        if (simd::length(computedTangent) <= kEpsilon || !isFinite(computedTangent)) {
+            computedTangent = simd::make_float3(1.0f, 0.0f, 0.0f);
+        }
+
+        if (simd::length(computedBitangent) <= kEpsilon || !isFinite(computedBitangent)) {
+            simd::float3 refAxis = (std::fabs(computedTangent.y) < 0.999f)
+                                       ? simd::make_float3(0.0f, 1.0f, 0.0f)
+                                       : simd::make_float3(0.0f, 0.0f, 1.0f);
+            computedBitangent = safeNormalize(simd::cross(refAxis, computedTangent));
+        }
+
+        if (simd::length(computedNormal) <= kEpsilon || !isFinite(computedNormal)) {
+            computedNormal = safeNormalize(simd::cross(u, v));
+        }
+
+        if (simd::length(computedNormal) <= kEpsilon || !isFinite(computedNormal)) {
+            computedNormal = simd::make_float3(0.0f, 1.0f, 0.0f);
+        }
+
+        computedTangent = safeNormalize(computedTangent -
+                                        computedNormal * simd::dot(computedNormal, computedTangent));
+        computedBitangent = safeNormalize(simd::cross(computedNormal, computedTangent));
+
+        bool tangentValid = simd::length(computedTangent) > kEpsilon && isFinite(computedTangent);
+        bool bitangentValid = simd::length(computedBitangent) > kEpsilon && isFinite(computedBitangent);
+        bool normalValid = simd::length(computedNormal) > kEpsilon && isFinite(computedNormal);
+
+        supportsNormalMap = tangentValid && bitangentValid && normalValid;
+        if (!supportsNormalMap) {
+            computedTangent = simd::make_float3(1.0f, 0.0f, 0.0f);
+            computedBitangent = simd::make_float3(0.0f, 1.0f, 0.0f);
+            computedNormal = simd::make_float3(0.0f, 0.0f, 1.0f);
+        }
+
+        tangent = computedTangent;
+        bitangent = computedBitangent;
+        normal = computedNormal;
+    }
 };
 
 }

--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -103,6 +103,10 @@ size_t Scene::addObjectInternal(const Primitive *prims, size_t count,
     Primitive &stored = primitives[start + i];
     if (stored.type == PrimitiveType::Triangle) {
       stored.triangle.computeFrame();
+    } else if (stored.type == PrimitiveType::Rectangle) {
+      stored.rectangle.computeFrame();
+    } else if (stored.type == PrimitiveType::Sphere) {
+      stored.sphere.supportsNormalMap = 0;
     }
   }
 
@@ -323,12 +327,19 @@ simd::float4 *Scene::createTransformsBuffer() const {
           simd::make_float4(simd::make_float3(p.sphere.radius, 0, 0), 0);
       buffer[base + 2] = simd::make_float4(simd::float3(0), 0);
       buffer[base + 3] = simd::make_float4(simd::float3(0), 0);
+      buffer[base + 6] =
+          simd::make_float4(simd::float3(0.0f, 0.0f, 1.0f), 0.0f);
     } else if (p.type == PrimitiveType::Rectangle) {
       buffer[base + 0] =
           simd::make_float4(p.rectangle.center, static_cast<float>(p.type));
       buffer[base + 1] = simd::make_float4(p.rectangle.u, 0);
       buffer[base + 2] = simd::make_float4(p.rectangle.v, 0);
       buffer[base + 3] = simd::make_float4(simd::float3(0), 0);
+      buffer[base + 4] = simd::make_float4(p.rectangle.tangent, 0.0f);
+      buffer[base + 5] = simd::make_float4(p.rectangle.bitangent, 0.0f);
+      buffer[base + 6] =
+          simd::make_float4(p.rectangle.normal,
+                            p.rectangle.supportsNormalMap ? 1.0f : 0.0f);
     } else {
       buffer[base + 0] =
           simd::make_float4(p.triangle.v0, static_cast<float>(p.type));
@@ -338,7 +349,8 @@ simd::float4 *Scene::createTransformsBuffer() const {
                                            p.triangle.uv2.x, p.triangle.uv2.y);
       buffer[base + 4] = simd::make_float4(p.triangle.tangent, 0.0f);
       buffer[base + 5] = simd::make_float4(p.triangle.bitangent, 0.0f);
-      buffer[base + 6] = simd::make_float4(p.triangle.normal, 0.0f);
+      buffer[base + 6] =
+          simd::make_float4(p.triangle.normal, 1.0f);
     }
   }
   return buffer;

--- a/MetalCpp Path Tracer/Scene/Sphere.h
+++ b/MetalCpp Path Tracer/Scene/Sphere.h
@@ -2,12 +2,14 @@
 #define SPHERE_H
 
 #include <simd/simd.h>
+#include <cstdint>
 
 namespace MetalCppPathTracer {
 
 struct Sphere {
     simd::float3 center;
     float radius;
+    uint32_t supportsNormalMap = 0;
 };
 
 }


### PR DESCRIPTION
## Summary
- compute and cache tangent frames for rectangles while marking spheres as unsupported for normal maps
- pack tangent, bitangent, and normal data with support flags into primitive buffers and expose them to shaders
- decode the tangent frame in the path tracer, track normal-map eligibility, and disable normal textures when unsupported

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff59a411d8832d9faa773e9ecb246f