### PR TITLE
Tighten offline denoiser filter

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1303,8 +1303,8 @@ void Renderer::processPendingCapturedFrames() {
       std::printf("Applying offline EXR denoiser to frame %llu\n",
                  static_cast<unsigned long long>(capture->frameIndex));
 
-      const int radius = 2;
-      const float spatialSigma = 1.0f;
+      const int radius = 1;
+      const float spatialSigma = 0.75f;
       const float albedoSigma = 0.25f;
       const float normalSigma = 0.1f;
       std::vector<float> denoised(pixelCount * 3, 0.0f);


### PR DESCRIPTION
## Summary
- reduce the offline EXR denoiser radius to shrink the filter footprint
- adjust the spatial sigma to maintain sharper detail retention when filtering captures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff83559ed0832da52a589920af5ffd