### PR TITLE
Make adaptive sampling detail floor motion-aware

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -4781,8 +4781,16 @@ void Renderer::updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd) {
     return;
   MTL::Texture *importance = _sampleImportanceSlot.texture;
   MTL::Texture *accumulation = _accumulationSlots[0].texture;
+  MTL::Texture *sampleCount = _sampleCountSlot.texture;
+  MTL::Texture *history = _accumulationSlots[1].texture;
+
   if (!importance || !accumulation || !_pUniformsBuffer)
     return;
+
+  if (!sampleCount)
+    return;
+  if (!history)
+    history = accumulation;
 
   NS::UInteger width = importance->width();
   NS::UInteger height = importance->height();
@@ -4796,6 +4804,8 @@ void Renderer::updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd) {
   pCompute->setComputePipelineState(_pAdaptiveSamplingPSO);
   pCompute->setTexture(accumulation, 0);
   pCompute->setTexture(importance, 1);
+  pCompute->setTexture(sampleCount, 2);
+  pCompute->setTexture(history, 3);
   pCompute->setBuffer(_pUniformsBuffer, 0, 0);
 
   const NS::UInteger threadWidth = 8;

--- a/MetalCpp Path Tracer/Renderer/Shaders/AdaptiveSampling.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/AdaptiveSampling.metal
@@ -17,9 +17,46 @@ inline float fetchLuminance(texture2d<half, access::read> accumulation,
     return luminance(float3(accumulation.read(uint2(x, y)).xyz));
 }
 
+inline float safeFetchLuminance(texture2d<half, access::read> source,
+                               uint width,
+                               uint height,
+                               int2 coord,
+                               float fallback)
+{
+    if (width == 0 || height == 0)
+    {
+        return fallback;
+    }
+    return fetchLuminance(source, width, height, coord);
+}
+
+inline float safeFetchValue(texture2d<half, access::read> source,
+                            uint width,
+                            uint height,
+                            uint2 coord)
+{
+    if (width == 0 || height == 0)
+    {
+        return 0.0f;
+    }
+
+    uint clampedX = min(coord.x, width - 1);
+    uint clampedY = min(coord.y, height - 1);
+
+    half4 value = source.read(uint2(clampedX, clampedY));
+    float result = float(value.x);
+    if (!isfinite(result))
+    {
+        return 0.0f;
+    }
+    return max(result, 0.0f);
+}
+
 kernel void adaptiveSamplingMain(
     texture2d<half, access::read> accumulation [[texture(0)]],
     texture2d<half, access::write> importance [[texture(1)]],
+    texture2d<half, access::read> sampleCountTexture [[texture(2)]],
+    texture2d<half, access::read> historyTexture [[texture(3)]],
     constant UniformsData& uniforms [[buffer(0)]],
     uint2 gid [[thread_position_in_grid]])
 {
@@ -48,11 +85,62 @@ kernel void adaptiveSamplingMain(
     float contrast = fabs(center - 0.25f * (left + right + up + down));
 
     float detail = gradient + 0.5f * diagonal + 4.0f * contrast;
-    detail = clamp(detail, 0.0f, 1.0f);
+    if (!isfinite(detail))
+    {
+        detail = 0.0f;
+    }
+
+    uint sampleWidth = sampleCountTexture.get_width();
+    uint sampleHeight = sampleCountTexture.get_height();
+    float totalSamples = safeFetchValue(sampleCountTexture, sampleWidth, sampleHeight, gid);
+
+    float frameCount = float(uniforms.frameCount);
+    frameCount = max(frameCount, 1.0f);
 
     float minSamples = float(max(uniforms.minSamplesPerPixel, 1u));
     float maxSamples = float(max(uniforms.maxSamplesPerPixel, uniforms.minSamplesPerPixel));
+
+    float completionDenominator = maxSamples * frameCount;
+    float completion = 0.0f;
+    if (completionDenominator > 0.0f)
+    {
+        completion = clamp(totalSamples / completionDenominator, 0.0f, 1.0f);
+    }
+
+    uint historyWidth = historyTexture.get_width();
+    uint historyHeight = historyTexture.get_height();
+    float historyCenter = safeFetchLuminance(historyTexture, historyWidth, historyHeight, coord, center);
+    float motionMagnitude = fabs(center - historyCenter);
+
+    float historyLeft = safeFetchLuminance(historyTexture, historyWidth, historyHeight,
+                                           coord + int2(-1, 0), left);
+    float historyRight = safeFetchLuminance(historyTexture, historyWidth, historyHeight,
+                                            coord + int2(1, 0), right);
+    float historyUp = safeFetchLuminance(historyTexture, historyWidth, historyHeight,
+                                         coord + int2(0, -1), up);
+    float historyDown = safeFetchLuminance(historyTexture, historyWidth, historyHeight,
+                                           coord + int2(0, 1), down);
+
+    motionMagnitude = max(motionMagnitude, fabs(left - historyLeft));
+    motionMagnitude = max(motionMagnitude, fabs(right - historyRight));
+    motionMagnitude = max(motionMagnitude, fabs(up - historyUp));
+    motionMagnitude = max(motionMagnitude, fabs(down - historyDown));
+    motionMagnitude = clamp(motionMagnitude, 0.0f, 1.0f);
+
+    float globalMotion = clamp(uniforms.motionIntensity, 0.0f, 1.0f);
+    float motionFactor = clamp(motionMagnitude * 4.0f + globalMotion * 0.5f, 0.0f, 1.0f);
+
+    float detailFloorBase = 0.05f * (1.0f - completion);
+    float detailFloor = detailFloorBase * (1.0f - motionFactor);
+    detailFloor = clamp(detailFloor, 0.0f, 1.0f);
+
+    detail = clamp(max(detail, detailFloor), 0.0f, 1.0f);
+
     float sampleBudget = mix(minSamples, maxSamples, detail);
+    if (!isfinite(sampleBudget))
+    {
+        sampleBudget = minSamples;
+    }
 
     importance.write(half4(sampleBudget, half(0.0), half(0.0), half(0.0)), gid);
 }


### PR DESCRIPTION
## Summary
- bind the sample count and history textures to the adaptive sampling compute dispatch
- compute a per-pixel motion magnitude and motion-aware detail floor before generating the sample budget
- clamp shader inputs to avoid invalid values and ensure stable importance output

## Testing
- not run (Metal runtime unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6900bc51140c832dad6a1ba380f6d873