### PR TITLE
Adjust decodeMaterial parameter qualifiers

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -64,7 +64,7 @@ inline float3 randomInUnitSphere(thread uint32_t &seed) {
   }
 }
 
-inline MaterialPayload decodeMaterial(const PackedMaterial &m,
+inline MaterialPayload decodeMaterial(thread const PackedMaterial &m,
                                       float lodAttenuation) {
   MaterialPayload payload;
   payload.diffuseColor =


### PR DESCRIPTION
## Summary
- update `decodeMaterial` to accept a `thread const PackedMaterial&` to comply with Metal address space rules

## Testing
- `xcrun metal -c 'MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal' -o /tmp/PathTraceKernel.air` *(fails: `xcrun` not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_6900a3cc1a1c832d9da147a3cf4d3483