### PR TITLE
Sharpen offline denoiser configuration

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -5,6 +5,7 @@
 #include "InputSystem.h"
 #include "Scene.h"
 #include "SceneLoader.h"
+#include "../offline/denoiser_settings.h"
 #include <Metal/MTLArgument.hpp>
 #include <Metal/MTLComputePipeline.hpp>
 #include <algorithm>
@@ -1420,9 +1421,12 @@ void Renderer::processPendingCapturedFrames() {
                  static_cast<unsigned long long>(capture->frameIndex));
 
       const int radius = 1;
-      const float spatialSigma = 0.75f;
-      const float albedoSigma = 0.25f;
-      const float normalSigma = 0.1f;
+      const float spatialSigma =
+          MetalCppPathTracer::DenoiserSettings::kSharpenedSpatialSigma;
+      const float albedoSigma =
+          MetalCppPathTracer::DenoiserSettings::kSharpenedAlbedoSigma;
+      const float normalSigma =
+          MetalCppPathTracer::DenoiserSettings::kSharpenedNormalSigma;
       std::vector<float> denoised(pixelCount * 3, 0.0f);
 
       auto normalizeVector = [](const float *v) {
@@ -1499,9 +1503,22 @@ void Renderer::processPendingCapturedFrames() {
             filtered[1] = accum[1] / totalWeight;
             filtered[2] = accum[2] / totalWeight;
           }
-          denoised[index * 3 + 0] = std::clamp(filtered[0], 0.0f, 1.0f);
-          denoised[index * 3 + 1] = std::clamp(filtered[1], 0.0f, 1.0f);
-          denoised[index * 3 + 2] = std::clamp(filtered[2], 0.0f, 1.0f);
+          const float strength =
+              MetalCppPathTracer::DenoiserSettings::kSharpenedDenoiseStrength;
+          std::array<float, 3> blended{
+              baseColor[0] + (filtered[0] - baseColor[0]) * strength,
+              baseColor[1] + (filtered[1] - baseColor[1]) * strength,
+              baseColor[2] + (filtered[2] - baseColor[2]) * strength,
+          };
+          if (MetalCppPathTracer::DenoiserSettings::kSharpenedClampOutput) {
+            denoised[index * 3 + 0] = std::clamp(blended[0], 0.0f, 1.0f);
+            denoised[index * 3 + 1] = std::clamp(blended[1], 0.0f, 1.0f);
+            denoised[index * 3 + 2] = std::clamp(blended[2], 0.0f, 1.0f);
+          } else {
+            denoised[index * 3 + 0] = blended[0];
+            denoised[index * 3 + 1] = blended[1];
+            denoised[index * 3 + 2] = blended[2];
+          }
         }
       }
 

--- a/MetalCpp Path Tracer/offline/denoiser_settings.h
+++ b/MetalCpp Path Tracer/offline/denoiser_settings.h
@@ -1,0 +1,27 @@
+#pragma once
+
+// Configuration parameters for the offline EXR denoiser.
+// The "sharpened" preset tightens the bilateral filter kernels and blends
+// the filtered result with the original color instead of fully overwriting it.
+// This keeps more high-frequency detail at the cost of retaining a little noise.
+namespace MetalCppPathTracer::DenoiserSettings {
+
+// Spatial Gaussian sigma controlling the bilateral filter footprint.
+inline constexpr float kSharpenedSpatialSigma = 0.5f;
+
+// Albedo Gaussian sigma used to reject neighbors with differing base colors.
+inline constexpr float kSharpenedAlbedoSigma = 0.15f;
+
+// Normal Gaussian sigma controlling how aggressively surface orientation
+// differences suppress contributions from neighbors.
+inline constexpr float kSharpenedNormalSigma = 0.05f;
+
+// Blend factor between the noisy input color and the filtered color.
+// 0 keeps the original, 1 fully replaces it with the filtered estimate.
+inline constexpr float kSharpenedDenoiseStrength = 0.8f;
+
+// Optional clamp to [0, 1] for LDR previews. Disabled by default so HDR
+// highlights are preserved when writing EXR outputs.
+inline constexpr bool kSharpenedClampOutput = false;
+
+} // namespace MetalCppPathTracer::DenoiserSettings


### PR DESCRIPTION
## Summary
- tighten the offline denoiser kernels and move the constants into a shared configuration header
- blend the filtered result with the original color using a configurable strength and expose an optional clamp toggle
- default the clamp to disabled so HDR information is preserved in EXR outputs while keeping the preset documentation up to date

## Testing
- python3 compare_exr_ssim.py runs runs *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_6900ca1d6f28832dbe517ba2081d0cc0