### PR TITLE
Defer frame capture processing until renderer teardown

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -716,7 +716,7 @@ Renderer::Renderer(MTL::Device *pDevice)
 }
 
 Renderer::~Renderer() {
-  processPendingCapturedFrames();
+  flushPendingCaptures();
 
   if (_pSphereBuffer)
     _pSphereBuffer->release();
@@ -834,8 +834,6 @@ void Renderer::setFrameCaptureEnabled(bool enabled) {
   _frameCaptureEnabled = enabled;
   if (_frameCaptureEnabled)
     ensureFrameCaptureDirectory();
-  else if (_captureOutputsPending.load(std::memory_order_acquire))
-    processPendingCapturedFrames();
 }
 
 void Renderer::setFrameCaptureInterval(size_t interval) {
@@ -1476,6 +1474,10 @@ void Renderer::processPendingCapturedFrames() {
       releaseCaptureBuffers();
     }
   }
+}
+
+void Renderer::flushPendingCaptures() {
+  processPendingCapturedFrames();
 }
 
 void Renderer::setDeltaTime(double deltaSeconds) {
@@ -4430,8 +4432,6 @@ void Renderer::draw(MTK::View *pView) {
   updateResidency();
 
   Camera::applyState(viewCamera);
-  if (_captureOutputsPending.load(std::memory_order_acquire))
-    processPendingCapturedFrames();
 
   Camera::deltaTime =
       _observerActive ? 0.0f : static_cast<float>(_deltaTimeSeconds);

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -95,6 +95,7 @@ public:
   bool benchmarkModeEnabled() const { return _benchmarkEnabled; }
   void setFrameCaptureEnabled(bool enabled);
   void setFrameCaptureInterval(size_t interval);
+  void flushPendingCaptures();
 
   bool hasKeyframes() const;
   bool setPrimitiveActive(size_t index, bool active);

--- a/MetalCpp Path Tracer/Window/ViewDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.cpp
@@ -63,6 +63,8 @@ ViewDelegate::~ViewDelegate() {
     _gpuMemLog.close();
   if (_perfLog.is_open())
     _perfLog.close();
+  if (_pRenderer)
+    _pRenderer->flushPendingCaptures();
   delete _pRenderer;
 }
 


### PR DESCRIPTION
## Summary
- add a renderer teardown helper to flush pending frame captures outside the render loop
- stop calling the denoiser when toggling capture mid-run so queued frames wait for shutdown
- ensure the UI delegate triggers the deferred flush when the view is dismissed

## Testing
- not run (Metal capture workflow requires the macOS runtime environment)


------
https://chatgpt.com/codex/tasks/task_e_68ff85159180832d8f62061ec8807091