### PR TITLE
Broaden casa cinematic emitters and boost bounce

### DIFF
--- a/MetalCpp Path Tracer/scene_casa_cinematic.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic.xml
@@ -37,16 +37,16 @@
             emissionPower="2.0" />
 
     <Sphere position="0,-1000,0" radius="1000" albedo="0.75,0.78,0.82"
-            emission="0.08,0.08,0.1" materialType="0" emissionPower="1.5" />
+            emission="0.08,0.08,0.1" materialType="0" emissionPower="2.2" />
 
     <Rectangle position="0,0,0" u="20,0,0" v="0,0,-20" albedo="0.32,0.31,0.3"
                emission="0,0,0" materialType="0" emissionPower="0" />
 
-    <Rectangle position="0,12,0" u="6,0,0" v="0,0,6" rotation="180,0,0"
-               albedo="1,1,1" emission="1.0,0.92,0.82" materialType="-1" emissionPower="18" />
+    <Rectangle position="-3,12,-3" u="12,0,0" v="0,0,12" rotation="180,0,0"
+               albedo="1,1,1" emission="1.0,0.92,0.82" materialType="-1" emissionPower="4.5" />
 
-    <Rectangle position="-18,18,12" u="4,0,0" v="0,0,-8" rotation="140,35,0"
-               albedo="1,1,1" emission="1.0,0.95,0.85" materialType="-1" emissionPower="30" />
+    <Rectangle position="-20,18,16" u="8,0,0" v="0,0,-16" rotation="140,35,0"
+               albedo="1,1,1" emission="1.0,0.95,0.85" materialType="-1" emissionPower="7.5" />
 
     <Mesh file="assets/casa.obj" position="0,0,0" scale="10"
           rotation="0,45,0" albedo="0.82,0.78,0.74" emission="0,0,0"

--- a/MetalCpp Path Tracer/scene_casa_cinematic_alwaysresident.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_alwaysresident.xml
@@ -40,19 +40,19 @@
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
             emissionPower="2.0" />
     <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
-            emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
+            emission="0.05,0.05,0.06" materialType="0" emissionPower="2.2" />
 
 <Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.34,0.33,0.32"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
-<Rectangle position="0,12,0" u="10,0,0" v="0,0,10" rotation="180,0,0"
-           albedo="1,1,1" emission="1.0,0.94,0.84" materialType="-1" emissionPower="26" />
+<Rectangle position="-5,12,-5" u="20,0,0" v="0,0,20" rotation="180,0,0"
+           albedo="1,1,1" emission="1.0,0.94,0.84" materialType="-1" emissionPower="6.5" />
 
-<Rectangle position="-20,18,12" u="6,0,0" v="0,0,-10" rotation="140,25,0"
-           albedo="1,1,1" emission="1.0,0.97,0.9" materialType="-1" emissionPower="34" />
+<Rectangle position="-23,18,17" u="12,0,0" v="0,0,-20" rotation="140,25,0"
+           albedo="1,1,1" emission="1.0,0.97,0.9" materialType="-1" emissionPower="8.5" />
 
-<Rectangle position="6,9,-18" u="8,0,0" v="0,0,6" rotation="160,-10,0"
-           albedo="1,1,1" emission="0.85,0.9,1.0" materialType="-1" emissionPower="18" />
+<Rectangle position="2,9,-21" u="16,0,0" v="0,0,12" rotation="160,-10,0"
+           albedo="1,1,1" emission="0.85,0.9,1.0" materialType="-1" emissionPower="4.5" />
 
 <Rectangle position="0,0,12" u="8,0,0" v="0,0,12" albedo="0.37,0.36,0.34"
            emission="0,0,0" materialType="0" emissionPower="0" />

--- a/MetalCpp Path Tracer/scene_casa_cinematic_distance.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_distance.xml
@@ -41,19 +41,19 @@
             emissionPower="2.0" />
 
     <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
-            emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
+            emission="0.05,0.05,0.06" materialType="0" emissionPower="2.2" />
 
 <Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.34,0.33,0.32"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
-<Rectangle position="0,12,0" u="10,0,0" v="0,0,10" rotation="180,0,0"
-           albedo="1,1,1" emission="1.0,0.94,0.84" materialType="-1" emissionPower="26" />
+<Rectangle position="-5,12,-5" u="20,0,0" v="0,0,20" rotation="180,0,0"
+           albedo="1,1,1" emission="1.0,0.94,0.84" materialType="-1" emissionPower="6.5" />
 
-<Rectangle position="-20,18,12" u="6,0,0" v="0,0,-10" rotation="140,25,0"
-           albedo="1,1,1" emission="1.0,0.97,0.9" materialType="-1" emissionPower="34" />
+<Rectangle position="-23,18,17" u="12,0,0" v="0,0,-20" rotation="140,25,0"
+           albedo="1,1,1" emission="1.0,0.97,0.9" materialType="-1" emissionPower="8.5" />
 
-<Rectangle position="6,9,-18" u="8,0,0" v="0,0,6" rotation="160,-10,0"
-           albedo="1,1,1" emission="0.85,0.9,1.0" materialType="-1" emissionPower="18" />
+<Rectangle position="2,9,-21" u="16,0,0" v="0,0,12" rotation="160,-10,0"
+           albedo="1,1,1" emission="0.85,0.9,1.0" materialType="-1" emissionPower="4.5" />
 
 <Rectangle position="0,0,12" u="8,0,0" v="0,0,12" albedo="0.37,0.36,0.34"
            emission="0,0,0" materialType="0" emissionPower="0" />

--- a/MetalCpp Path Tracer/scene_casa_cinematic_energy.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_energy.xml
@@ -40,19 +40,19 @@
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
             emissionPower="2.0" />
     <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
-            emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
+            emission="0.05,0.05,0.06" materialType="0" emissionPower="2.2" />
 
 <Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.34,0.33,0.32"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
-<Rectangle position="0,12,0" u="10,0,0" v="0,0,10" rotation="180,0,0"
-           albedo="1,1,1" emission="1.0,0.94,0.84" materialType="-1" emissionPower="26" />
+<Rectangle position="-5,12,-5" u="20,0,0" v="0,0,20" rotation="180,0,0"
+           albedo="1,1,1" emission="1.0,0.94,0.84" materialType="-1" emissionPower="6.5" />
 
-<Rectangle position="-20,18,12" u="6,0,0" v="0,0,-10" rotation="140,25,0"
-           albedo="1,1,1" emission="1.0,0.97,0.9" materialType="-1" emissionPower="34" />
+<Rectangle position="-23,18,17" u="12,0,0" v="0,0,-20" rotation="140,25,0"
+           albedo="1,1,1" emission="1.0,0.97,0.9" materialType="-1" emissionPower="8.5" />
 
-<Rectangle position="6,9,-18" u="8,0,0" v="0,0,6" rotation="160,-10,0"
-           albedo="1,1,1" emission="0.85,0.9,1.0" materialType="-1" emissionPower="18" />
+<Rectangle position="2,9,-21" u="16,0,0" v="0,0,12" rotation="160,-10,0"
+           albedo="1,1,1" emission="0.85,0.9,1.0" materialType="-1" emissionPower="4.5" />
 
 <Rectangle position="0,0,12" u="8,0,0" v="0,0,12" albedo="0.37,0.36,0.34"
            emission="0,0,0" materialType="0" emissionPower="0" />

--- a/MetalCpp Path Tracer/scene_casa_cinematic_rayhit.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_rayhit.xml
@@ -40,19 +40,19 @@
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
             emissionPower="2.0" />
     <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
-            emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
+            emission="0.05,0.05,0.06" materialType="0" emissionPower="2.2" />
 
 <Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.34,0.33,0.32"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
-<Rectangle position="0,12,0" u="10,0,0" v="0,0,10" rotation="180,0,0"
-           albedo="1,1,1" emission="1.0,0.94,0.84" materialType="-1" emissionPower="26" />
+<Rectangle position="-5,12,-5" u="20,0,0" v="0,0,20" rotation="180,0,0"
+           albedo="1,1,1" emission="1.0,0.94,0.84" materialType="-1" emissionPower="6.5" />
 
-<Rectangle position="-20,18,12" u="6,0,0" v="0,0,-10" rotation="140,25,0"
-           albedo="1,1,1" emission="1.0,0.97,0.9" materialType="-1" emissionPower="34" />
+<Rectangle position="-23,18,17" u="12,0,0" v="0,0,-20" rotation="140,25,0"
+           albedo="1,1,1" emission="1.0,0.97,0.9" materialType="-1" emissionPower="8.5" />
 
-<Rectangle position="6,9,-18" u="8,0,0" v="0,0,6" rotation="160,-10,0"
-           albedo="1,1,1" emission="0.85,0.9,1.0" materialType="-1" emissionPower="18" />
+<Rectangle position="2,9,-21" u="16,0,0" v="0,0,12" rotation="160,-10,0"
+           albedo="1,1,1" emission="0.85,0.9,1.0" materialType="-1" emissionPower="4.5" />
 
 <Rectangle position="0,0,12" u="8,0,0" v="0,0,12" albedo="0.37,0.36,0.34"
            emission="0,0,0" materialType="0" emissionPower="0" />

--- a/MetalCpp Path Tracer/scene_casa_cinematic_screenspace.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_screenspace.xml
@@ -40,19 +40,19 @@
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
             emissionPower="2.0" />
     <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
-            emission="0.05,0.05,0.06" materialType="0" emissionPower="1.2" />
+            emission="0.05,0.05,0.06" materialType="0" emissionPower="2.2" />
 
 <Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.34,0.33,0.32"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
-<Rectangle position="0,12,0" u="10,0,0" v="0,0,10" rotation="180,0,0"
-           albedo="1,1,1" emission="1.0,0.94,0.84" materialType="-1" emissionPower="26" />
+<Rectangle position="-5,12,-5" u="20,0,0" v="0,0,20" rotation="180,0,0"
+           albedo="1,1,1" emission="1.0,0.94,0.84" materialType="-1" emissionPower="6.5" />
 
-<Rectangle position="-20,18,12" u="6,0,0" v="0,0,-10" rotation="140,25,0"
-           albedo="1,1,1" emission="1.0,0.97,0.9" materialType="-1" emissionPower="34" />
+<Rectangle position="-23,18,17" u="12,0,0" v="0,0,-20" rotation="140,25,0"
+           albedo="1,1,1" emission="1.0,0.97,0.9" materialType="-1" emissionPower="8.5" />
 
-<Rectangle position="6,9,-18" u="8,0,0" v="0,0,6" rotation="160,-10,0"
-           albedo="1,1,1" emission="0.85,0.9,1.0" materialType="-1" emissionPower="18" />
+<Rectangle position="2,9,-21" u="16,0,0" v="0,0,12" rotation="160,-10,0"
+           albedo="1,1,1" emission="0.85,0.9,1.0" materialType="-1" emissionPower="4.5" />
 
 <Rectangle position="0,0,12" u="8,0,0" v="0,0,12" albedo="0.37,0.36,0.34"
            emission="0,0,0" materialType="0" emissionPower="0" />


### PR DESCRIPTION
## Summary
- widen the ceiling, window, and portal emitters in each casa cinematic scene variant and lower their emission power to keep a soft but stable flux
- raise the skydome emission to provide gentle global bounce that complements the broader key lights

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6900ddb1b488832d99996f322aa1562f