### PR TITLE
Defer frame capture processing until after residency updates

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -4430,9 +4430,6 @@ void Renderer::updateUniforms(bool cameraChanged) {
 }
 
 void Renderer::draw(MTK::View *pView) {
-  if (_captureOutputsPending.load(std::memory_order_acquire))
-    processPendingCapturedFrames();
-
   processRayHitCounters();
   bool cameraChanged = updateCameraStates();
   Camera::State viewCamera =
@@ -4442,6 +4439,9 @@ void Renderer::draw(MTK::View *pView) {
   updateResidency();
 
   Camera::applyState(viewCamera);
+  if (_captureOutputsPending.load(std::memory_order_acquire))
+    processPendingCapturedFrames();
+
   Camera::deltaTime =
       _observerActive ? 0.0f : static_cast<float>(_deltaTimeSeconds);
   updateUniforms(cameraChanged);


### PR DESCRIPTION
## Summary
- move the pending capture processing in `Renderer::draw` to run after the residency update so denoising no longer blocks residency changes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ff747d7c84832d9397ea089b512a93