### PR TITLE
Add history sampling toggle for path tracer

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -246,6 +246,7 @@ struct UniformsData {
   uint32_t textureCount = 0;
   uint32_t maxSamplesPerDispatch = 1;
   uint32_t debugOutputMode = 0;
+  uint32_t historyAccumulationEnabled = 1;
   float importanceVisualizationScale = 1.0f;
 };
 
@@ -988,6 +989,14 @@ void Renderer::setFrameCaptureInterval(size_t interval) {
   if (interval == 0)
     interval = 1;
   _frameCaptureInterval = interval;
+}
+
+void Renderer::setHistorySamplingEnabled(bool enabled) {
+  if (_historySamplingEnabled == enabled)
+    return;
+
+  _historySamplingEnabled = enabled;
+  _needsAccumulationReset = true;
 }
 
 void Renderer::initializeBenchmarking() {
@@ -5114,6 +5123,7 @@ void Renderer::updateUniforms(bool cameraChanged) {
   u.debugAS = InputSystem::debugAS;
   u.lightCount = static_cast<uint32_t>(_lightCount);
   u.debugOutputMode = InputSystem::importanceDebugMode;
+  u.historyAccumulationEnabled = _historySamplingEnabled ? 1u : 0u;
   u.importanceVisualizationScale = _importanceVisualizationScale;
 
   markBufferModified(_pUniformsBuffer, NS::Range::Make(0, sizeof(UniformsData)));
@@ -5546,8 +5556,10 @@ void Renderer::draw(MTK::View *pView) {
       if (denoiseEncoder) {
         denoiseEncoder->setComputePipelineState(_pDenoiserPSO);
 
-        MTL::Texture *historyTexture =
-            denoisedHistory ? denoisedHistory : accum1;
+        MTL::Texture *historyTexture = nullptr;
+        if (_historySamplingEnabled) {
+          historyTexture = denoisedHistory ? denoisedHistory : accum1;
+        }
         denoiseEncoder->setTexture(accum1, 0);
         denoiseEncoder->setTexture(historyTexture, 1);
         denoiseEncoder->setTexture(albedoTexture, 2);
@@ -5557,8 +5569,8 @@ void Renderer::draw(MTK::View *pView) {
 
         DenoiserUniforms params{};
         params.historyValid =
-            (historyTexture && historyTexture != accum1 &&
-             _framesSinceAccumulationReset > 0)
+            (_historySamplingEnabled && historyTexture &&
+             historyTexture != accum1 && _framesSinceAccumulationReset > 0)
                 ? 1u
                 : 0u;
         params.radius = 2u;
@@ -7528,10 +7540,10 @@ void Renderer::completeFrameMetrics(MTL::CommandBuffer *pCmd) {
                          _totalNodeCount - _residentNodeCount :
                          0;
   printf(
-      "Resident nodes: %zu offloaded: %zu CPU: %.3f ms Submit: %.3f ms GPU: %.3f ms Rays/s: %.2f\n",
+      "Resident nodes: %zu offloaded: %zu CPU: %.3f ms Submit: %.3f ms GPU: %.3f ms Rays/s: %.2f History:%s\n",
       _activeNodeCount, offloaded, _lastCPUTime * 1000.0,
       _lastCommandSubmissionSeconds * 1000.0, _lastGPUTime * 1000.0,
-      _lastRaysPerSecond);
+      _lastRaysPerSecond, _historySamplingEnabled ? "on" : "off");
 
   if (_benchmarkEnabled && !_pendingBenchmarkSamples.empty()) {
     BenchmarkSample sample = std::move(_pendingBenchmarkSamples.front());

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -108,6 +108,8 @@ public:
   bool benchmarkModeEnabled() const { return _benchmarkEnabled; }
   void setFrameCaptureEnabled(bool enabled);
   void setFrameCaptureInterval(size_t interval);
+  void setHistorySamplingEnabled(bool enabled);
+  bool historySamplingEnabled() const { return _historySamplingEnabled; }
 
   bool hasKeyframes() const;
   bool setPrimitiveActive(size_t index, bool active);
@@ -507,6 +509,7 @@ private:
   uint32_t _maxSamplesPerDispatchBudget = 4;
   size_t _framesSinceAccumulationReset = 0;
   float _importanceVisualizationScale = 1.5f;
+  bool _historySamplingEnabled = true;
   bool _needsAccumulationReset = true;
   bool _accumulationTargetsNeedClear = false;
   MTL::Buffer *_pTextureClearBuffer = nullptr;

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -51,6 +51,7 @@ kernel void pathTraceKernel(
   if (screenSize.x <= 0.0f || screenSize.y <= 0.0f)
     return;
 
+  bool historyEnabled = (u.historyAccumulationEnabled != 0u);
   float2 uv = (float2(pixel) + 0.5f) / screenSize;
   uint32_t seed = random(uv, u.randomSeed.xyz) * ((uint32_t)-1);
 
@@ -65,8 +66,12 @@ kernel void pathTraceKernel(
   requestedSamples = clamp(requestedSamples, u.minSamplesPerPixel,
                            u.maxSamplesPerPixel);
 
-  float storedSampleCount = float(sampleCount.read(pixel).x);
-  uint previousSamples = uint(round(storedSampleCount));
+  float storedSampleCount = 0.0f;
+  if (historyEnabled)
+    storedSampleCount = float(sampleCount.read(pixel).x);
+  uint previousSamples = 0u;
+  if (historyEnabled)
+    previousSamples = uint(round(storedSampleCount));
   uint targetSamples = max(u.maxSamplesPerPixel, u.minSamplesPerPixel);
   previousSamples = min(previousSamples, targetSamples);
   uint remainingTargetSamples = 0u;
@@ -83,7 +88,9 @@ kernel void pathTraceKernel(
     samplesThisFrame = min(remainingTargetSamples, dispatchBudget);
 
   float previousSampleCount = float(previousSamples);
-  float4 previousColor = float4(lastFrame.read(pixel));
+  float4 previousColor = float4(0.0f);
+  if (historyEnabled)
+    previousColor = float4(lastFrame.read(pixel));
 
   float3 accumulatedColor = float3(0.0);
   float3 accumulatedAlbedo = float3(0.0);
@@ -128,10 +135,12 @@ kernel void pathTraceKernel(
   float3 averaged = (totalSamples > 0.0f) ? combinedSum / totalSamples : float3(0.0f);
   averaged = clamp(averaged, 0.0f, 1.0f);
 
-  float3 previousAlbedo =
-      float3(float4(albedoAccum.read(pixel)).xyz);
-  float3 previousNormal =
-      float3(float4(normalAccum.read(pixel)).xyz);
+  float3 previousAlbedo = float3(0.0f);
+  float3 previousNormal = float3(0.0f);
+  if (historyEnabled) {
+    previousAlbedo = float3(float4(albedoAccum.read(pixel)).xyz);
+    previousNormal = float3(float4(normalAccum.read(pixel)).xyz);
+  }
   float3 albedoSum = previousAlbedo * previousSampleCount + accumulatedAlbedo;
   float3 normalSum = previousNormal * previousSampleCount + accumulatedNormal;
   float3 averagedAlbedo =

--- a/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/Structs.h
@@ -114,6 +114,7 @@ struct UniformsData
     uint textureCount;
     uint maxSamplesPerDispatch;
     uint debugOutputMode;
+    uint historyAccumulationEnabled;
     float importanceVisualizationScale;
 };
 

--- a/MetalCpp Path Tracer/Window/ViewDelegate.cpp
+++ b/MetalCpp Path Tracer/Window/ViewDelegate.cpp
@@ -27,7 +27,7 @@ ViewDelegate::ViewDelegate(MTL::Device *pDevice)
     _perfLog.open(perf);
     if (_perfLog.is_open())
       _perfLog <<
-          "frame,fps,cpu_ms,command_submit_ms,gpu_ms,rays_per_second,active_nodes,resident_nodes,offloaded_nodes,total_nodes\n";
+          "frame,fps,cpu_ms,command_submit_ms,gpu_ms,rays_per_second,active_nodes,resident_nodes,offloaded_nodes,total_nodes,history_enabled\n";
 
     std::filesystem::path gpu = base / "gpu_mem.csv";
     _gpuMemLog.open(gpu);
@@ -47,6 +47,10 @@ ViewDelegate::ViewDelegate(MTL::Device *pDevice)
 
   bool captureEnabled = parseBoolEnv(std::getenv("MPT_CAPTURE_EXR"));
 
+  bool historySampling = true;
+  if (const char *historyEnv = std::getenv("MPT_HISTORY_SAMPLING"))
+    historySampling = parseBoolEnv(historyEnv);
+
   size_t captureInterval = 4;
   if (const char *intervalEnv = std::getenv("MPT_CAPTURE_INTERVAL")) {
     unsigned long parsed = std::strtoul(intervalEnv, nullptr, 10);
@@ -56,6 +60,7 @@ ViewDelegate::ViewDelegate(MTL::Device *pDevice)
 
   _pRenderer->setFrameCaptureEnabled(captureEnabled);
   _pRenderer->setFrameCaptureInterval(captureInterval);
+  _pRenderer->setHistorySamplingEnabled(historySampling);
 }
 
 ViewDelegate::~ViewDelegate() {
@@ -89,8 +94,8 @@ void ViewDelegate::drawInMTKView(MTK::View *pView) {
     size_t offloaded = total > resident ? total - resident : 0;
     _perfLog << _frameCount << "," << fps << "," << cpu_ms << ","
              << submit_ms << "," << gpu_ms << "," << rays << "," << active
-             << "," << resident
-             << "," << offloaded << "," << total << "\n";
+             << "," << resident << "," << offloaded << "," << total << ","
+             << (_pRenderer->historySamplingEnabled() ? 1 : 0) << "\n";
     _perfLog.flush();
   }
   if (_gpuMemLog.is_open()) {

--- a/runs/README
+++ b/runs/README
@@ -1,0 +1,18 @@
+# Runs Configuration Notes
+
+## History sampling toggle
+
+Set the `MPT_HISTORY_SAMPLING` environment variable to control whether the
+renderer reuses history buffers between frames. The flag accepts any truthy
+value (e.g. `1`, `true`, `yes`) to enable sampling and falsy values (`0`,
+`false`, `no`) to disable it. When disabled the path tracer skips all history
+reads and writes the current frame only to the accumulation, normal, albedo and
+sample-count targets. Denoiser history blending is also disabled and per-frame
+metrics/logs (stdout and `perf.csv`) report the toggle state in a
+`history_enabled` column.
+
+Example:
+
+```
+MPT_HISTORY_SAMPLING=0 ./MetalCpp\ Path\ Tracer
+```


### PR DESCRIPTION
## Summary
- add a renderer-level toggle for history buffer sampling with CSV/log reporting and environment configuration
- propagate the history flag through uniforms to the path tracing compute shader and denoiser so prior-frame data is skipped when disabled
- document the new MPT_HISTORY_SAMPLING option for regression coverage in the runs README

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6900b4325798832d851ee30c2ed68010