### PR TITLE
Fix previous color read for path tracer kernel

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -86,7 +86,7 @@ kernel void pathTraceKernel(
     previousMean = 0.0f;
     previousM2 = 0.0f;
   }
-  float3 previousColor = float3(lastFrame.read(pixel));
+  float3 previousColor = float4(lastFrame.read(pixel)).xyz;
 
   float3 accumulatedColor = float3(0.0);
   float3 accumulatedAlbedo = float3(0.0);


### PR DESCRIPTION
## Summary
- promote the previous-frame texture read to float4 before trimming to xyz to match the half4 source data

## Testing
- `xcodebuild -list -project 'MetalCpp Path Tracer.xcodeproj'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_6900c5925c40832d89ead713e3f75304