### PR TITLE
Implement dynamic sample dispatch budgeting

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -231,6 +231,7 @@ struct UniformsData {
   uint32_t minSamplesPerPixel = 1;
   uint32_t maxSamplesPerPixel = 1;
   uint32_t textureCount = 0;
+  uint32_t maxSamplesPerDispatch = 1;
 };
 
 struct TileDispatchRegion {
@@ -819,6 +820,7 @@ Renderer::Renderer(MTL::Device *pDevice)
 
   recalculateViewport();
   initializeBenchmarking();
+  _maxSamplesPerDispatchBudget = std::max(_maxSamplesPerPixel, 1u);
 }
 
 Renderer::~Renderer() {
@@ -4914,6 +4916,13 @@ void Renderer::updateUniforms(bool cameraChanged) {
   u.sampleImportanceTextureIndex = 3;
   u.minSamplesPerPixel = minSamples;
   u.maxSamplesPerPixel = maxSamples;
+  if (_maxSamplesPerDispatchBudget == 0)
+    _maxSamplesPerDispatchBudget = maxSamples;
+  uint32_t dispatchBudget =
+      std::max<uint32_t>(_maxSamplesPerDispatchBudget, 1);
+  dispatchBudget = std::min(dispatchBudget, maxSamples);
+  _maxSamplesPerDispatchBudget = dispatchBudget;
+  u.maxSamplesPerDispatch = dispatchBudget;
   size_t boundTextureCount = std::min(
       _materialTextures.size(), static_cast<size_t>(kMaxMaterialTextureSlots));
   u.textureCount = static_cast<uint32_t>(boundTextureCount);
@@ -5125,7 +5134,10 @@ void Renderer::draw(MTK::View *pView) {
     size_t tileIndex = 0;
     const size_t maxWorkPerCommand =
         std::max<size_t>(kMaxTileSampleWorkPerCommand, 1);
-    const size_t effectiveMaxSamples = std::max<size_t>(maxSamples, 1);
+    const size_t effectiveMaxSamples = std::max<size_t>(
+        std::min<size_t>(maxSamples,
+                          static_cast<size_t>(_maxSamplesPerDispatchBudget)),
+        size_t(1));
 
     while (tileIndex < tiles.size()) {
       size_t batchStart = tileIndex;
@@ -7076,6 +7088,53 @@ void Renderer::beginFrameMetrics() {
   }
 }
 
+void Renderer::updateDispatchSampleBudget() {
+  uint32_t maxSamples = std::max(_minSamplesPerPixel, _maxSamplesPerPixel);
+  maxSamples = std::max<uint32_t>(maxSamples, 1u);
+
+  if (_maxSamplesPerDispatchBudget == 0)
+    _maxSamplesPerDispatchBudget = maxSamples;
+
+  if (_targetFrameTimeSeconds <= 0.0)
+    _targetFrameTimeSeconds = 1.0 / 60.0;
+
+  double measured = _lastCPUTime;
+  if (measured <= 0.0)
+    return;
+
+  constexpr double smoothing = 0.1;
+  if (_smoothedCpuFrameTimeSeconds <= 0.0) {
+    _smoothedCpuFrameTimeSeconds = measured;
+  } else {
+    _smoothedCpuFrameTimeSeconds =
+        _smoothedCpuFrameTimeSeconds * (1.0 - smoothing) + measured * smoothing;
+  }
+
+  double target = _targetFrameTimeSeconds;
+  double tolerance = target * 0.05;
+  double smoothed = _smoothedCpuFrameTimeSeconds;
+
+  if (smoothed > target + tolerance) {
+    double overRatio = std::min(smoothed / target, 4.0);
+    uint32_t reduction = static_cast<uint32_t>(
+        std::ceil(double(_maxSamplesPerDispatchBudget) * (overRatio - 1.0) * 0.5));
+    reduction = std::max<uint32_t>(reduction, 1u);
+    if (_maxSamplesPerDispatchBudget > 1u)
+      _maxSamplesPerDispatchBudget =
+          std::max<uint32_t>(1u, _maxSamplesPerDispatchBudget - reduction);
+  } else if (smoothed < target - tolerance) {
+    double underRatio = std::min(target / std::max(smoothed, 1e-6), 4.0);
+    uint32_t increase = static_cast<uint32_t>(
+        std::ceil(double(_maxSamplesPerDispatchBudget) * (underRatio - 1.0) * 0.5));
+    increase = std::max<uint32_t>(increase, 1u);
+    _maxSamplesPerDispatchBudget = std::min<uint32_t>(
+        _maxSamplesPerDispatchBudget + increase, maxSamples);
+  }
+
+  _maxSamplesPerDispatchBudget =
+      std::clamp(_maxSamplesPerDispatchBudget, 1u, maxSamples);
+}
+
 void Renderer::completeFrameMetrics(MTL::CommandBuffer *pCmd) {
   auto cpuEnd = std::chrono::high_resolution_clock::now();
   _lastCPUTime = std::chrono::duration<double>(cpuEnd - _cpuStart).count();
@@ -7089,6 +7148,7 @@ void Renderer::completeFrameMetrics(MTL::CommandBuffer *pCmd) {
   } else {
     _lastRaysPerSecond = 0.0;
   }
+  updateDispatchSampleBudget();
   size_t offloaded = _totalNodeCount > _residentNodeCount ?
                          _totalNodeCount - _residentNodeCount :
                          0;

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -146,6 +146,7 @@ private:
   bool updateAlwaysResident(bool forceAllToggles);
   void flushResidencyChanges(bool forceFullRebuild);
   void beginFrameMetrics();
+  void updateDispatchSampleBudget();
   void completeFrameMetrics(MTL::CommandBuffer *pCmd);
   void trackFrameCommandBuffer(MTL::CommandBuffer *commandBuffer);
   void waitForPendingFrameCommands();
@@ -456,6 +457,8 @@ private:
   size_t _lastRayCount = 0;
 
   double _deltaTimeSeconds = 0.0;
+  double _targetFrameTimeSeconds = 1.0 / 60.0;
+  double _smoothedCpuFrameTimeSeconds = 0.0;
 
   size_t _animationFrame = 0;
 
@@ -483,6 +486,7 @@ private:
 
   uint32_t _minSamplesPerPixel = 1;
   uint32_t _maxSamplesPerPixel = 4;
+  uint32_t _maxSamplesPerDispatchBudget = 4;
   bool _needsAccumulationReset = true;
   bool _accumulationTargetsNeedClear = false;
   MTL::Buffer *_pTextureClearBuffer = nullptr;

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -58,11 +58,31 @@ kernel void pathTraceKernel(
   if (!isfinite(desiredSamples))
     desiredSamples = float(u.minSamplesPerPixel);
 
-  uint samplesThisFrame = uint(round(desiredSamples));
-  samplesThisFrame = clamp(samplesThisFrame, u.minSamplesPerPixel, u.maxSamplesPerPixel);
-  samplesThisFrame = max(samplesThisFrame, 1u);
+  desiredSamples = clamp(desiredSamples, float(u.minSamplesPerPixel),
+                         float(u.maxSamplesPerPixel));
 
-  float previousSampleCount = float(sampleCount.read(pixel).x);
+  uint requestedSamples = uint(round(desiredSamples));
+  requestedSamples = clamp(requestedSamples, u.minSamplesPerPixel,
+                           u.maxSamplesPerPixel);
+
+  float storedSampleCount = float(sampleCount.read(pixel).x);
+  uint previousSamples = uint(round(storedSampleCount));
+  uint targetSamples = max(u.maxSamplesPerPixel, u.minSamplesPerPixel);
+  previousSamples = min(previousSamples, targetSamples);
+  uint remainingTargetSamples = 0u;
+  if (previousSamples < targetSamples)
+    remainingTargetSamples = targetSamples - previousSamples;
+
+  uint dispatchBudget = max(u.maxSamplesPerDispatch, 1u);
+  uint samplesThisFrame = requestedSamples;
+  samplesThisFrame = min(samplesThisFrame, remainingTargetSamples);
+  samplesThisFrame = min(samplesThisFrame, dispatchBudget);
+
+  if (samplesThisFrame == 0u && remainingTargetSamples > 0u &&
+      dispatchBudget > 0u)
+    samplesThisFrame = min(remainingTargetSamples, dispatchBudget);
+
+  float previousSampleCount = float(previousSamples);
   float4 previousColor = float4(lastFrame.read(pixel));
 
   float3 accumulatedColor = float3(0.0);

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -77,6 +77,7 @@ struct UniformsData
     uint minSamplesPerPixel;
     uint maxSamplesPerPixel;
     uint textureCount;
+    uint maxSamplesPerDispatch;
 };
 
 struct TileRegion


### PR DESCRIPTION
## Summary
- add CPU frame-time tracking to derive a dynamic `maxSamplesPerDispatch` budget
- clamp per-dispatch sampling work and continue accumulating pixel progress across frames
- expose the new budget in uniforms and use it when scheduling tile dispatches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69009691c1d4832d89bd3fcadc56d95f