### PR TITLE
Handle normal-map textures as linear data

### DIFF
--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -175,15 +175,16 @@ const std::vector<std::string> &Scene::getTexturePaths() const {
   return texturePaths;
 }
 
-int Scene::registerTexture(const std::string &path, Texture texture) {
-  auto it = textureLookup.find(path);
+int Scene::registerTexture(const std::string &cacheKey,
+                           const std::string &displayPath, Texture texture) {
+  auto it = textureLookup.find(cacheKey);
   if (it != textureLookup.end())
     return it->second;
 
   int index = static_cast<int>(textures.size());
   textures.push_back(std::move(texture));
-  texturePaths.push_back(path);
-  textureLookup.emplace(path, index);
+  texturePaths.push_back(displayPath);
+  textureLookup.emplace(cacheKey, index);
   return index;
 }
 

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -113,7 +113,8 @@ public:
 
   const std::vector<Texture> &getTextures() const;
   const std::vector<std::string> &getTexturePaths() const;
-  int registerTexture(const std::string &path, Texture texture);
+  int registerTexture(const std::string &cacheKey, const std::string &displayPath,
+                      Texture texture);
 
   ResidencyStrategy getResidencyStrategy() const;
   void setResidencyStrategy(ResidencyStrategy strategy);

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -89,7 +89,8 @@ TextureCache& GetTextureCache() {
 static int ResolveTextureIndex(const std::string& texName,
                                const std::string& baseDir,
                                Scene* scene,
-                               TextureCache& cache) {
+                               TextureCache& cache,
+                               TextureUsage usage = TextureUsage::Color) {
     if (!scene || texName.empty()) {
         return -1;
     }
@@ -101,14 +102,18 @@ static int ResolveTextureIndex(const std::string& texName,
     resolved = resolved.lexically_normal();
 
     std::string key = resolved.string();
-    auto it = cache.find(key);
+    TextureColorSpace colorSpace = DetermineTextureColorSpace(key, usage);
+    std::string cacheKey = key;
+    cacheKey += (colorSpace == TextureColorSpace::Linear) ? "|linear" : "|srgb";
+
+    auto it = cache.find(cacheKey);
     if (it != cache.end()) {
         return it->second;
     }
 
     LoadedTextureImage image;
-    if (!LoadTextureImage(key, image)) {
-        cache.emplace(key, -1);
+    if (!LoadTextureImage(key, image, usage)) {
+        cache.emplace(cacheKey, -1);
         return -1;
     }
 
@@ -117,8 +122,8 @@ static int ResolveTextureIndex(const std::string& texName,
     texture.height = static_cast<uint32_t>(image.height);
     texture.pixels = std::move(image.pixels);
 
-    int index = scene->registerTexture(key, std::move(texture));
-    cache.emplace(key, index);
+    int index = scene->registerTexture(cacheKey, key, std::move(texture));
+    cache.emplace(cacheKey, index);
     return index;
 }
 
@@ -149,7 +154,8 @@ static Material ConvertTinyMaterial(const tinyobj::material_t& src,
 
     material.diffuseTextureIndex = ResolveTextureIndex(src.diffuse_texname,
                                                        baseDir, scene,
-                                                       textureCache);
+                                                       textureCache,
+                                                       TextureUsage::Color);
     if (material.diffuseTextureIndex >= 0) {
         constexpr float kMinDiffuseLuminance = 1.0e-4f;
         if (luminance(material.diffuseColor) <= kMinDiffuseLuminance) {
@@ -158,14 +164,66 @@ static Material ConvertTinyMaterial(const tinyobj::material_t& src,
     }
     material.specularTextureIndex = ResolveTextureIndex(src.specular_texname,
                                                         baseDir, scene,
-                                                        textureCache);
+                                                        textureCache,
+                                                        TextureUsage::Color);
     std::string normalTex = src.normal_texname.empty() ? src.bump_texname
                                                        : src.normal_texname;
     material.normalTextureIndex = ResolveTextureIndex(normalTex,
                                                       baseDir, scene,
-                                                      textureCache);
+                                                      textureCache,
+                                                      TextureUsage::NormalMap);
 
     return material;
+}
+
+static void ApplyTextureAttributes(const XMLElement* element,
+                                   const std::filesystem::path& baseDir,
+                                   Scene* scene,
+                                   Material& material,
+                                   TextureCache& textureCache) {
+    if (!element || !scene) {
+        return;
+    }
+
+    std::string baseDirStr = baseDir.string();
+
+    auto resolveTexture = [&](const char* attrValue, TextureUsage usage) {
+        if (!attrValue || !attrValue[0]) {
+            return -1;
+        }
+        return ResolveTextureIndex(attrValue, baseDirStr, scene, textureCache, usage);
+    };
+
+    const char* diffuseAttr = element->Attribute("diffuseTexture");
+    if (!diffuseAttr) {
+        diffuseAttr = element->Attribute("albedoTexture");
+    }
+    int diffuseIndex = resolveTexture(diffuseAttr, TextureUsage::Color);
+    if (diffuseIndex >= 0) {
+        material.diffuseTextureIndex = diffuseIndex;
+        constexpr float kMinDiffuseLuminance = 1.0e-4f;
+        if (luminance(material.diffuseColor) <= kMinDiffuseLuminance) {
+            material.diffuseColor = simd::make_float3(1.0f, 1.0f, 1.0f);
+        }
+    }
+
+    const char* specularAttr = element->Attribute("specularTexture");
+    int specularIndex = resolveTexture(specularAttr, TextureUsage::Color);
+    if (specularIndex >= 0) {
+        material.specularTextureIndex = specularIndex;
+    }
+
+    const char* normalAttr = element->Attribute("normalTexture");
+    if (!normalAttr) {
+        normalAttr = element->Attribute("normalMap");
+    }
+    if (!normalAttr) {
+        normalAttr = element->Attribute("bumpTexture");
+    }
+    int normalIndex = resolveTexture(normalAttr, TextureUsage::NormalMap);
+    if (normalIndex >= 0) {
+        material.normalTextureIndex = normalIndex;
+    }
 }
 
 static Material ParseMaterialAttributes(const XMLElement* element) {
@@ -541,6 +599,8 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
     scene->screenSize.y = root->FloatAttribute("height", scene->screenSize.y);
     scene->maxRayDepth = root->UnsignedAttribute("maxRayDepth", scene->maxRayDepth);
 
+    TextureCache& textureCache = GetTextureCache();
+
     if (const char* residencyAttr = root->Attribute("residencyStrategy")) {
         std::string value = residencyAttr;
         std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
@@ -631,6 +691,7 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             p.sphere.radius = e->FloatAttribute("radius", 1.0f);
 
             p.material = ParseMaterialAttributes(e);
+            ApplyTextureAttributes(e, baseDir, scene, p.material, textureCache);
 
             scene->addPrimitive(p);
         }
@@ -648,6 +709,7 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             }
 
             p.material = ParseMaterialAttributes(e);
+            ApplyTextureAttributes(e, baseDir, scene, p.material, textureCache);
 
             scene->addPrimitive(p);
         }
@@ -699,6 +761,7 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             }
 
             Material overrideMaterial = ParseMaterialAttributes(e);
+            ApplyTextureAttributes(e, baseDir, scene, overrideMaterial, textureCache);
 
             size_t clusterMaxTriangles = static_cast<size_t>(
                 e->Unsigned64Attribute("clusterMaxTriangles", 0));

--- a/MetalCpp Path Tracer/Scene/TextureLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/TextureLoader.cpp
@@ -4,7 +4,10 @@
 #include <ImageIO/ImageIO.h>
 #include <CoreFoundation/CoreFoundation.h>
 
+#include <algorithm>
+#include <cctype>
 #include <cstdio>
+#include <filesystem>
 #include <vector>
 
 namespace MetalCppPathTracer {
@@ -18,7 +21,69 @@ CFURLRef CreateFileURL(const std::string &path) {
 
 } // namespace
 
-bool LoadTextureImage(const std::string &path, LoadedTextureImage &outImage) {
+namespace {
+
+bool ContainsDelimitedToken(const std::string &value, const std::string &token) {
+    size_t pos = value.find(token);
+    while (pos != std::string::npos) {
+        bool startOk = (pos == 0) ||
+                       !std::isalnum(static_cast<unsigned char>(value[pos - 1]));
+        size_t end = pos + token.size();
+        bool endOk = (end >= value.size()) ||
+                      !std::isalnum(static_cast<unsigned char>(value[end]));
+        if (startOk && endOk) {
+            return true;
+        }
+        pos = value.find(token, pos + token.size());
+    }
+    return false;
+}
+
+bool LooksLikeNormalMapFilename(const std::string &path) {
+    std::filesystem::path fsPath(path);
+    std::string filename = fsPath.filename().string();
+    std::string lower = filename;
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    static const char *kTokens[] = {"normalmap", "normal", "nrm", "nmap", "tangent"};
+    for (const char *token : kTokens) {
+        if (ContainsDelimitedToken(lower, token)) {
+            return true;
+        }
+    }
+
+    if (lower.find(".normal.") != std::string::npos) {
+        return true;
+    }
+
+    std::string extension = fsPath.extension().string();
+    std::transform(extension.begin(), extension.end(), extension.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    if (extension == ".nrm" || extension == ".nm" || extension == ".normal") {
+        return true;
+    }
+
+    return false;
+}
+
+} // namespace
+
+TextureColorSpace DetermineTextureColorSpace(const std::string &path,
+                                            TextureUsage usage) {
+    if (usage == TextureUsage::NormalMap || usage == TextureUsage::Data) {
+        return TextureColorSpace::Linear;
+    }
+
+    if (LooksLikeNormalMapFilename(path)) {
+        return TextureColorSpace::Linear;
+    }
+
+    return TextureColorSpace::sRGB;
+}
+
+bool LoadTextureImage(const std::string &path, LoadedTextureImage &outImage,
+                      TextureUsage usage) {
     CFURLRef url = CreateFileURL(path);
     if (!url) {
         std::printf("Failed to create URL for texture '%s'\n", path.c_str());
@@ -51,14 +116,31 @@ bool LoadTextureImage(const std::string &path, LoadedTextureImage &outImage) {
     }
 
     std::vector<uint8_t> rawData(width * height * 4);
-    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+
+    TextureColorSpace targetSpace = DetermineTextureColorSpace(path, usage);
+    CGColorSpaceRef colorSpace = nullptr;
+#if defined(kCGColorSpaceGenericRGBLinear)
+    if (targetSpace == TextureColorSpace::Linear) {
+        colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceGenericRGBLinear);
+    }
+#endif
+#if defined(kCGColorSpaceSRGB)
+    if (!colorSpace && targetSpace == TextureColorSpace::sRGB) {
+        colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
+    }
+#endif
+    if (!colorSpace) {
+        colorSpace = CGColorSpaceCreateDeviceRGB();
+    }
     CGContextRef context = CGBitmapContextCreate(
         rawData.data(), width, height, 8, width * 4, colorSpace,
         kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
 
     if (!context) {
         std::printf("Failed to create bitmap context for texture '%s'\n", path.c_str());
-        CGColorSpaceRelease(colorSpace);
+        if (colorSpace) {
+            CGColorSpaceRelease(colorSpace);
+        }
         CGImageRelease(image);
         CFRelease(source);
         CFRelease(url);
@@ -69,7 +151,9 @@ bool LoadTextureImage(const std::string &path, LoadedTextureImage &outImage) {
                              static_cast<double>(height));
     CGContextDrawImage(context, rect, image);
 
-    CGColorSpaceRelease(colorSpace);
+    if (colorSpace) {
+        CGColorSpaceRelease(colorSpace);
+    }
     CGContextRelease(context);
     CGImageRelease(image);
     CFRelease(source);

--- a/MetalCpp Path Tracer/Scene/TextureLoader.h
+++ b/MetalCpp Path Tracer/Scene/TextureLoader.h
@@ -12,7 +12,22 @@ struct LoadedTextureImage {
     std::vector<float> pixels; // RGBA, linear [0,1]
 };
 
-bool LoadTextureImage(const std::string &path, LoadedTextureImage &outImage);
+enum class TextureUsage {
+    Color,
+    NormalMap,
+    Data,
+};
+
+enum class TextureColorSpace {
+    sRGB,
+    Linear,
+};
+
+TextureColorSpace DetermineTextureColorSpace(const std::string &path,
+                                            TextureUsage usage);
+
+bool LoadTextureImage(const std::string &path, LoadedTextureImage &outImage,
+                      TextureUsage usage = TextureUsage::Color);
 
 } // namespace MetalCppPathTracer
 

--- a/MetalCpp Path Tracer/scene.xml
+++ b/MetalCpp Path Tracer/scene.xml
@@ -1,6 +1,9 @@
 <Scene width="960" height="540" maxRayDepth="8" startCompacted="true" residencyStrategy="distance"
        textureResidencyMemoryCapMB="16"
        lodEnterDistance="50" lodExitDistance="75" residencyCooldown="1" lodToggleBudget="10000">
+    <!-- Materials support texture paths via diffuseTexture/albedoTexture, specularTexture, and normalTexture. -->
+    <!-- Normal maps flagged this way are imported in linear color space so tangent data is preserved. -->
+    <!-- Example: <Mesh file="assets/statue.obj" normalTexture="assets/statue_normal.png" /> -->
     <CameraPath>
         <!-- Default regression path: retreat over a bridge of geometry so far clusters are unloaded -->
         <Keyframe frame="0" position="0,8,15" lookAt="0,5,-25" />


### PR DESCRIPTION
## Summary
- detect normal map usage and filename hints so texture loading preserves linear tangent-space data
- allow XML scene materials to declare diffuse/specular/normal textures and document the new attributes for authors

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff602152a8832db4047981f344b57e