### PR TITLE
Add temporal cross-bilateral denoiser

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -43,6 +43,19 @@
 #include "../tinyexr.h"
 
 namespace {
+struct DenoiserUniforms {
+  uint32_t radius = 2;
+  uint32_t historyValid = 0;
+  float temporalBlendBase = 0.85f;
+  float sampleCountForStableHistory = 4.0f;
+  float normalSigma = 0.3f;
+  float albedoSigma = 0.25f;
+  float luminanceSigma = 0.15f;
+  float spatialSigma = 1.5f;
+};
+static_assert(sizeof(DenoiserUniforms) % 16 == 0,
+              "DenoiserUniforms must align to 16 bytes for Metal");
+
 class TaskLimiter {
 public:
   explicit TaskLimiter(size_t maxTasks) : _maxTasks(maxTasks) {}
@@ -899,6 +912,8 @@ Renderer::~Renderer() {
 
   for (auto &slot : _accumulationSlots)
     releaseTextureSlot(slot);
+  for (auto &slot : _denoisedSlots)
+    releaseTextureSlot(slot);
   releaseTextureSlot(_sampleCountSlot);
   releaseTextureSlot(_sampleImportanceSlot);
   releaseTextureSlot(_albedoSlot);
@@ -911,6 +926,8 @@ Renderer::~Renderer() {
     _pPathTracePSO->release();
   if (_pAdaptiveSamplingPSO)
     _pAdaptiveSamplingPSO->release();
+  if (_pDenoiserPSO)
+    _pDenoiserPSO->release();
   if (_pOverlayPSO)
     _pOverlayPSO->release();
 
@@ -1635,6 +1652,10 @@ void Renderer::buildShaders() {
     _pAdaptiveSamplingPSO->release();
     _pAdaptiveSamplingPSO = nullptr;
   }
+  if (_pDenoiserPSO) {
+    _pDenoiserPSO->release();
+    _pDenoiserPSO = nullptr;
+  }
 
   NS::Error *pError = nullptr;
   MTL::Library *pLibrary = _pDevice->newDefaultLibrary();
@@ -1743,6 +1764,17 @@ void Renderer::buildShaders() {
       __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
     }
     pAdaptiveFn->release();
+  }
+
+  pError = nullptr;
+  MTL::Function *pDenoiserFn =
+      pLibrary->newFunction(NS::String::string("denoiseMain", UTF8StringEncoding));
+  if (pDenoiserFn) {
+    _pDenoiserPSO = _pDevice->newComputePipelineState(pDenoiserFn, &pError);
+    if (!_pDenoiserPSO && pError) {
+      __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
+    }
+    pDenoiserFn->release();
   }
 
   pVertexFn->release();
@@ -4475,6 +4507,10 @@ const char *Renderer::textureSlotLabel(const ManagedTextureSlot &slot) const {
     return "_albedoSlot";
   if (&slot == &_normalSlot)
     return "_normalSlot";
+  if (&slot == &_denoisedSlots[0])
+    return "_denoisedSlots[0]";
+  if (&slot == &_denoisedSlots[1])
+    return "_denoisedSlots[1]";
   return "<unknown texture slot>";
 }
 
@@ -4693,9 +4729,10 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
   if (!belowBudget && !overMemory)
     return;
 
-  std::array<ManagedTextureSlot *, 6> slots = {
+  std::array<ManagedTextureSlot *, 8> slots = {
       &_accumulationSlots[0], &_accumulationSlots[1], &_sampleCountSlot,
-      &_sampleImportanceSlot, &_albedoSlot, &_normalSlot};
+      &_sampleImportanceSlot, &_albedoSlot, &_normalSlot,
+      &_denoisedSlots[0], &_denoisedSlots[1]};
 
   MTL::BlitCommandEncoder *blit = nullptr;
   for (ManagedTextureSlot *slot : slots)
@@ -4808,6 +4845,9 @@ void Renderer::buildTextures() {
   for (auto &slot : _accumulationSlots)
     configureTextureSlot(slot, width, height,
                          MTL::PixelFormat::PixelFormatRGBA16Float, usage);
+  for (auto &slot : _denoisedSlots)
+    configureTextureSlot(slot, width, height,
+                         MTL::PixelFormat::PixelFormatRGBA16Float, usage);
   configureTextureSlot(_sampleCountSlot, width, height,
                        MTL::PixelFormat::PixelFormatR16Float, usage);
   configureTextureSlot(_sampleImportanceSlot, width, height,
@@ -4825,9 +4865,10 @@ bool Renderer::resetAccumulationTargets(MTL::CommandBuffer *cmd) {
   if (!cmd)
     return false;
 
-  std::array<ManagedTextureSlot *, 6> slots = {
+  std::array<ManagedTextureSlot *, 8> slots = {
       &_accumulationSlots[0], &_accumulationSlots[1], &_sampleCountSlot,
-      &_sampleImportanceSlot, &_albedoSlot, &_normalSlot};
+      &_sampleImportanceSlot, &_albedoSlot, &_normalSlot,
+      &_denoisedSlots[0], &_denoisedSlots[1]};
 
   bool anyDescriptors = false;
   bool allResident = true;
@@ -5014,8 +5055,10 @@ void Renderer::updateUniforms(bool cameraChanged) {
       u.randomSeed = {randomFloat(), randomFloat(), randomFloat()};
     }
     u.frameCount = 0;
+    _framesSinceAccumulationReset = 0;
   } else {
     u.frameCount++;
+    ++_framesSinceAccumulationReset;
   }
 
   uint32_t minSamples = std::min(_minSamplesPerPixel, _maxSamplesPerPixel);
@@ -5094,6 +5137,7 @@ void Renderer::draw(MTK::View *pView) {
   updateUniforms(cameraChanged);
   beginFrameMetrics();
   std::swap(_accumulationSlots[0], _accumulationSlots[1]);
+  std::swap(_denoisedSlots[0], _denoisedSlots[1]);
 
   uint64_t frameIndex = _renderedFrameCount;
   bool captureThisFrame = _frameCaptureEnabled && _frameCaptureInterval > 0 &&
@@ -5135,6 +5179,8 @@ void Renderer::draw(MTK::View *pView) {
   MTL::Texture *sampleImportance = _sampleImportanceSlot.texture;
   MTL::Texture *albedoTexture = _albedoSlot.texture;
   MTL::Texture *normalTexture = _normalSlot.texture;
+  MTL::Texture *denoisedHistory = _denoisedSlots[0].texture;
+  MTL::Texture *denoisedOutput = _denoisedSlots[1].texture;
   if (allowResidency) {
     accum0 = requestResidentTexture(_accumulationSlots[0], prepCmd, restoreBlit);
     accum1 = requestResidentTexture(_accumulationSlots[1], prepCmd, restoreBlit);
@@ -5143,13 +5189,16 @@ void Renderer::draw(MTK::View *pView) {
         requestResidentTexture(_sampleImportanceSlot, prepCmd, restoreBlit);
     albedoTexture = requestResidentTexture(_albedoSlot, prepCmd, restoreBlit);
     normalTexture = requestResidentTexture(_normalSlot, prepCmd, restoreBlit);
+    denoisedHistory =
+        requestResidentTexture(_denoisedSlots[0], prepCmd, restoreBlit);
+    denoisedOutput =
+        requestResidentTexture(_denoisedSlots[1], prepCmd, restoreBlit);
   }
   if (restoreBlit)
     restoreBlit->endEncoding();
 
-  bool haveAllTextures =
-      accum0 && accum1 && sampleCount && sampleImportance && albedoTexture &&
-      normalTexture;
+  bool haveAllTextures = accum0 && accum1 && sampleCount && sampleImportance &&
+                         albedoTexture && normalTexture && denoisedOutput;
 
   if (_accumulationTargetsNeedClear && haveAllTextures) {
     if (resetAccumulationTargets(prepCmd)) {
@@ -5486,6 +5535,64 @@ void Renderer::draw(MTK::View *pView) {
   _lastCommandSubmissionSeconds =
       measuredSubmission ? commandSubmissionSeconds : 0.0;
 
+  bool denoiserRan = false;
+
+  if (_pDenoiserPSO && denoisedOutput && accum1 && albedoTexture &&
+      normalTexture && sampleCount) {
+    MTL::CommandBuffer *denoiseCmd = _pCommandQueue->commandBuffer();
+    if (denoiseCmd) {
+      MTL::ComputeCommandEncoder *denoiseEncoder =
+          denoiseCmd->computeCommandEncoder();
+      if (denoiseEncoder) {
+        denoiseEncoder->setComputePipelineState(_pDenoiserPSO);
+
+        MTL::Texture *historyTexture =
+            denoisedHistory ? denoisedHistory : accum1;
+        denoiseEncoder->setTexture(accum1, 0);
+        denoiseEncoder->setTexture(historyTexture, 1);
+        denoiseEncoder->setTexture(albedoTexture, 2);
+        denoiseEncoder->setTexture(normalTexture, 3);
+        denoiseEncoder->setTexture(sampleCount, 4);
+        denoiseEncoder->setTexture(denoisedOutput, 5);
+
+        DenoiserUniforms params{};
+        params.historyValid =
+            (historyTexture && historyTexture != accum1 &&
+             _framesSinceAccumulationReset > 0)
+                ? 1u
+                : 0u;
+        params.radius = 2u;
+        params.temporalBlendBase = 0.85f;
+        params.sampleCountForStableHistory = 4.0f;
+        params.normalSigma = 0.3f;
+        params.albedoSigma = 0.25f;
+        params.luminanceSigma = 0.15f;
+        params.spatialSigma = 1.5f;
+        denoiseEncoder->setBytes(&params, sizeof(params), 0);
+
+        NS::UInteger width = denoisedOutput->width();
+        NS::UInteger height = denoisedOutput->height();
+        if (width > 0 && height > 0) {
+          NS::UInteger tgWidth =
+              std::max<NS::UInteger>(1, _pDenoiserPSO->threadExecutionWidth());
+          NS::UInteger maxThreads = std::max<NS::UInteger>(
+              tgWidth, _pDenoiserPSO->maxTotalThreadsPerThreadgroup());
+          NS::UInteger tgHeight =
+              std::max<NS::UInteger>(1, maxThreads / tgWidth);
+          MTL::Size threadsPerGroup = MTL::Size::Make(tgWidth, tgHeight, 1);
+          MTL::Size threadgroups = MTL::Size::Make(
+              (width + threadsPerGroup.width - 1) / threadsPerGroup.width,
+              (height + threadsPerGroup.height - 1) / threadsPerGroup.height, 1);
+          denoiseEncoder->dispatchThreadgroups(threadgroups, threadsPerGroup);
+          denoiserRan = true;
+        }
+
+        denoiseEncoder->endEncoding();
+      }
+      denoiseCmd->commit();
+    }
+  }
+
   MTL::CommandBuffer *presentCmd = _pCommandQueue->commandBuffer();
   if (!presentCmd) {
     completeFrameMetrics(nullptr);
@@ -5504,7 +5611,9 @@ void Renderer::draw(MTK::View *pView) {
   MTL::RenderCommandEncoder *pEnc = presentCmd->renderCommandEncoder(pRpd);
 
   pEnc->setRenderPipelineState(_pPSO);
-  pEnc->setFragmentTexture(accum1, 0);
+  MTL::Texture *presentTexture =
+      (denoiserRan && denoisedOutput) ? denoisedOutput : accum1;
+  pEnc->setFragmentTexture(presentTexture, 0);
   pEnc->setFragmentTexture(sampleImportance, 1);
   if (_pUniformsBuffer)
     pEnc->setFragmentBuffer(_pUniformsBuffer, 0, 0);
@@ -5562,7 +5671,7 @@ void Renderer::draw(MTK::View *pView) {
                            NS::UInteger(vertexCount));
 
       pEnc->setRenderPipelineState(_pPSO);
-      pEnc->setFragmentTexture(accum1, 0);
+      pEnc->setFragmentTexture(presentTexture, 0);
       pEnc->setFragmentTexture(sampleImportance, 1);
       if (_pUniformsBuffer)
         pEnc->setFragmentBuffer(_pUniformsBuffer, 0, 0);
@@ -5574,9 +5683,11 @@ void Renderer::draw(MTK::View *pView) {
   MTL::BlitCommandEncoder *pBlit = nullptr;
   bool performedRayHitReadback = false;
 
-  if (captureThisFrame && accum1) {
-    if (auto capture = encodeFrameCapture(accum1, albedoTexture, normalTexture,
-                                          frameIndex, presentCmd, pBlit))
+  if (captureThisFrame && (presentTexture || accum1)) {
+    MTL::Texture *captureTexture = presentTexture ? presentTexture : accum1;
+    if (auto capture =
+            encodeFrameCapture(captureTexture, albedoTexture, normalTexture,
+                               frameIndex, presentCmd, pBlit))
       captureList->push_back(capture);
   }
 
@@ -7382,6 +7493,17 @@ void Renderer::updateDispatchSampleBudget() {
     increase = std::max<uint32_t>(increase, 1u);
     _maxSamplesPerDispatchBudget = std::min<uint32_t>(
         _maxSamplesPerDispatchBudget + increase, maxSamples);
+  }
+
+  if (_pDenoiserPSO && _framesSinceAccumulationReset >= 6) {
+    uint32_t lowTarget = std::max<uint32_t>(_minSamplesPerPixel, 2u);
+    lowTarget = std::min<uint32_t>(lowTarget, maxSamples);
+    if (_maxSamplesPerDispatchBudget > lowTarget) {
+      uint32_t relaxed = static_cast<uint32_t>(
+          std::ceil(static_cast<double>(_maxSamplesPerDispatchBudget) * 0.85));
+      _maxSamplesPerDispatchBudget =
+          std::max<uint32_t>(std::max(lowTarget, relaxed), 1u);
+    }
   }
 
   _maxSamplesPerDispatchBudget =

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -218,6 +218,7 @@ private:
   MTL::RenderPipelineState *_pOverlayPSO = nullptr;
   MTL::ComputePipelineState *_pPathTracePSO = nullptr;
   MTL::ComputePipelineState *_pAdaptiveSamplingPSO = nullptr;
+  MTL::ComputePipelineState *_pDenoiserPSO = nullptr;
 
   // Core scene and geometry data
   Scene *_pScene = nullptr;
@@ -272,6 +273,7 @@ private:
   ManagedTextureSlot _sampleImportanceSlot;
   ManagedTextureSlot _albedoSlot;
   ManagedTextureSlot _normalSlot;
+  ManagedTextureSlot _denoisedSlots[2];
 
   struct PendingBlasBuild {
     Renderer *renderer = nullptr;
@@ -503,6 +505,7 @@ private:
   uint32_t _minSamplesPerPixel = 1;
   uint32_t _maxSamplesPerPixel = 4;
   uint32_t _maxSamplesPerDispatchBudget = 4;
+  size_t _framesSinceAccumulationReset = 0;
   float _importanceVisualizationScale = 1.5f;
   bool _needsAccumulationReset = true;
   bool _accumulationTargetsNeedClear = false;

--- a/MetalCpp Path Tracer/Renderer/Shaders/Denoiser.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Denoiser.metal
@@ -1,0 +1,125 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct DenoiserUniforms {
+    uint radius;
+    uint historyValid;
+    float temporalBlendBase;
+    float sampleCountForStableHistory;
+    float normalSigma;
+    float albedoSigma;
+    float luminanceSigma;
+    float spatialSigma;
+};
+
+inline float gaussianWeight(float distance, float sigma) {
+    float safeSigma = max(sigma, 1e-3f);
+    return exp(-distance / (2.0f * safeSigma * safeSigma));
+}
+
+inline float3 sanitizeNormal(float3 normal) {
+    float lenSq = dot(normal, normal);
+    if (lenSq < 1e-6f) {
+        return float3(0.0f);
+    }
+    return normal / sqrt(lenSq);
+}
+
+inline float luminance(float3 color) {
+    const float3 weights = float3(0.299f, 0.587f, 0.114f);
+    return dot(color, weights);
+}
+
+kernel void denoiseMain(texture2d<half, access::read> currentFrame [[texture(0)]],
+                        texture2d<half, access::read> lastFrame [[texture(1)]],
+                        texture2d<half, access::read> albedoAccum [[texture(2)]],
+                        texture2d<half, access::read> normalAccum [[texture(3)]],
+                        texture2d<half, access::read> sampleCountTex [[texture(4)]],
+                        texture2d<half, access::write> outputFrame [[texture(5)]],
+                        constant DenoiserUniforms &params [[buffer(0)]],
+                        uint2 gid [[thread_position_in_grid]]) {
+    uint width = outputFrame.get_width();
+    uint height = outputFrame.get_height();
+    if (gid.x >= width || gid.y >= height)
+        return;
+
+    half4 currentSample = currentFrame.read(gid);
+    float3 currentColor = float3(currentSample.xyz);
+
+    half4 historySample = lastFrame.read(gid);
+    float3 historyColor = float3(historySample.xyz);
+
+    half4 albedoSample = albedoAccum.read(gid);
+    float3 baseAlbedo = float3(albedoSample.xyz);
+
+    half4 normalSample = normalAccum.read(gid);
+    float3 baseNormal = sanitizeNormal(float3(normalSample.xyz));
+
+    float sampleCount = float(sampleCountTex.read(gid).x);
+    float sampleFactor = clamp(sampleCount / max(params.sampleCountForStableHistory, 1.0f), 0.0f, 1.0f);
+
+    float historyWeight = 0.0f;
+    if (params.historyValid != 0) {
+        float lumCurr = luminance(currentColor);
+        float lumHist = luminance(historyColor);
+        float diff = fabs(lumCurr - lumHist);
+        float luminanceWeight = gaussianWeight(diff * diff, max(params.luminanceSigma, 1e-3f));
+        historyWeight = params.temporalBlendBase * sampleFactor * luminanceWeight;
+    }
+    historyWeight = clamp(historyWeight, 0.0f, 0.95f);
+    float3 temporalColor = mix(currentColor, historyColor, historyWeight);
+
+    int radius = int(params.radius);
+    float3 accumColor = float3(0.0f);
+    float accumWeight = 0.0f;
+    float spatialSigma = max(params.spatialSigma, 0.5f);
+    float normalSigma = max(params.normalSigma, 1e-3f);
+    float albedoSigma = max(params.albedoSigma, 1e-3f);
+
+    for (int y = -radius; y <= radius; ++y) {
+        int iy = clamp(int(gid.y) + y, 0, int(height) - 1);
+        for (int x = -radius; x <= radius; ++x) {
+            int ix = clamp(int(gid.x) + x, 0, int(width) - 1);
+            uint2 coord = uint2(ix, iy);
+
+            float distance2 = float(x * x + y * y);
+            float spatialWeight = gaussianWeight(distance2, spatialSigma);
+
+            half4 neighborAlbedoSample = albedoAccum.read(coord);
+            float3 neighborAlbedo = float3(neighborAlbedoSample.xyz);
+            float3 albedoDiff = neighborAlbedo - baseAlbedo;
+            float albedoWeight = gaussianWeight(dot(albedoDiff, albedoDiff), albedoSigma);
+
+            half4 neighborNormalSample = normalAccum.read(coord);
+            float3 neighborNormal = sanitizeNormal(float3(neighborNormalSample.xyz));
+            float3 normalDiff = neighborNormal - baseNormal;
+            float normalWeight = gaussianWeight(dot(normalDiff, normalDiff), normalSigma);
+
+            half4 neighborCurrentSample = currentFrame.read(coord);
+            float3 neighborCurrent = float3(neighborCurrentSample.xyz);
+            half4 neighborHistorySample = lastFrame.read(coord);
+            float3 neighborHistory = float3(neighborHistorySample.xyz);
+            float neighborSamples = float(sampleCountTex.read(coord).x);
+            float neighborFactor = clamp(neighborSamples / max(params.sampleCountForStableHistory, 1.0f), 0.0f, 1.0f);
+            float neighborHistoryWeight = 0.0f;
+            if (params.historyValid != 0) {
+                float lumCurr = luminance(neighborCurrent);
+                float lumHist = luminance(neighborHistory);
+                float diff = fabs(lumCurr - lumHist);
+                float lumWeight = gaussianWeight(diff * diff, max(params.luminanceSigma, 1e-3f));
+                neighborHistoryWeight = params.temporalBlendBase * neighborFactor * lumWeight;
+            }
+            neighborHistoryWeight = clamp(neighborHistoryWeight, 0.0f, 0.95f);
+            float3 neighborTemporal = mix(neighborCurrent, neighborHistory, neighborHistoryWeight);
+
+            float weight = spatialWeight * normalWeight * albedoWeight;
+            accumColor += neighborTemporal * weight;
+            accumWeight += weight;
+        }
+    }
+
+    float3 filtered = accumWeight > 0.0f ? accumColor / accumWeight : temporalColor;
+    filtered = clamp(filtered, 0.0f, 1.0f);
+    outputFrame.write(half4(float4(filtered, 1.0f)), gid);
+}


### PR DESCRIPTION
## Summary
- add a temporal accumulation + cross-bilateral denoiser compute shader and register its pipeline
- manage denoiser history/output textures in the renderer, dispatch the filter each frame, and present the filtered image
- track frames since the last accumulation reset so adaptive sampling can bias toward lower SPP once the denoiser stabilizes

## Testing
- not run (Metal runtime unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6900a83cc9b8832db490d73262ba3f3d