### PR TITLE
Add camera motion decay for accumulation buffers

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -264,6 +264,10 @@ constexpr uint32_t kPathTraceTileHeight = 128;
 constexpr size_t kBaseTileSampleWorkPerCommand = 256 * 256 * 4;
 constexpr size_t kCommandSubmissionWorkMultiplier = 8;
 constexpr uint32_t kMaxMaterialTextureSlots = 64;
+constexpr float kCameraMotionMatrixThreshold = 1e-4f;
+constexpr float kCameraMotionSmoothing = 0.9f;
+constexpr float kAccumulationMotionDecayFactor = 0.25f;
+constexpr float kPendingDecayEpsilon = 1e-3f;
 
 inline uint32_t bitm_random() {
   static uint32_t current_seed = 92407235;
@@ -290,6 +294,18 @@ size_t saturatingMul(size_t a, size_t b) {
   if (a > std::numeric_limits<size_t>::max() / b)
     return std::numeric_limits<size_t>::max();
   return a * b;
+}
+
+float maxAbsDifference(const simd::float4x4 &a, const simd::float4x4 &b) {
+  float result = 0.0f;
+  for (int column = 0; column < 4; ++column) {
+    const simd::float4 delta = a.columns[column] - b.columns[column];
+    result = std::max(result, std::fabs(delta.x));
+    result = std::max(result, std::fabs(delta.y));
+    result = std::max(result, std::fabs(delta.z));
+    result = std::max(result, std::fabs(delta.w));
+  }
+  return result;
 }
 
 constexpr size_t kTextureResidencyPrimitiveBudget = 1;
@@ -926,6 +942,8 @@ Renderer::~Renderer() {
     _pPathTracePSO->release();
   if (_pAdaptiveSamplingPSO)
     _pAdaptiveSamplingPSO->release();
+  if (_pAccumulationDecayPSO)
+    _pAccumulationDecayPSO->release();
   if (_pDenoiserPSO)
     _pDenoiserPSO->release();
   if (_pOverlayPSO)
@@ -1652,6 +1670,10 @@ void Renderer::buildShaders() {
     _pAdaptiveSamplingPSO->release();
     _pAdaptiveSamplingPSO = nullptr;
   }
+  if (_pAccumulationDecayPSO) {
+    _pAccumulationDecayPSO->release();
+    _pAccumulationDecayPSO = nullptr;
+  }
   if (_pDenoiserPSO) {
     _pDenoiserPSO->release();
     _pDenoiserPSO = nullptr;
@@ -1764,6 +1786,18 @@ void Renderer::buildShaders() {
       __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
     }
     pAdaptiveFn->release();
+  }
+
+  pError = nullptr;
+  MTL::Function *pDecayFn = pLibrary->newFunction(
+      NS::String::string("accumulationDecayMain", UTF8StringEncoding));
+  if (pDecayFn) {
+    _pAccumulationDecayPSO =
+        _pDevice->newComputePipelineState(pDecayFn, &pError);
+    if (!_pAccumulationDecayPSO && pError) {
+      __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
+    }
+    pDecayFn->release();
   }
 
   pError = nullptr;
@@ -4924,6 +4958,82 @@ bool Renderer::resetAccumulationTargets(MTL::CommandBuffer *cmd) {
   return allResident;
 }
 
+void Renderer::requestAccumulationDecay(float factor) {
+  if (!(factor < 1.0f))
+    return;
+  factor = std::clamp(factor, 0.0f, 1.0f);
+  if (factor >= 1.0f)
+    return;
+  _pendingGpuDecayFactor = std::clamp(_pendingGpuDecayFactor * factor, 0.0f, 1.0f);
+}
+
+bool Renderer::applyAccumulationDecay(MTL::CommandBuffer *cmd, float factor) {
+  if (!cmd || !_pAccumulationDecayPSO)
+    return false;
+
+  factor = std::clamp(factor, 0.0f, 1.0f);
+  if (factor >= 1.0f - kPendingDecayEpsilon)
+    return false;
+
+  MTL::Texture *accum0 = _accumulationSlots[0].texture;
+  MTL::Texture *accum1 = _accumulationSlots[1].texture;
+  MTL::Texture *sampleCount = _sampleCountSlot.texture;
+  MTL::Texture *albedo = _albedoSlot.texture;
+  MTL::Texture *normal = _normalSlot.texture;
+  MTL::Texture *importance = _sampleImportanceSlot.texture;
+  if (!accum0 || !accum1 || !sampleCount || !albedo || !normal || !importance)
+    return false;
+
+  NS::UInteger width = accum0->width();
+  NS::UInteger height = accum0->height();
+  if (width == 0 || height == 0)
+    return false;
+
+  MTL::ComputeCommandEncoder *encoder = cmd->computeCommandEncoder();
+  if (!encoder)
+    return false;
+
+  encoder->setComputePipelineState(_pAccumulationDecayPSO);
+  encoder->setTexture(accum0, 0);
+  encoder->setTexture(accum1, 1);
+  encoder->setTexture(sampleCount, 2);
+  encoder->setTexture(albedo, 3);
+  encoder->setTexture(normal, 4);
+  encoder->setTexture(importance, 5);
+
+  MTL::Texture *denoisedHistory = _denoisedSlots[0].texture;
+  MTL::Texture *denoisedOutput = _denoisedSlots[1].texture;
+  encoder->setTexture(denoisedHistory, 6);
+  encoder->setTexture(denoisedOutput, 7);
+
+  struct AccumulationDecayUniforms {
+    float factor;
+    uint32_t hasHistory;
+    uint32_t hasOutput;
+    uint32_t padding;
+  } uniforms{factor, denoisedHistory ? 1u : 0u, denoisedOutput ? 1u : 0u, 0u};
+
+  encoder->setBytes(&uniforms, sizeof(uniforms), 0);
+
+  NS::UInteger threadWidth =
+      std::max<NS::UInteger>(1, _pAccumulationDecayPSO->threadExecutionWidth());
+  NS::UInteger maxThreads = std::max<NS::UInteger>(
+      threadWidth, _pAccumulationDecayPSO->maxTotalThreadsPerThreadgroup());
+  NS::UInteger threadHeight =
+      std::max<NS::UInteger>(1, maxThreads / threadWidth);
+
+  MTL::Size threadsPerThreadgroup =
+      MTL::Size::Make(threadWidth, threadHeight, 1);
+  MTL::Size threadgroups = MTL::Size::Make(
+      (width + threadsPerThreadgroup.width - 1) / threadsPerThreadgroup.width,
+      (height + threadsPerThreadgroup.height - 1) / threadsPerThreadgroup.height,
+      1);
+
+  encoder->dispatchThreadgroups(threadgroups, threadsPerThreadgroup);
+  encoder->endEncoding();
+  return true;
+}
+
 void Renderer::updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd) {
   if (!_pAdaptiveSamplingPSO || !pCmd)
     return;
@@ -5046,8 +5156,70 @@ bool Renderer::updateCameraStates() {
 void Renderer::updateUniforms(bool cameraChanged) {
   UniformsData &u = *((UniformsData *)_pUniformsBuffer->contents());
 
-  if (cameraChanged)
-    _needsAccumulationReset = true;
+  Camera::State activeCamera{};
+  activeCamera.position = Camera::position;
+  activeCamera.forward = Camera::forward;
+  activeCamera.up = Camera::up;
+  activeCamera.verticalFov = Camera::verticalFov;
+  activeCamera.focalLength = Camera::focalLength;
+
+  float aspect =
+      (Camera::screenSize.y > 0.0f)
+          ? (Camera::screenSize.x / std::max(Camera::screenSize.y, 1e-6f))
+          : 1.0f;
+  constexpr float kViewProjectionNear = 0.1f;
+  constexpr float kViewProjectionFar = 1000.0f;
+  simd::float4x4 viewMatrix = makeViewMatrix(activeCamera);
+  simd::float4x4 projectionMatrix =
+      makePerspectiveMatrix(activeCamera.verticalFov, aspect,
+                            kViewProjectionNear, kViewProjectionFar);
+  simd::float4x4 viewProjection = simd_mul(projectionMatrix, viewMatrix);
+
+  float diffMagnitude = 0.0f;
+  if (_hasPreviousViewProjection) {
+    diffMagnitude =
+        maxAbsDifference(viewProjection, _previousViewProjectionMatrix);
+    float smoothingComplement = std::max(0.0f, 1.0f - kCameraMotionSmoothing);
+    _smoothedCameraMotionMagnitude =
+        _smoothedCameraMotionMagnitude * kCameraMotionSmoothing +
+        diffMagnitude * smoothingComplement;
+  } else {
+    _smoothedCameraMotionMagnitude = 0.0f;
+  }
+
+  bool matrixMotion = _hasPreviousViewProjection &&
+                      (diffMagnitude > kCameraMotionMatrixThreshold ||
+                       _smoothedCameraMotionMagnitude >
+                           kCameraMotionMatrixThreshold);
+  bool motionDetected = cameraChanged || matrixMotion;
+
+  _previousViewProjectionMatrix = viewProjection;
+  _hasPreviousViewProjection = true;
+
+  if (!_needsAccumulationReset && motionDetected) {
+    float decayFactor =
+        std::clamp(kAccumulationMotionDecayFactor, 0.0f, 1.0f);
+    if (decayFactor < 1.0f) {
+      requestAccumulationDecay(decayFactor);
+
+      auto decayCounter = [](auto value, float factor) {
+        using ValueType = decltype(value);
+        if (factor >= 1.0f)
+          return value;
+        double scaled = static_cast<double>(value) * factor;
+        scaled = std::max(0.0, scaled);
+        ValueType decayed = static_cast<ValueType>(std::floor(scaled));
+        if (value > 0 && decayed >= value)
+          decayed = static_cast<ValueType>(value - 1);
+        return decayed;
+      };
+
+      u.frameCount = decayCounter(u.frameCount, decayFactor);
+      _framesSinceAccumulationReset =
+          decayCounter(_framesSinceAccumulationReset, decayFactor);
+      u.randomSeed = {randomFloat(), randomFloat(), randomFloat()};
+    }
+  }
 
   if (_needsAccumulationReset) {
     if (!_accumulationTargetsNeedClear) {
@@ -5199,6 +5371,11 @@ void Renderer::draw(MTK::View *pView) {
 
   bool haveAllTextures = accum0 && accum1 && sampleCount && sampleImportance &&
                          albedoTexture && normalTexture && denoisedOutput;
+
+  if (_pendingGpuDecayFactor < (1.0f - kPendingDecayEpsilon)) {
+    if (applyAccumulationDecay(prepCmd, _pendingGpuDecayFactor))
+      _pendingGpuDecayFactor = 1.0f;
+  }
 
   if (_accumulationTargetsNeedClear && haveAllTextures) {
     if (resetAccumulationTargets(prepCmd)) {

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -194,6 +194,8 @@ private:
                                std::function<void(bool)> completion);
   void updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd);
   bool resetAccumulationTargets(MTL::CommandBuffer *cmd);
+  bool applyAccumulationDecay(MTL::CommandBuffer *cmd, float factor);
+  void requestAccumulationDecay(float factor);
   void rebuildMaterialTextures();
   void clearMaterialTextures();
   void initializeBenchmarking();
@@ -218,6 +220,7 @@ private:
   MTL::RenderPipelineState *_pOverlayPSO = nullptr;
   MTL::ComputePipelineState *_pPathTracePSO = nullptr;
   MTL::ComputePipelineState *_pAdaptiveSamplingPSO = nullptr;
+  MTL::ComputePipelineState *_pAccumulationDecayPSO = nullptr;
   MTL::ComputePipelineState *_pDenoiserPSO = nullptr;
 
   // Core scene and geometry data
@@ -509,6 +512,10 @@ private:
   float _importanceVisualizationScale = 1.5f;
   bool _needsAccumulationReset = true;
   bool _accumulationTargetsNeedClear = false;
+  float _pendingGpuDecayFactor = 1.0f;
+  simd::float4x4 _previousViewProjectionMatrix{};
+  bool _hasPreviousViewProjection = false;
+  float _smoothedCameraMotionMagnitude = 0.0f;
   MTL::Buffer *_pTextureClearBuffer = nullptr;
   size_t _textureClearBufferCapacity = 0;
 

--- a/MetalCpp Path Tracer/Renderer/Shaders/AccumulationDecay.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/AccumulationDecay.metal
@@ -1,0 +1,58 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct AccumulationDecayUniforms {
+    float factor;
+    uint hasHistory;
+    uint hasOutput;
+    uint padding;
+};
+
+kernel void accumulationDecayMain(
+    texture2d<half, access::read_write> accumulationA [[texture(0)]],
+    texture2d<half, access::read_write> accumulationB [[texture(1)]],
+    texture2d<half, access::read_write> sampleCount [[texture(2)]],
+    texture2d<half, access::read_write> albedoAccum [[texture(3)]],
+    texture2d<half, access::read_write> normalAccum [[texture(4)]],
+    texture2d<half, access::read_write> sampleImportance [[texture(5)]],
+    texture2d<half, access::read_write> denoisedHistory [[texture(6)]],
+    texture2d<half, access::read_write> denoisedOutput [[texture(7)]],
+    constant AccumulationDecayUniforms &uniforms [[buffer(0)]],
+    uint2 gid [[thread_position_in_grid]]) {
+  uint width = accumulationA.get_width();
+  uint height = accumulationA.get_height();
+  if (gid.x >= width || gid.y >= height)
+    return;
+
+  float factor = uniforms.factor;
+
+  half4 valueA = accumulationA.read(gid);
+  accumulationA.write(half4(float4(valueA) * factor), gid);
+
+  half4 valueB = accumulationB.read(gid);
+  accumulationB.write(half4(float4(valueB) * factor), gid);
+
+  half4 samples = sampleCount.read(gid);
+  samples.x = half(float(samples.x) * factor);
+  sampleCount.write(samples, gid);
+
+  half4 albedo = albedoAccum.read(gid);
+  albedoAccum.write(half4(float4(albedo) * factor), gid);
+
+  half4 normal = normalAccum.read(gid);
+  normalAccum.write(half4(float4(normal) * factor), gid);
+
+  half4 importance = sampleImportance.read(gid);
+  sampleImportance.write(half4(float4(importance) * factor), gid);
+
+  if (uniforms.hasHistory != 0u) {
+    half4 history = denoisedHistory.read(gid);
+    denoisedHistory.write(half4(float4(history) * factor), gid);
+  }
+
+  if (uniforms.hasOutput != 0u) {
+    half4 output = denoisedOutput.read(gid);
+    denoisedOutput.write(half4(float4(output) * factor), gid);
+  }
+}


### PR DESCRIPTION
## Summary
- detect significant camera motion via view-projection deltas and schedule accumulation decay instead of full resets
- add a compute-based accumulation decay pass that scales color, sample count, and history textures with a tunable factor
- integrate the decay pipeline and random seeding into the render loop while tracking motion state on the CPU

## Testing
- Not run (Metal renderer cannot be executed in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6900ac4c4590832d8eb644ac7bbb68f6