### PR TITLE
Fix dirty resident lookup when rebuilding BLAS resources

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -3436,6 +3436,12 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     _lightCount = _cachedLightIndices.size();
   }
 
+  std::vector<uint8_t> dirtyResidentLookup(sceneObjects.size(), 0);
+  for (size_t dirtyIndex : _dirtyResidentObjects) {
+    if (dirtyIndex < dirtyResidentLookup.size())
+      dirtyResidentLookup[dirtyIndex] = 1;
+  }
+
   for (size_t objectIndex = 0; objectIndex < sceneObjects.size(); ++objectIndex) {
     bool shouldBeResident = objectShouldBeResident[objectIndex];
     auto &gpuResident = _residentObjectGpuResources[objectIndex];
@@ -3443,11 +3449,8 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
 
     if (shouldBeResident) {
       bool requiresRebuild = needFullUpload;
-      if (!requiresRebuild) {
-        requiresRebuild =
-            std::binary_search(_dirtyResidentObjects.begin(),
-                                _dirtyResidentObjects.end(), objectIndex);
-      }
+      if (!requiresRebuild && dirtyResidentLookup[objectIndex])
+        requiresRebuild = true;
       if (!requiresRebuild && !gpuResident.geometryValid)
         requiresRebuild = true;
 


### PR DESCRIPTION
## Summary
- build a lookup table for dirty resident objects before iterating resident objects
- ensure dirty objects request BLAS rebuilds even when the dirty list is unsorted

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff790a2cbc832dbf6507a489cbf694