### PR TITLE
Boost cinematic fill lights

### DIFF
--- a/MetalCpp Path Tracer/scene_casa_cinematic.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic.xml
@@ -14,27 +14,27 @@
     </CameraPath>
 
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
-    <Sphere position="15.530729,5.941341,21.354753" radius="0.20"
+    <Sphere position="16.293294,6.036662,22.40328" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="7.436511,3.929564,7.436511" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="8.35218,4.044023,8.35218" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-5.321601,2.745601,9.660801" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-6.423999,3.159,10.212" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-15.538120,4.538120,18.461880" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-16.288675,5.288675,17.711325" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-19.673401,4.673401,-4.653197" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-20.204124,5.204124,-3.591752" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="18.000000,3.900772,2.793822" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="18.0,4.062017,1.503861" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="9.538120,4.907624,-13.353368" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="10.288675,5.057735,-14.404145" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
+            emissionPower="2.0" />
 
     <Sphere position="0,-1000,0" radius="1000" albedo="0.75,0.78,0.82"
             emission="0.08,0.08,0.1" materialType="0" emissionPower="1.5" />

--- a/MetalCpp Path Tracer/scene_casa_cinematic_alwaysresident.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_alwaysresident.xml
@@ -15,30 +15,30 @@
 </CameraPath>
 
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
-    <Sphere position="23.481081,6.935135,27.394595" radius="0.20"
+    <Sphere position="24.324324,7.040541,28.378378" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="13.475512,4.925073,15.400585" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="14.327805,5.046829,16.374634" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-3.807383,3.903691,13.229531" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-4.120386,4.060193,14.481543" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-17.250366,4.875061,18.249878" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-18.468521,5.078087,17.843826" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-25.225280,5.833989,5.889326" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-26.4842,6.103757,6.069171" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-23.236416,5.856828,-9.809104" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-24.47724,6.089482,-10.11931" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="15.439888,4.887978,-13.439888" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="16.35007,5.070014,-14.35007" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="25.206531,5.927866,4.072134" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="26.495918,6.045083,3.954917" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
+            emissionPower="2.0" />
     <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
             emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
 

--- a/MetalCpp Path Tracer/scene_casa_cinematic_distance.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_distance.xml
@@ -15,30 +15,30 @@
 </CameraPath>
 
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
-    <Sphere position="23.481081,6.935135,27.394595" radius="0.20"
+    <Sphere position="24.324324,7.040541,28.378378" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="13.475512,4.925073,15.400585" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="14.327805,5.046829,16.374634" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-3.807383,3.903691,13.229531" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-4.120386,4.060193,14.481543" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-17.250366,4.875061,18.249878" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-18.468521,5.078087,17.843826" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-25.225280,5.833989,5.889326" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-26.4842,6.103757,6.069171" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-23.236416,5.856828,-9.809104" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-24.47724,6.089482,-10.11931" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="15.439888,4.887978,-13.439888" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="16.35007,5.070014,-14.35007" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="25.206531,5.927866,4.072134" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="26.495918,6.045083,3.954917" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
+            emissionPower="2.0" />
 
     <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
             emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />

--- a/MetalCpp Path Tracer/scene_casa_cinematic_energy.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_energy.xml
@@ -15,30 +15,30 @@
 </CameraPath>
 
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
-    <Sphere position="23.481081,6.935135,27.394595" radius="0.20"
+    <Sphere position="24.324324,7.040541,28.378378" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="13.475512,4.925073,15.400585" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="14.327805,5.046829,16.374634" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-3.807383,3.903691,13.229531" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-4.120386,4.060193,14.481543" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-17.250366,4.875061,18.249878" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-18.468521,5.078087,17.843826" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-25.225280,5.833989,5.889326" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-26.4842,6.103757,6.069171" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-23.236416,5.856828,-9.809104" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-24.47724,6.089482,-10.11931" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="15.439888,4.887978,-13.439888" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="16.35007,5.070014,-14.35007" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="25.206531,5.927866,4.072134" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="26.495918,6.045083,3.954917" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
+            emissionPower="2.0" />
     <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
             emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
 

--- a/MetalCpp Path Tracer/scene_casa_cinematic_rayhit.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_rayhit.xml
@@ -15,30 +15,30 @@
 </CameraPath>
 
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
-    <Sphere position="23.481081,6.935135,27.394595" radius="0.20"
+    <Sphere position="24.324324,7.040541,28.378378" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="13.475512,4.925073,15.400585" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="14.327805,5.046829,16.374634" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-3.807383,3.903691,13.229531" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-4.120386,4.060193,14.481543" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-17.250366,4.875061,18.249878" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-18.468521,5.078087,17.843826" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-25.225280,5.833989,5.889326" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-26.4842,6.103757,6.069171" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-23.236416,5.856828,-9.809104" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-24.47724,6.089482,-10.11931" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="15.439888,4.887978,-13.439888" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="16.35007,5.070014,-14.35007" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="25.206531,5.927866,4.072134" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="26.495918,6.045083,3.954917" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
+            emissionPower="2.0" />
     <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
             emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
 

--- a/MetalCpp Path Tracer/scene_casa_cinematic_screenspace.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_screenspace.xml
@@ -15,30 +15,30 @@
 </CameraPath>
 
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
-    <Sphere position="23.481081,6.935135,27.394595" radius="0.20"
+    <Sphere position="24.324324,7.040541,28.378378" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="13.475512,4.925073,15.400585" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="14.327805,5.046829,16.374634" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-3.807383,3.903691,13.229531" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-4.120386,4.060193,14.481543" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-17.250366,4.875061,18.249878" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-18.468521,5.078087,17.843826" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-25.225280,5.833989,5.889326" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-26.4842,6.103757,6.069171" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="-23.236416,5.856828,-9.809104" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="-24.47724,6.089482,-10.11931" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="15.439888,4.887978,-13.439888" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="16.35007,5.070014,-14.35007" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
-    <Sphere position="25.206531,5.927866,4.072134" radius="0.20"
+            emissionPower="2.0" />
+    <Sphere position="26.495918,6.045083,3.954917" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
-            emissionPower="1.0" />
+            emissionPower="2.0" />
     <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
             emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
 


### PR DESCRIPTION
## Summary
- increase the emissionPower of the behind-camera fill-light spheres to 2.0 across all casa cinematic scene variants to strengthen the off-screen environment illumination

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6900d91e55dc832d8128123a1af8a0a1