### PR TITLE
Adjust casa cinematic bunny materials

### DIFF
--- a/MetalCpp Path Tracer/scene_casa_cinematic.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic.xml
@@ -65,17 +65,17 @@
           materialType="0" emissionPower="0" />
 
     <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.8"
-          rotation="0,5,0" albedo="0.98,0.99,1.0" emission="0,0,0"
-          materialType="1.48" transmission="1,1,1" roughness="0.05"
+          rotation="0,5,0" albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+          materialType="0" transmission="1,1,1" roughness="0.25"
           emissionPower="0" />
 
     <Mesh file="assets/bunny.obj" position="3.5,0.1,2.5" scale="0.65"
-          rotation="0,-15,0" albedo="0.98,0.99,1.0" emission="0,0,0"
-          materialType="1.48" transmission="1,1,1" roughness="0.08"
+          rotation="0,-15,0" albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+          materialType="0" transmission="1,1,1" roughness="0.28"
           emissionPower="0" />
 
     <Mesh file="assets/bunny.obj" position="-6,0.1,4" scale="0.7"
-          rotation="0,35,0" albedo="0.98,0.99,1.0" emission="0,0,0"
-          materialType="1.48" transmission="1,1,1" roughness="0.06"
+          rotation="0,35,0" albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+          materialType="0" transmission="1,1,1" roughness="0.26"
           emissionPower="0" />
 </Scene>

--- a/MetalCpp Path Tracer/scene_casa_cinematic_alwaysresident.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_alwaysresident.xml
@@ -164,20 +164,20 @@
 
 <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
       rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0"
-      materialType="1.48" transmission="1,1,1" roughness="0.05"
+      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      materialType="0" transmission="1,1,1" roughness="0.25"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="4.8,0.1,3.5" scale="0.75"
       rotation="0,-15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0"
-      materialType="1.48" transmission="1,1,1" roughness="0.06"
+      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      materialType="0" transmission="1,1,1" roughness="0.28"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-5.5,0.1,4.2" scale="0.9"
       rotation="0,35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0"
-      materialType="1.48" transmission="1,1,1" roughness="0.07"
+      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      materialType="0" transmission="1,1,1" roughness="0.27"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="7.0,0.1,13.5" scale="0.95"

--- a/MetalCpp Path Tracer/scene_casa_cinematic_distance.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_distance.xml
@@ -165,20 +165,20 @@
 
 <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
       rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0"
-      materialType="1.48" transmission="1,1,1" roughness="0.05"
+      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      materialType="0" transmission="1,1,1" roughness="0.25"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="4.8,0.1,3.5" scale="0.75"
       rotation="0,-15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0"
-      materialType="1.48" transmission="1,1,1" roughness="0.06"
+      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      materialType="0" transmission="1,1,1" roughness="0.28"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-5.5,0.1,4.2" scale="0.9"
       rotation="0,35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0"
-      materialType="1.48" transmission="1,1,1" roughness="0.07"
+      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      materialType="0" transmission="1,1,1" roughness="0.27"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="7.0,0.1,13.5" scale="0.95"

--- a/MetalCpp Path Tracer/scene_casa_cinematic_energy.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_energy.xml
@@ -164,20 +164,20 @@
 
 <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
       rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0"
-      materialType="1.48" transmission="1,1,1" roughness="0.05"
+      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      materialType="0" transmission="1,1,1" roughness="0.25"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="4.8,0.1,3.5" scale="0.75"
       rotation="0,-15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0"
-      materialType="1.48" transmission="1,1,1" roughness="0.06"
+      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      materialType="0" transmission="1,1,1" roughness="0.28"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-5.5,0.1,4.2" scale="0.9"
       rotation="0,35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0"
-      materialType="1.48" transmission="1,1,1" roughness="0.07"
+      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      materialType="0" transmission="1,1,1" roughness="0.27"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="7.0,0.1,13.5" scale="0.95"

--- a/MetalCpp Path Tracer/scene_casa_cinematic_rayhit.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_rayhit.xml
@@ -164,20 +164,20 @@
 
 <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
       rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0"
-      materialType="1.48" transmission="1,1,1" roughness="0.05"
+      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      materialType="0" transmission="1,1,1" roughness="0.25"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="4.8,0.1,3.5" scale="0.75"
       rotation="0,-15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0"
-      materialType="1.48" transmission="1,1,1" roughness="0.06"
+      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      materialType="0" transmission="1,1,1" roughness="0.28"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-5.5,0.1,4.2" scale="0.9"
       rotation="0,35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0"
-      materialType="1.48" transmission="1,1,1" roughness="0.07"
+      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      materialType="0" transmission="1,1,1" roughness="0.27"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="7.0,0.1,13.5" scale="0.95"

--- a/MetalCpp Path Tracer/scene_casa_cinematic_screenspace.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_screenspace.xml
@@ -164,20 +164,20 @@
 
 <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
       rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0"
-      materialType="1.48" transmission="1,1,1" roughness="0.05"
+      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      materialType="0" transmission="1,1,1" roughness="0.25"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="4.8,0.1,3.5" scale="0.75"
       rotation="0,-15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0"
-      materialType="1.48" transmission="1,1,1" roughness="0.06"
+      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      materialType="0" transmission="1,1,1" roughness="0.28"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-5.5,0.1,4.2" scale="0.9"
       rotation="0,35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0"
-      materialType="1.48" transmission="1,1,1" roughness="0.07"
+      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      materialType="0" transmission="1,1,1" roughness="0.27"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="7.0,0.1,13.5" scale="0.95"


### PR DESCRIPTION
## Summary
- switch the hero bunny meshes in the casa cinematic scenes to opaque dielectric materials
- increase roughness for the same meshes in all preset variants to eliminate glass caustics

## Testing
- not run (rendering not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6900dc8bf2c0832d8a0869a644e80194