### PR TITLE
Add camera-adjacent fill lights to casa cinematic scenes

### DIFF
--- a/MetalCpp Path Tracer/scene_casa_cinematic.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic.xml
@@ -13,6 +13,29 @@
         <Keyframe frame="480" position="10,5,-14" lookAt="0,3,0" />
     </CameraPath>
 
+    <!-- Camera-adjacent fill lights to reduce path tracing noise -->
+    <Sphere position="15.530729,5.941341,21.354753" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="7.436511,3.929564,7.436511" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-5.321601,2.745601,9.660801" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-15.538120,4.538120,18.461880" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-19.673401,4.673401,-4.653197" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="18.000000,3.900772,2.793822" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="9.538120,4.907624,-13.353368" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+
     <Sphere position="0,-1000,0" radius="1000" albedo="0.75,0.78,0.82"
             emission="0.08,0.08,0.1" materialType="0" emissionPower="1.5" />
 

--- a/MetalCpp Path Tracer/scene_casa_cinematic_alwaysresident.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_alwaysresident.xml
@@ -14,8 +14,33 @@
     <Keyframe frame="840" position="26,6,4" lookAt="4,4,6" />
 </CameraPath>
 
-<Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
-        emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
+    <!-- Camera-adjacent fill lights to reduce path tracing noise -->
+    <Sphere position="23.481081,6.935135,27.394595" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="13.475512,4.925073,15.400585" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-3.807383,3.903691,13.229531" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-17.250366,4.875061,18.249878" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-25.225280,5.833989,5.889326" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-23.236416,5.856828,-9.809104" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="15.439888,4.887978,-13.439888" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="25.206531,5.927866,4.072134" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
+            emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
 
 <Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.34,0.33,0.32"
            emission="0,0,0" materialType="0" emissionPower="0" />

--- a/MetalCpp Path Tracer/scene_casa_cinematic_distance.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_distance.xml
@@ -14,8 +14,34 @@
     <Keyframe frame="840" position="26,6,4" lookAt="4,4,6" />
 </CameraPath>
 
-<Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
-        emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
+    <!-- Camera-adjacent fill lights to reduce path tracing noise -->
+    <Sphere position="23.481081,6.935135,27.394595" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="13.475512,4.925073,15.400585" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-3.807383,3.903691,13.229531" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-17.250366,4.875061,18.249878" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-25.225280,5.833989,5.889326" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-23.236416,5.856828,-9.809104" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="15.439888,4.887978,-13.439888" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="25.206531,5.927866,4.072134" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+
+    <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
+            emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
 
 <Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.34,0.33,0.32"
            emission="0,0,0" materialType="0" emissionPower="0" />

--- a/MetalCpp Path Tracer/scene_casa_cinematic_energy.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_energy.xml
@@ -14,8 +14,33 @@
     <Keyframe frame="840" position="26,6,4" lookAt="4,4,6" />
 </CameraPath>
 
-<Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
-        emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
+    <!-- Camera-adjacent fill lights to reduce path tracing noise -->
+    <Sphere position="23.481081,6.935135,27.394595" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="13.475512,4.925073,15.400585" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-3.807383,3.903691,13.229531" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-17.250366,4.875061,18.249878" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-25.225280,5.833989,5.889326" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-23.236416,5.856828,-9.809104" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="15.439888,4.887978,-13.439888" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="25.206531,5.927866,4.072134" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
+            emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
 
 <Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.34,0.33,0.32"
            emission="0,0,0" materialType="0" emissionPower="0" />

--- a/MetalCpp Path Tracer/scene_casa_cinematic_rayhit.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_rayhit.xml
@@ -14,8 +14,33 @@
     <Keyframe frame="840" position="26,6,4" lookAt="4,4,6" />
 </CameraPath>
 
-<Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
-        emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
+    <!-- Camera-adjacent fill lights to reduce path tracing noise -->
+    <Sphere position="23.481081,6.935135,27.394595" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="13.475512,4.925073,15.400585" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-3.807383,3.903691,13.229531" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-17.250366,4.875061,18.249878" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-25.225280,5.833989,5.889326" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-23.236416,5.856828,-9.809104" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="15.439888,4.887978,-13.439888" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="25.206531,5.927866,4.072134" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
+            emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
 
 <Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.34,0.33,0.32"
            emission="0,0,0" materialType="0" emissionPower="0" />

--- a/MetalCpp Path Tracer/scene_casa_cinematic_screenspace.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_screenspace.xml
@@ -14,8 +14,33 @@
     <Keyframe frame="840" position="26,6,4" lookAt="4,4,6" />
 </CameraPath>
 
-<Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
-        emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
+    <!-- Camera-adjacent fill lights to reduce path tracing noise -->
+    <Sphere position="23.481081,6.935135,27.394595" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="13.475512,4.925073,15.400585" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-3.807383,3.903691,13.229531" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-17.250366,4.875061,18.249878" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-25.225280,5.833989,5.889326" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="-23.236416,5.856828,-9.809104" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="15.439888,4.887978,-13.439888" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="25.206531,5.927866,4.072134" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="1.0" />
+    <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
+            emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
 
 <Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.34,0.33,0.32"
            emission="0,0,0" materialType="0" emissionPower="0" />


### PR DESCRIPTION
## Summary
- add warm camera-adjacent fill lights along the casa cinematic path to reduce noise across all variants

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6900d0ef2a44832da627a986bc5794df