### PR TITLE
Restore resident rebuild behavior

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -3436,27 +3436,15 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     _lightCount = _cachedLightIndices.size();
   }
 
-  std::vector<uint8_t> dirtyResidentLookup(sceneObjects.size(), 0);
-  for (size_t dirtyIndex : _dirtyResidentObjects) {
-    if (dirtyIndex < dirtyResidentLookup.size())
-      dirtyResidentLookup[dirtyIndex] = 1;
-  }
-
   for (size_t objectIndex = 0; objectIndex < sceneObjects.size(); ++objectIndex) {
     bool shouldBeResident = objectShouldBeResident[objectIndex];
     auto &gpuResident = _residentObjectGpuResources[objectIndex];
     auto &instanceRecord = _instanceRecords[objectIndex];
 
     if (shouldBeResident) {
-      bool requiresRebuild = needFullUpload;
-      if (!requiresRebuild && dirtyResidentLookup[objectIndex])
-        requiresRebuild = true;
-      if (!requiresRebuild && !gpuResident.geometryValid)
-        requiresRebuild = true;
-
       bool built = gpuResident.ensureResident(
           *this, objectIndex, sceneObjects[objectIndex], instanceRecord,
-          requiresRebuild);
+          needFullUpload);
       if (!built) {
         shouldBeResident = false;
         objectShouldBeResident[objectIndex] = false;


### PR DESCRIPTION
## Summary
- remove the temporary dirty-resident lookup in `rebuildResidentResources`
- call `ensureResident` with the original `needFullUpload` flag to match the prior implementation

## Testing
- not run (rayhit budget/crossfire scene build unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ff808fea7c832da8dc501213fe6929