### PR TITLE
Use per-pixel variance to drive adaptive completion

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -4702,7 +4702,7 @@ void Renderer::buildTextures() {
     configureTextureSlot(slot, width, height,
                          MTL::PixelFormat::PixelFormatRGBA16Float, usage);
   configureTextureSlot(_sampleCountSlot, width, height,
-                       MTL::PixelFormat::PixelFormatR16Float, usage);
+                       MTL::PixelFormat::PixelFormatRGBA32Float, usage);
   configureTextureSlot(_sampleImportanceSlot, width, height,
                        MTL::PixelFormat::PixelFormatR16Float, usage);
   configureTextureSlot(_albedoSlot, width, height,

--- a/MetalCpp Path Tracer/Renderer/Shaders/AdaptiveSampling.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/AdaptiveSampling.metal
@@ -30,32 +30,36 @@ inline float safeFetchLuminance(texture2d<half, access::read> source,
     return fetchLuminance(source, width, height, coord);
 }
 
-inline float safeFetchValue(texture2d<half, access::read> source,
-                            uint width,
-                            uint height,
-                            uint2 coord)
+inline float4 safeFetchSampleState(texture2d<float, access::read> source,
+                                   uint width,
+                                   uint height,
+                                   uint2 coord)
 {
     if (width == 0 || height == 0)
     {
-        return 0.0f;
+        return float4(0.0f);
     }
 
     uint clampedX = min(coord.x, width - 1);
     uint clampedY = min(coord.y, height - 1);
 
-    half4 value = source.read(uint2(clampedX, clampedY));
-    float result = float(value.x);
-    if (!isfinite(result))
+    float4 value = source.read(uint2(clampedX, clampedY));
+    if (!(isfinite(value.x) && isfinite(value.y) && isfinite(value.z) && isfinite(value.w)))
     {
-        return 0.0f;
+        return float4(0.0f);
     }
-    return max(result, 0.0f);
+
+    value.x = max(value.x, 0.0f);
+    value.y = max(value.y, 0.0f);
+    value.z = max(value.z, 0.0f);
+    value.w = max(value.w, 0.0f);
+    return value;
 }
 
 kernel void adaptiveSamplingMain(
     texture2d<half, access::read> accumulation [[texture(0)]],
     texture2d<half, access::write> importance [[texture(1)]],
-    texture2d<half, access::read> sampleCountTexture [[texture(2)]],
+    texture2d<float, access::read> sampleCountTexture [[texture(2)]],
     texture2d<half, access::read> historyTexture [[texture(3)]],
     constant UniformsData& uniforms [[buffer(0)]],
     uint2 gid [[thread_position_in_grid]])
@@ -92,20 +96,58 @@ kernel void adaptiveSamplingMain(
 
     uint sampleWidth = sampleCountTexture.get_width();
     uint sampleHeight = sampleCountTexture.get_height();
-    float totalSamples = safeFetchValue(sampleCountTexture, sampleWidth, sampleHeight, gid);
-
-    float frameCount = float(uniforms.frameCount);
-    frameCount = max(frameCount, 1.0f);
+    float4 sampleState = safeFetchSampleState(sampleCountTexture, sampleWidth, sampleHeight, gid);
+    float totalSamples = sampleState.x;
+    float runningMean = sampleState.y;
+    float variance = sampleState.w;
+    if (totalSamples > 1.0f && variance <= 0.0f)
+    {
+        float denom = max(totalSamples - 1.0f, 1.0f);
+        variance = max(sampleState.z / denom, 0.0f);
+    }
 
     float minSamples = float(max(uniforms.minSamplesPerPixel, 1u));
     float maxSamples = float(max(uniforms.maxSamplesPerPixel, uniforms.minSamplesPerPixel));
 
-    float completionDenominator = maxSamples * frameCount;
     float completion = 0.0f;
-    if (completionDenominator > 0.0f)
+    float sampleCompletion = 0.0f;
+    if (maxSamples > 0.0f)
     {
-        completion = clamp(totalSamples / completionDenominator, 0.0f, 1.0f);
+        sampleCompletion = clamp(totalSamples / maxSamples, 0.0f, 1.0f);
     }
+
+    constexpr float kAbsoluteErrorThreshold = 1.0f / 512.0f;
+    constexpr float kRelativeErrorThreshold = 0.02f;
+    if (totalSamples >= 2.0f && kAbsoluteErrorThreshold > 0.0f && kRelativeErrorThreshold > 0.0f)
+    {
+        variance = max(variance, 0.0f);
+        float error = sqrt(variance);
+        if (isfinite(error))
+        {
+            float normalizedAbsolute = error / kAbsoluteErrorThreshold;
+            float safeMean = max(runningMean, 1e-4f);
+            float normalizedRelative = error / (safeMean * kRelativeErrorThreshold);
+            float absoluteCompletion = 1.0f - normalizedAbsolute;
+            float relativeCompletion = 1.0f - normalizedRelative;
+            if (!isfinite(absoluteCompletion))
+            {
+                absoluteCompletion = 0.0f;
+            }
+            if (!isfinite(relativeCompletion))
+            {
+                relativeCompletion = 0.0f;
+            }
+            completion = max(absoluteCompletion, relativeCompletion);
+        }
+    }
+
+    if (totalSamples < 2.0f && minSamples > 0.0f)
+    {
+        completion = max(completion, clamp(totalSamples / minSamples, 0.0f, 1.0f));
+    }
+
+    completion = max(completion, sampleCompletion);
+    completion = clamp(completion, 0.0f, 1.0f);
 
     uint historyWidth = historyTexture.get_width();
     uint historyHeight = historyTexture.get_height();

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -21,7 +21,7 @@ kernel void pathTraceKernel(
     device const InstanceRecord *instanceRecords [[buffer(13)]],
     texture2d<half, access::read> lastFrame [[texture(0)]],
     texture2d<half, access::write> currentFrame [[texture(1)]],
-    texture2d<half, access::read_write> sampleCount [[texture(2)]],
+    texture2d<float, access::read_write> sampleCount [[texture(2)]],
     texture2d<half, access::read> sampleImportance [[texture(3)]],
     texture2d<half, access::read_write> albedoAccum [[texture(4)]],
     texture2d<half, access::read_write> normalAccum [[texture(5)]],
@@ -63,7 +63,21 @@ kernel void pathTraceKernel(
   samplesThisFrame = max(samplesThisFrame, 1u);
 
   float decay = clamp(u.accumulationDecay, 0.0f, 1.0f);
-  float previousSampleCount = float(sampleCount.read(pixel).x) * decay;
+  float4 sampleState = sampleCount.read(pixel);
+  float previousSampleCount = max(sampleState.x, 0.0f) * decay;
+  float previousMean = max(sampleState.y, 0.0f);
+  float previousM2 = max(sampleState.z, 0.0f) * decay;
+  if (!isfinite(previousSampleCount))
+    previousSampleCount = 0.0f;
+  if (!isfinite(previousMean) || previousSampleCount <= 0.0f)
+    previousMean = 0.0f;
+  if (!isfinite(previousM2) || previousSampleCount <= 0.0f)
+    previousM2 = 0.0f;
+  if (previousSampleCount < 1e-3f) {
+    previousSampleCount = 0.0f;
+    previousMean = 0.0f;
+    previousM2 = 0.0f;
+  }
   float4 previousColor = float4(lastFrame.read(pixel));
 
   float3 accumulatedColor = float3(0.0);
@@ -72,6 +86,10 @@ kernel void pathTraceKernel(
 
   float3 rayDx = u.rayDx;
   float3 rayDy = u.rayDy;
+
+  float runningSamples = previousSampleCount;
+  float runningMean = previousMean;
+  float runningM2 = previousM2;
 
   for (uint sampleIdx = 0; sampleIdx < samplesThisFrame; ++sampleIdx) {
     float xOff = (randomFloat(seed) - 0.5f) / screenSize.x;
@@ -101,9 +119,21 @@ kernel void pathTraceKernel(
     accumulatedColor += sample.radiance;
     accumulatedAlbedo += sample.albedo;
     accumulatedNormal += sample.normal;
+
+    float sampleLum = luminance(sample.radiance);
+    if (!isfinite(sampleLum))
+      sampleLum = 0.0f;
+    sampleLum = clamp(sampleLum, 0.0f, 1e6f);
+
+    float delta = sampleLum - runningMean;
+    runningSamples += 1.0f;
+    float invSamples = runningSamples > 0.0f ? 1.0f / runningSamples : 0.0f;
+    runningMean += delta * invSamples;
+    float delta2 = sampleLum - runningMean;
+    runningM2 = max(runningM2 + delta * delta2, 0.0f);
   }
 
-  float totalSamples = previousSampleCount + float(samplesThisFrame);
+  float totalSamples = runningSamples;
   float3 previousSum = previousColor.xyz * previousSampleCount;
   float3 combinedSum = previousSum + accumulatedColor;
   float3 averaged = (totalSamples > 0.0f) ? combinedSum / totalSamples : float3(0.0f);
@@ -126,5 +156,17 @@ kernel void pathTraceKernel(
   currentFrame.write(half4(result), pixel);
   albedoAccum.write(half4(float4(averagedAlbedo, 1.0f)), pixel);
   normalAccum.write(half4(float4(averagedNormal, 1.0f)), pixel);
-  sampleCount.write(half4(totalSamples, half(0.0f), half(0.0f), half(0.0f)), pixel);
+  if (!isfinite(runningMean) || runningMean < 0.0f)
+    runningMean = 0.0f;
+  if (!isfinite(runningM2) || runningM2 < 0.0f)
+    runningM2 = 0.0f;
+
+  float variance = 0.0f;
+  if (runningSamples > 1.0f) {
+    float denom = max(runningSamples - 1.0f, 1.0f);
+    variance = max(runningM2 / denom, 0.0f);
+  }
+  if (!isfinite(variance))
+    variance = 0.0f;
+  sampleCount.write(float4(totalSamples, runningMean, runningM2, variance), pixel);
 }


### PR DESCRIPTION
## Summary
- store per-pixel luminance variance in the sample count history buffer with higher precision
- update the path tracing kernel to maintain running luminance statistics per pixel
- compute adaptive completion from variance-driven error thresholds with numerical safety guards

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6900bed8adcc832d9125de4bb919965c