### PR TITLE
Process pending EXR captures while rendering

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1300,6 +1300,9 @@ void Renderer::processPendingCapturedFrames() {
     }
 
     if (!albedoData.empty() && !normalData.empty()) {
+      std::printf("Applying offline EXR denoiser to frame %llu\n",
+                 static_cast<unsigned long long>(capture->frameIndex));
+
       const int radius = 2;
       const float spatialSigma = 1.0f;
       const float albedoSigma = 0.25f;
@@ -4427,6 +4430,9 @@ void Renderer::updateUniforms(bool cameraChanged) {
 }
 
 void Renderer::draw(MTK::View *pView) {
+  if (_captureOutputsPending.load(std::memory_order_acquire))
+    processPendingCapturedFrames();
+
   processRayHitCounters();
   bool cameraChanged = updateCameraStates();
   Camera::State viewCamera =


### PR DESCRIPTION
## Summary
- process pending EXR captures at the start of each frame so offline denoising happens while capture is enabled
- log when the offline EXR denoiser runs to make denoising progress visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff6427d5cc832da5572a64fa8d9714