### PR TITLE
Fix transform buffer initialization for Apple SIMD

### DIFF
--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -316,9 +316,9 @@ simd::float4 *Scene::createTransformsBuffer() const {
   for (size_t i = 0; i < primitives.size(); ++i) {
     const auto &p = primitives[i];
     size_t base = kPrimitiveFloat4Count * i;
-    buffer[base + 4] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-    buffer[base + 5] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-    buffer[base + 6] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
+    buffer[base + 4] = simd::make_float4(simd::float3(0.0f), 0.0f);
+    buffer[base + 5] = simd::make_float4(simd::float3(0.0f), 0.0f);
+    buffer[base + 6] = simd::make_float4(simd::float3(0.0f), 0.0f);
 
     if (p.type == PrimitiveType::Sphere) {
       buffer[base + 0] =


### PR DESCRIPTION
## Summary
- replace the zero-initialization of transform buffer entries with simd::make_float4 calls for Apple SIMD compatibility

## Testing
- xcodebuild -project 'MetalCpp Path Tracer.xcodeproj' *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68ff5c93324c832d90fad37363f27135