### PR TITLE
Add GPU accumulation decay pass

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -902,6 +902,10 @@ Renderer::~Renderer() {
     _pPathTracePSO->release();
   if (_pAdaptiveSamplingPSO)
     _pAdaptiveSamplingPSO->release();
+  if (_pAccumulationDecayPSO) {
+    _pAccumulationDecayPSO->release();
+    _pAccumulationDecayPSO = nullptr;
+  }
   if (_pOverlayPSO)
     _pOverlayPSO->release();
 
@@ -1625,6 +1629,10 @@ void Renderer::buildShaders() {
     _pAdaptiveSamplingPSO->release();
     _pAdaptiveSamplingPSO = nullptr;
   }
+  if (_pAccumulationDecayPSO) {
+    _pAccumulationDecayPSO->release();
+    _pAccumulationDecayPSO = nullptr;
+  }
 
   NS::Error *pError = nullptr;
   MTL::Library *pLibrary = _pDevice->newDefaultLibrary();
@@ -1733,6 +1741,18 @@ void Renderer::buildShaders() {
       __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
     }
     pAdaptiveFn->release();
+  }
+
+  pError = nullptr;
+  MTL::Function *pDecayFn = pLibrary->newFunction(
+      NS::String::string("decayAccumulationKernel", UTF8StringEncoding));
+  if (pDecayFn) {
+    _pAccumulationDecayPSO =
+        _pDevice->newComputePipelineState(pDecayFn, &pError);
+    if (!_pAccumulationDecayPSO && pError) {
+      __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
+    }
+    pDecayFn->release();
   }
 
   pVertexFn->release();
@@ -4776,6 +4796,44 @@ bool Renderer::resetAccumulationTargets(MTL::CommandBuffer *cmd) {
   return allResident;
 }
 
+bool Renderer::applyAccumulationDecay(MTL::CommandBuffer *pCmd,
+                                      float decayFactor,
+                                      MTL::Texture *radianceHistory,
+                                      MTL::Texture *albedoHistory,
+                                      MTL::Texture *normalHistory) {
+  if (!pCmd || !_pAccumulationDecayPSO || !radianceHistory || !albedoHistory ||
+      !normalHistory)
+    return false;
+
+  NS::UInteger width = radianceHistory->width();
+  NS::UInteger height = radianceHistory->height();
+  if (width == 0 || height == 0)
+    return true;
+
+  MTL::ComputeCommandEncoder *pCompute = pCmd->computeCommandEncoder();
+  if (!pCompute)
+    return false;
+
+  float clampedDecay = std::clamp(decayFactor, 0.0f, 1.0f);
+  pCompute->setComputePipelineState(_pAccumulationDecayPSO);
+  pCompute->setTexture(radianceHistory, 0);
+  pCompute->setTexture(albedoHistory, 1);
+  pCompute->setTexture(normalHistory, 2);
+  pCompute->setBytes(&clampedDecay, sizeof(float), 0);
+
+  const NS::UInteger threadWidth = 8;
+  const NS::UInteger threadHeight = 8;
+  MTL::Size threadsPerThreadgroup =
+      MTL::Size::Make(threadWidth, threadHeight, 1);
+  MTL::Size threadgroups = MTL::Size::Make(
+      (width + threadWidth - 1) / threadWidth,
+      (height + threadHeight - 1) / threadHeight, 1);
+
+  pCompute->dispatchThreadgroups(threadgroups, threadsPerThreadgroup);
+  pCompute->endEncoding();
+  return true;
+}
+
 void Renderer::updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd) {
   if (!_pAdaptiveSamplingPSO || !pCmd)
     return;
@@ -4972,6 +5030,15 @@ void Renderer::updateUniforms(bool cameraChanged) {
   u.accumulationDecay = accumulationDecay;
   u.motionIntensity = motionIntensity;
 
+  if (_needsAccumulationReset || _accumulationTargetsNeedClear ||
+      accumulationDecay >= 1.0f) {
+    _pendingTextureDecay = false;
+    _pendingTextureDecayFactor = 1.0f;
+  } else {
+    _pendingTextureDecay = true;
+    _pendingTextureDecayFactor = accumulationDecay;
+  }
+
   uint32_t minSamples = std::min(_minSamplesPerPixel, _maxSamplesPerPixel);
   uint32_t maxSamples = std::max(_minSamplesPerPixel, _maxSamplesPerPixel);
   minSamples = std::max<uint32_t>(minSamples, 1);
@@ -5101,6 +5168,14 @@ void Renderer::draw(MTK::View *pView) {
     if (resetAccumulationTargets(prepCmd)) {
       _accumulationTargetsNeedClear = false;
       _needsAccumulationReset = false;
+    }
+  }
+
+  if (_pendingTextureDecay && haveAllTextures) {
+    if (applyAccumulationDecay(prepCmd, _pendingTextureDecayFactor, accum0,
+                               albedoTexture, normalTexture)) {
+      _pendingTextureDecay = false;
+      _pendingTextureDecayFactor = 1.0f;
     }
   }
 

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -179,6 +179,10 @@ private:
   bool submitAsyncCommandBuffer(MTL::CommandBuffer *commandBuffer,
                                std::function<void(bool)> completion);
   void updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd);
+  bool applyAccumulationDecay(MTL::CommandBuffer *pCmd, float decayFactor,
+                              MTL::Texture *radianceHistory,
+                              MTL::Texture *albedoHistory,
+                              MTL::Texture *normalHistory);
   bool resetAccumulationTargets(MTL::CommandBuffer *cmd);
   void rebuildMaterialTextures();
   void clearMaterialTextures();
@@ -490,6 +494,9 @@ private:
   bool _accumulationTargetsNeedClear = false;
   MTL::Buffer *_pTextureClearBuffer = nullptr;
   size_t _textureClearBufferCapacity = 0;
+  bool _pendingTextureDecay = false;
+  float _pendingTextureDecayFactor = 1.0f;
+  MTL::ComputePipelineState *_pAccumulationDecayPSO = nullptr;
 
   size_t setObjectActive(size_t objectIndex, bool active);
   void configureTextureSlot(ManagedTextureSlot &slot, NS::UInteger width,

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -64,21 +64,29 @@ kernel void pathTraceKernel(
 
   float decay = clamp(u.accumulationDecay, 0.0f, 1.0f);
   float4 sampleState = sampleCount.read(pixel);
-  float previousSampleCount = max(sampleState.x, 0.0f) * decay;
+  float historicalSampleCount = max(sampleState.x, 0.0f);
+  if (!isfinite(historicalSampleCount))
+    historicalSampleCount = 0.0f;
+  float effectiveSampleCount = historicalSampleCount;
+  if (decay < 1.0f)
+    effectiveSampleCount *= decay;
+  if (!isfinite(effectiveSampleCount))
+    effectiveSampleCount = 0.0f;
   float previousMean = max(sampleState.y, 0.0f);
-  float previousM2 = max(sampleState.z, 0.0f) * decay;
-  if (!isfinite(previousSampleCount))
-    previousSampleCount = 0.0f;
-  if (!isfinite(previousMean) || previousSampleCount <= 0.0f)
+  float previousM2 = max(sampleState.z, 0.0f);
+  if (decay < 1.0f)
+    previousM2 *= decay;
+  if (!isfinite(previousMean) || effectiveSampleCount <= 0.0f)
     previousMean = 0.0f;
-  if (!isfinite(previousM2) || previousSampleCount <= 0.0f)
+  if (!isfinite(previousM2) || effectiveSampleCount <= 0.0f)
     previousM2 = 0.0f;
-  if (previousSampleCount < 1e-3f) {
-    previousSampleCount = 0.0f;
+  if (effectiveSampleCount < 1e-3f) {
+    effectiveSampleCount = 0.0f;
+    historicalSampleCount = 0.0f;
     previousMean = 0.0f;
     previousM2 = 0.0f;
   }
-  float4 previousColor = float4(lastFrame.read(pixel));
+  float3 previousColor = float3(lastFrame.read(pixel));
 
   float3 accumulatedColor = float3(0.0);
   float3 accumulatedAlbedo = float3(0.0);
@@ -87,7 +95,7 @@ kernel void pathTraceKernel(
   float3 rayDx = u.rayDx;
   float3 rayDy = u.rayDy;
 
-  float runningSamples = previousSampleCount;
+  float runningSamples = effectiveSampleCount;
   float runningMean = previousMean;
   float runningM2 = previousM2;
 
@@ -134,7 +142,7 @@ kernel void pathTraceKernel(
   }
 
   float totalSamples = runningSamples;
-  float3 previousSum = previousColor.xyz * previousSampleCount;
+  float3 previousSum = previousColor * historicalSampleCount;
   float3 combinedSum = previousSum + accumulatedColor;
   float3 averaged = (totalSamples > 0.0f) ? combinedSum / totalSamples : float3(0.0f);
   averaged = clamp(averaged, 0.0f, 1.0f);
@@ -143,8 +151,8 @@ kernel void pathTraceKernel(
       float3(float4(albedoAccum.read(pixel)).xyz);
   float3 previousNormal =
       float3(float4(normalAccum.read(pixel)).xyz);
-  float3 albedoSum = previousAlbedo * previousSampleCount + accumulatedAlbedo;
-  float3 normalSum = previousNormal * previousSampleCount + accumulatedNormal;
+  float3 albedoSum = previousAlbedo * historicalSampleCount + accumulatedAlbedo;
+  float3 normalSum = previousNormal * historicalSampleCount + accumulatedNormal;
   float3 averagedAlbedo =
       (totalSamples > 0.0f) ? albedoSum / totalSamples : float3(0.0f);
   averagedAlbedo = clamp(averagedAlbedo, 0.0f, 1.0f);
@@ -169,4 +177,35 @@ kernel void pathTraceKernel(
   if (!isfinite(variance))
     variance = 0.0f;
   sampleCount.write(float4(totalSamples, runningMean, runningM2, variance), pixel);
+}
+
+kernel void decayAccumulationKernel(
+    texture2d<half, access::read_write> radiance [[texture(0)]],
+    texture2d<half, access::read_write> albedo [[texture(1)]],
+    texture2d<half, access::read_write> normal [[texture(2)]],
+    constant float &decay [[buffer(0)]],
+    uint2 gid [[thread_position_in_grid]]) {
+  if (radiance.get_width() == 0 || radiance.get_height() == 0)
+    return;
+
+  if (gid.x >= radiance.get_width() || gid.y >= radiance.get_height())
+    return;
+
+  float factor = clamp(decay, 0.0f, 1.0f);
+
+  float4 radianceValue = float4(radiance.read(gid));
+  radianceValue *= factor;
+  radiance.write(half4(radianceValue), gid);
+
+  if (gid.x < albedo.get_width() && gid.y < albedo.get_height()) {
+    float4 albedoValue = float4(albedo.read(gid));
+    albedoValue *= factor;
+    albedo.write(half4(albedoValue), gid);
+  }
+
+  if (gid.x < normal.get_width() && gid.y < normal.get_height()) {
+    float4 normalValue = float4(normal.read(gid));
+    normalValue *= factor;
+    normal.write(half4(normalValue), gid);
+  }
 }


### PR DESCRIPTION
## Summary
- add a dedicated compute pipeline that decays the radiance, albedo, and normal accumulation textures when motion triggers a decay factor
- track pending decay work during uniform updates and dispatch it on the existing preparation command buffer for safe synchronization
- update the path tracing kernel to consume the pre-decayed history data without double-applying the decay factor

## Testing
- not run (Metal renderer and scripted camera playback unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6900c1cb1620832dbd5abd2e5a5cdbfc