### PR TITLE
Clamp dispatch sample budget reduction

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -7131,9 +7131,13 @@ void Renderer::updateDispatchSampleBudget() {
     uint32_t reduction = static_cast<uint32_t>(
         std::ceil(double(_maxSamplesPerDispatchBudget) * (overRatio - 1.0) * 0.5));
     reduction = std::max<uint32_t>(reduction, 1u);
-    if (_maxSamplesPerDispatchBudget > 1u)
-      _maxSamplesPerDispatchBudget =
-          std::max<uint32_t>(1u, _maxSamplesPerDispatchBudget - reduction);
+    if (_maxSamplesPerDispatchBudget > 1u) {
+      uint32_t newBudget =
+          reduction >= _maxSamplesPerDispatchBudget
+              ? 1u
+              : _maxSamplesPerDispatchBudget - reduction;
+      _maxSamplesPerDispatchBudget = std::max<uint32_t>(newBudget, 1u);
+    }
   } else if (smoothed < target - tolerance) {
     double underRatio = std::min(target / std::max(smoothed, 1e-6), 4.0);
     uint32_t increase = static_cast<uint32_t>(


### PR DESCRIPTION
## Summary
- guard the dispatch sample reduction to clamp at one instead of underflowing
- keep the final clamp to bound the budget between one and the configured maximum

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69009da0a0d4832d91e54d7ffecc0707