### PR TITLE
Adjust adaptive sampling for accumulation decay

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Shaders/AdaptiveSampling.metal
+++ b/MetalCpp Path Tracer/Renderer/Shaders/AdaptiveSampling.metal
@@ -97,13 +97,23 @@ kernel void adaptiveSamplingMain(
     uint sampleWidth = sampleCountTexture.get_width();
     uint sampleHeight = sampleCountTexture.get_height();
     float4 sampleState = safeFetchSampleState(sampleCountTexture, sampleWidth, sampleHeight, gid);
-    float totalSamples = sampleState.x;
+    float totalSamples = max(sampleState.x, 0.0f);
     float runningMean = sampleState.y;
-    float variance = sampleState.w;
+    float m2 = max(sampleState.z, 0.0f);
+    float variance = max(sampleState.w, 0.0f);
+
+    float accumulationDecay = clamp(uniforms.accumulationDecay, 0.0f, 1.0f);
+    if (accumulationDecay < 1.0f)
+    {
+        totalSamples *= accumulationDecay;
+        m2 *= accumulationDecay;
+        variance *= accumulationDecay;
+    }
+
     if (totalSamples > 1.0f && variance <= 0.0f)
     {
         float denom = max(totalSamples - 1.0f, 1.0f);
-        variance = max(sampleState.z / denom, 0.0f);
+        variance = max(m2 / denom, 0.0f);
     }
 
     float minSamples = float(max(uniforms.minSamplesPerPixel, 1u));


### PR DESCRIPTION
## Summary
- clamp the uniform accumulation decay value and scale the historical sample counts before adaptive sampling heuristics
- recompute variance from the decayed moments so completion and budgeting respond immediately to decay changes

## Testing
- not run (Metal tooling is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6900c8366100832db06d6d6017cca130