### PR TITLE
Normalize adaptive sampling gradients and add importance debug view

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -232,6 +232,8 @@ struct UniformsData {
   uint32_t maxSamplesPerPixel = 1;
   uint32_t textureCount = 0;
   uint32_t maxSamplesPerDispatch = 1;
+  uint32_t debugOutputMode = 0;
+  float importanceVisualizationScale = 1.0f;
 };
 
 struct TileDispatchRegion {
@@ -4702,7 +4704,7 @@ void Renderer::buildTextures() {
   configureTextureSlot(_sampleCountSlot, width, height,
                        MTL::PixelFormat::PixelFormatR16Float, usage);
   configureTextureSlot(_sampleImportanceSlot, width, height,
-                       MTL::PixelFormat::PixelFormatR16Float, usage);
+                       MTL::PixelFormat::PixelFormatRGBA16Float, usage);
   configureTextureSlot(_albedoSlot, width, height,
                        MTL::PixelFormat::PixelFormatRGBA16Float, usage);
   configureTextureSlot(_normalSlot, width, height,
@@ -4779,7 +4781,8 @@ void Renderer::updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd) {
     return;
   MTL::Texture *importance = _sampleImportanceSlot.texture;
   MTL::Texture *accumulation = _accumulationSlots[0].texture;
-  if (!importance || !accumulation || !_pUniformsBuffer)
+  MTL::Texture *sampleCount = _sampleCountSlot.texture;
+  if (!importance || !accumulation || !sampleCount || !_pUniformsBuffer)
     return;
 
   NS::UInteger width = importance->width();
@@ -4794,6 +4797,7 @@ void Renderer::updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd) {
   pCompute->setComputePipelineState(_pAdaptiveSamplingPSO);
   pCompute->setTexture(accumulation, 0);
   pCompute->setTexture(importance, 1);
+  pCompute->setTexture(sampleCount, 2);
   pCompute->setBuffer(_pUniformsBuffer, 0, 0);
 
   const NS::UInteger threadWidth = 8;
@@ -4960,6 +4964,8 @@ void Renderer::updateUniforms(bool cameraChanged) {
   u.debugAS = InputSystem::debugAS;
   u.lightCount = static_cast<uint32_t>(_lightCount);
   u.lightTotalWeight = _lightTotalWeight;
+  u.debugOutputMode = InputSystem::importanceDebugMode;
+  u.importanceVisualizationScale = _importanceVisualizationScale;
 
   markBufferModified(_pUniformsBuffer, NS::Range::Make(0, sizeof(UniformsData)));
 }
@@ -5263,6 +5269,9 @@ void Renderer::draw(MTK::View *pView) {
 
   pEnc->setRenderPipelineState(_pPSO);
   pEnc->setFragmentTexture(accum1, 0);
+  pEnc->setFragmentTexture(sampleImportance, 1);
+  if (_pUniformsBuffer)
+    pEnc->setFragmentBuffer(_pUniformsBuffer, 0, 0);
 
   pEnc->drawPrimitives(MTL::PrimitiveType::PrimitiveTypeTriangle,
                        NS::UInteger(0), NS::UInteger(6));
@@ -5318,6 +5327,9 @@ void Renderer::draw(MTK::View *pView) {
 
       pEnc->setRenderPipelineState(_pPSO);
       pEnc->setFragmentTexture(accum1, 0);
+      pEnc->setFragmentTexture(sampleImportance, 1);
+      if (_pUniformsBuffer)
+        pEnc->setFragmentBuffer(_pUniformsBuffer, 0, 0);
     }
   }
 

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -487,6 +487,7 @@ private:
   uint32_t _minSamplesPerPixel = 1;
   uint32_t _maxSamplesPerPixel = 4;
   uint32_t _maxSamplesPerDispatchBudget = 4;
+  float _importanceVisualizationScale = 1.5f;
   bool _needsAccumulationReset = true;
   bool _accumulationTargetsNeedClear = false;
   MTL::Buffer *_pTextureClearBuffer = nullptr;

--- a/MetalCpp Path Tracer/Renderer/Shaders/AdaptiveSampling.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/AdaptiveSampling.metal
@@ -20,6 +20,7 @@ inline float fetchLuminance(texture2d<half, access::read> accumulation,
 kernel void adaptiveSamplingMain(
     texture2d<half, access::read> accumulation [[texture(0)]],
     texture2d<half, access::write> importance [[texture(1)]],
+    texture2d<half, access::read> sampleCountTex [[texture(2)]],
     constant UniformsData& uniforms [[buffer(0)]],
     uint2 gid [[thread_position_in_grid]])
 {
@@ -43,16 +44,55 @@ kernel void adaptiveSamplingMain(
     float diag2 = fetchLuminance(accumulation, width, height, coord + int2(-1, 1));
     float diag3 = fetchLuminance(accumulation, width, height, coord + int2(1, 1));
 
-    float gradient = fabs(right - left) + fabs(down - up);
-    float diagonal = fabs(diag0 - diag3) + fabs(diag1 - diag2);
-    float contrast = fabs(center - 0.25f * (left + right + up + down));
+    float mean = (center + left + right + up + down + diag0 + diag1 + diag2 + diag3) / 9.0f;
+    float safeMean = max(mean, 1e-4f);
+    float invMean = 1.0f / safeMean;
 
-    float detail = gradient + 0.5f * diagonal + 4.0f * contrast;
-    detail = clamp(detail, 0.0f, 1.0f);
+    float gradient = (fabs(right - left) + fabs(down - up)) * invMean;
+    float diagonal = (fabs(diag0 - diag3) + fabs(diag1 - diag2)) * invMean;
+    float contrast =
+        fabs(center - 0.25f * (left + right + up + down)) * invMean;
 
+    float variance = 0.0f;
+    variance += (center - mean) * (center - mean);
+    variance += (left - mean) * (left - mean);
+    variance += (right - mean) * (right - mean);
+    variance += (up - mean) * (up - mean);
+    variance += (down - mean) * (down - mean);
+    variance += (diag0 - mean) * (diag0 - mean);
+    variance += (diag1 - mean) * (diag1 - mean);
+    variance += (diag2 - mean) * (diag2 - mean);
+    variance += (diag3 - mean) * (diag3 - mean);
+    variance /= 9.0f;
+
+    float normalizedVariance = variance / (safeMean * safeMean + 1e-8f);
+    float varianceClamped = clamp(normalizedVariance, 0.0f, 4.0f);
+    float varianceSqrt = sqrt(varianceClamped) * 0.5f;
+
+    float spatialDetail = gradient + 0.5f * diagonal + contrast;
+    float normalizedSpatial = clamp(spatialDetail / 3.0f, 0.0f, 1.0f);
+    float baseDetail = clamp(normalizedSpatial + 0.6f * varianceSqrt, 0.0f, 1.0f);
+
+    float historySamples = float(sampleCountTex.read(gid).x);
     float minSamples = float(max(uniforms.minSamplesPerPixel, 1u));
-    float maxSamples = float(max(uniforms.maxSamplesPerPixel, uniforms.minSamplesPerPixel));
-    float sampleBudget = mix(minSamples, maxSamples, detail);
+    float maxSamples =
+        float(max(uniforms.maxSamplesPerPixel, uniforms.minSamplesPerPixel));
+    float completion = (maxSamples > 0.0f)
+                           ? clamp(historySamples / maxSamples, 0.0f, 1.0f)
+                           : 0.0f;
 
-    importance.write(half4(sampleBudget, half(0.0), half(0.0), half(0.0)), gid);
+    float varianceHistory =
+        varianceSqrt * rsqrt(max(historySamples, 1.0f));
+    varianceHistory = clamp(varianceHistory * 1.5f, 0.0f, 1.0f);
+
+    float stability = smoothstep(0.3f, 0.9f, completion);
+    float blendedDetail = mix(baseDetail, varianceHistory, stability);
+    float detailFloor = 0.05f * (1.0f - completion);
+    float finalDetail = clamp(max(blendedDetail, detailFloor), 0.0f, 1.0f);
+
+    float sampleBudget = mix(minSamples, maxSamples, finalDetail);
+
+    importance.write(
+        half4(sampleBudget, half(finalDetail), half(varianceSqrt), half(completion)),
+        gid);
 }

--- a/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Fragment.metal
@@ -4,8 +4,21 @@ using namespace metal;
 
 #include "Structs.h"
 
-fragment float4 presentMain(v2f in [[stage_in]],
-                             texture2d<half, access::sample> accumulation [[texture(0)]]) {
+fragment float4 presentMain(
+    v2f in [[stage_in]],
+    texture2d<half, access::sample> accumulation [[texture(0)]],
+    texture2d<half, access::sample> importance [[texture(1)]],
+    constant UniformsData &uniforms [[buffer(0)]]) {
   constexpr sampler linearSampler(filter::linear, address::clamp_to_edge);
+  if (uniforms.debugOutputMode != 0 && importance.get_width() > 0 &&
+      importance.get_height() > 0) {
+    half4 imp = importance.sample(linearSampler, in.uv);
+    float scale = max(uniforms.importanceVisualizationScale, 0.0f);
+    float detail = clamp(float(imp.y) * scale, 0.0f, 1.0f);
+    float completion = clamp(float(imp.w), 0.0f, 1.0f);
+    float variance = clamp(float(imp.z) * scale, 0.0f, 1.0f);
+    float3 debugColor = float3(detail, completion, variance);
+    return float4(debugColor, 1.0f);
+  }
   return float4(accumulation.sample(linearSampler, in.uv));
 }

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -78,6 +78,8 @@ struct UniformsData
     uint maxSamplesPerPixel;
     uint textureCount;
     uint maxSamplesPerDispatch;
+    uint debugOutputMode;
+    float importanceVisualizationScale;
 };
 
 struct TileRegion

--- a/MetalCpp Path Tracer/Window/ControllerView.mm
+++ b/MetalCpp Path Tracer/Window/ControllerView.mm
@@ -95,6 +95,10 @@ MTK::View *MetalCppPathTracer::ControllerView::get(CGRect frame) {
     if(event.keyCode == 31) { // o - toggle observer camera
         MetalCppPathTracer::InputSystem::observerToggleRequest = true;
     }
+    if(event.keyCode == 34) { // i - toggle adaptive importance visualization
+        MetalCppPathTracer::InputSystem::importanceDebugMode =
+            (MetalCppPathTracer::InputSystem::importanceDebugMode + 1) % 2;
+    }
 }
 
 - (void)keyUp:(NSEvent *)event {

--- a/MetalCpp Path Tracer/Window/InputSystem.h
+++ b/MetalCpp Path Tracer/Window/InputSystem.h
@@ -14,6 +14,7 @@ inline float zoomInput = 0;
 inline bool resetInput = 0;
 inline int debugAS = 0; // 0:none, 1:TLAS, 2:BLAS
 inline bool observerToggleRequest = false;
+inline uint32_t importanceDebugMode = 0; // 0:disabled, 1:importance visualization
 
 inline void clearInputs()
 {


### PR DESCRIPTION
## Summary
- normalize adaptive importance gradients by local luminance and fold in temporal history from the sample-count buffer to avoid bright smooth emitters dominating
- store debug channels in the importance map and expose a toggleable visualization overlay in the present shader
- plumb the new uniforms, textures, and UI toggle through the renderer so converged pixels gravitate toward the minimum SPP

## Testing
- Not run (Metal-only project)


------
https://chatgpt.com/codex/tasks/task_e_69009ada8434832da215bd5e150cce7a