### PR TITLE
Rezone casa cinematic presets into staged residency zones

### DIFF
--- a/MetalCpp Path Tracer/scene_casa_cinematic.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic.xml
@@ -4,13 +4,13 @@
     <ObserverCamera position="18,12,18" lookAt="0,4,0" verticalFov="45" />
 
     <CameraPath>
-        <Keyframe frame="0" position="16,6,22" lookAt="0,4,0" />
-        <Keyframe frame="80" position="8,4,8" lookAt="0,3,0" />
-        <Keyframe frame="160" position="-6,3,10" lookAt="-2,1.5,8" />
-        <Keyframe frame="240" position="-16,5,18" lookAt="-14,3,20" />
-        <Keyframe frame="320" position="-20,5,-4" lookAt="-18,3,-8" />
-        <Keyframe frame="400" position="18,4,2" lookAt="18,3,10" />
-        <Keyframe frame="480" position="10,5,-14" lookAt="0,3,0" />
+        <Keyframe frame="0" position="16,6,24" lookAt="0,4,0" />
+        <Keyframe frame="120" position="9,4,10" lookAt="2.5,3.5,4" />
+        <Keyframe frame="240" position="-4,3,12" lookAt="-6,3,10" />
+        <Keyframe frame="360" position="-14,5,20" lookAt="-18,4,24" />
+        <Keyframe frame="480" position="-18,5,-2" lookAt="-16,3,-10" />
+        <Keyframe frame="600" position="18,4,-2" lookAt="24,3,12" />
+        <Keyframe frame="720" position="8,5,-18" lookAt="0,3,-12" />
     </CameraPath>
 
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
@@ -48,21 +48,58 @@
     <Rectangle position="-20,18,16" u="8,0,0" v="0,0,-16" rotation="140,35,0"
                albedo="1,1,1" emission="1.0,0.95,0.85" materialType="-1" emissionPower="7.5" />
 
-    <Mesh file="assets/casa.obj" position="0,0,0" scale="10"
-          rotation="0,45,0" albedo="0.82,0.78,0.74" emission="0,0,0"
-          materialType="0" emissionPower="0" />
+    <!-- Zone 1: Foreground plaza kept mostly clear so the fly-through opens up -->
+    <Mesh file="assets/casa.obj" position="0,0,0" scale="9.5"
+          rotation="0,45,0" clusterMaxTriangles="4096" clusterMaxExtent="28"
+          albedo="0.82,0.78,0.74" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-14,0,20" scale="6"
-          rotation="0,-25,0" albedo="0.9,0.9,0.9" emission="0,0,0"
-          materialType="0" emissionPower="0" />
+    <!-- Zone 2: Mid-ground grove that slides into view as the camera rounds the house -->
+    <Mesh file="assets/Tree.obj" position="18,0,26" scale="6.3"
+          rotation="0,12,0" clusterMaxTriangles="528" clusterMaxExtent="18"
+          albedo="0.88,0.9,0.86" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="18,0,8" scale="5.5"
-          rotation="0,20,0" albedo="0.9,0.9,0.9" emission="0,0,0"
-          materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-24,0,22" scale="6.1"
+          rotation="0,-32,0" clusterMaxTriangles="528" clusterMaxExtent="18"
+          albedo="0.86,0.88,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-18,0,-6" scale="5.8"
-          rotation="0,-35,0" albedo="0.9,0.9,0.9" emission="0,0,0"
-          materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-20,0,-20" scale="5.9"
+          rotation="0,-118,0" clusterMaxTriangles="528" clusterMaxExtent="18"
+          albedo="0.88,0.86,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <Mesh file="assets/Tree.obj" position="22,0,-18" scale="6.2"
+          rotation="0,128,0" clusterMaxTriangles="528" clusterMaxExtent="18"
+          albedo="0.9,0.88,0.84" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <!-- Zone 3: Distant villas form a high-contrast ring for the closing shots -->
+    <Mesh file="assets/casa.obj" position="44,0,40" scale="7.6"
+          rotation="0,20,0" clusterMaxTriangles="5120" clusterMaxExtent="46"
+          albedo="0.8,0.77,0.73" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <Mesh file="assets/casa.obj" position="-48,0,28" scale="8.1"
+          rotation="0,-60,0" clusterMaxTriangles="5120" clusterMaxExtent="46"
+          albedo="0.79,0.76,0.72" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <Mesh file="assets/casa.obj" position="-36,0,-46" scale="7.8"
+          rotation="0,95,0" clusterMaxTriangles="5120" clusterMaxExtent="46"
+          albedo="0.78,0.75,0.71" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <Mesh file="assets/Tree.obj" position="36,0,-38" scale="6.5"
+          rotation="0,146,0" clusterMaxTriangles="600" clusterMaxExtent="20"
+          albedo="0.87,0.89,0.85" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <Mesh file="assets/Tree.obj" position="34,0,30" scale="6.4"
+          rotation="0,32,0" clusterMaxTriangles="600" clusterMaxExtent="20"
+          albedo="0.9,0.88,0.86" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
     <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.8"
           rotation="0,5,0" albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"

--- a/MetalCpp Path Tracer/scene_casa_cinematic_alwaysresident.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_alwaysresident.xml
@@ -4,14 +4,14 @@
 <ObserverCamera position="22,10,26" lookAt="0,4,0" verticalFov="45" />
 
 <CameraPath>
-    <Keyframe frame="0" position="24,7,28" lookAt="0,4,0" />
-    <Keyframe frame="120" position="14,5,16" lookAt="0,3,0" />
-    <Keyframe frame="240" position="-4,4,14" lookAt="-2,3,6" />
-    <Keyframe frame="360" position="-18,5,18" lookAt="-12,4,20" />
-    <Keyframe frame="480" position="-26,6,6" lookAt="-12,3,4" />
-    <Keyframe frame="600" position="-24,6,-10" lookAt="-8,3,-6" />
-    <Keyframe frame="720" position="16,5,-14" lookAt="6,3,-4" />
-    <Keyframe frame="840" position="26,6,4" lookAt="4,4,6" />
+    <Keyframe frame="0" position="24,7,30" lookAt="0,4,0" />
+    <Keyframe frame="150" position="12,5,14" lookAt="3,3,4" />
+    <Keyframe frame="300" position="-6,4,14" lookAt="-10,3,12" />
+    <Keyframe frame="450" position="-18,5,24" lookAt="-24,4,30" />
+    <Keyframe frame="600" position="-26,6,6" lookAt="-22,4,8" />
+    <Keyframe frame="750" position="-22,6,-12" lookAt="-14,4,-12" />
+    <Keyframe frame="900" position="18,5,-18" lookAt="6,3,-8" />
+    <Keyframe frame="1020" position="30,6,6" lookAt="20,4,20" />
 </CameraPath>
 
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
@@ -57,110 +57,83 @@
 <Rectangle position="0,0,12" u="8,0,0" v="0,0,12" albedo="0.37,0.36,0.34"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
-<Mesh file="assets/casa.obj" position="0,0,0" scale="10"
-      rotation="0,45,0" clusterMaxTriangles="4096" clusterMaxExtent="32"
-      albedo="0.82,0.78,0.74" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <!-- Zone 1: Always-resident plaza stays breathable up close -->
+    <Mesh file="assets/casa.obj" position="0,0,0" scale="9.6"
+          rotation="0,45,0" clusterMaxTriangles="5120" clusterMaxExtent="30"
+          albedo="0.82,0.78,0.74" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/casa.obj" position="32,0,32" scale="8"
-      rotation="0,-20,0" clusterMaxTriangles="4096" clusterMaxExtent="32"
-      albedo="0.78,0.76,0.72" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <!-- Zone 2: Dense but offset mid-ground landscaping kept loaded at all times -->
+    <Mesh file="assets/Tree.obj" position="18,0,24" scale="6.4"
+          rotation="0,20,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.9,0.88,0.84" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/casa.obj" position="-42,0,-28" scale="9"
-      rotation="0,120,0" clusterMaxTriangles="4096" clusterMaxExtent="32"
-      albedo="0.79,0.75,0.7" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="0,0,26" scale="6.2"
+          rotation="0,0,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.88,0.9,0.86" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-22,0,24" scale="6.4"
-      rotation="0,-20,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.9,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-20,0,24" scale="6.5"
+          rotation="0,-32,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.86,0.88,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-8,0,28" scale="5.8"
-      rotation="0,10,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.86,0.9,0.88" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-22,0,-18" scale="6.3"
+          rotation="0,-120,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.9,0.88,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="10,0,28" scale="6.0"
-      rotation="0,-5,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.9,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="20,0,-20" scale="6.1"
+          rotation="0,132,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.88,0.86,0.88" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="24,0,20" scale="6.8"
-      rotation="0,35,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.88,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <!-- Zone 3: Full perimeter of villas showcases the always-loaded budget -->
+    <Mesh file="assets/casa.obj" position="48,0,44" scale="8.0"
+          rotation="0,16,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
+          albedo="0.8,0.77,0.73" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="28,0,6" scale="6.5"
-      rotation="0,60,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.92,0.9,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="6,0,56" scale="7.8"
+          rotation="0,-4,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
+          albedo="0.79,0.76,0.72" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="28,0,-10" scale="6.3"
-      rotation="0,100,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.92,0.88" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="-50,0,42" scale="8.2"
+          rotation="0,-70,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
+          albedo="0.78,0.75,0.71" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="20,0,-26" scale="6.7"
-      rotation="0,130,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.9,0.92" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="-40,0,-52" scale="7.9"
+          rotation="0,110,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
+          albedo="0.77,0.74,0.7" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="8,0,-28" scale="6.0"
-      rotation="0,160,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.88,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="40,0,-50" scale="7.7"
+          rotation="0,148,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
+          albedo="0.81,0.78,0.74" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-10,0,-26" scale="6.2"
-      rotation="0,-140,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.9,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="32,0,40" scale="6.6"
+          rotation="0,28,0" clusterMaxTriangles="600" clusterMaxExtent="22"
+          albedo="0.88,0.9,0.84" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-24,0,-18" scale="6.6"
-      rotation="0,-110,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.86,0.88" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-34,0,42" scale="6.7"
+          rotation="0,-40,0" clusterMaxTriangles="600" clusterMaxExtent="22"
+          albedo="0.86,0.9,0.88" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-30,0,-2" scale="6.7"
-      rotation="0,-80,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.88,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-32,0,-40" scale="6.5"
+          rotation="0,120,0" clusterMaxTriangles="600" clusterMaxExtent="22"
+          albedo="0.9,0.88,0.86" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-26,0,14" scale="6.3"
-      rotation="0,-50,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.86,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="14,0,14" scale="4.5"
-      rotation="0,15,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.84,0.88,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-12,0,14" scale="4.7"
-      rotation="0,-25,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.86,0.84,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="16,0,-6" scale="4.2"
-      rotation="0,45,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.9,0.86,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-14,0,-4" scale="4.4"
-      rotation="0,-65,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.86,0.88,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="4,0,20" scale="4.3"
-      rotation="0,0,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.88,0.86,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-4,0,20" scale="4.1"
-      rotation="0,0,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.86,0.88,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="30,0,-38" scale="6.4"
+          rotation="0,152,0" clusterMaxTriangles="600" clusterMaxExtent="22"
+          albedo="0.88,0.86,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
       rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"

--- a/MetalCpp Path Tracer/scene_casa_cinematic_distance.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_distance.xml
@@ -4,14 +4,14 @@
 <ObserverCamera position="22,10,26" lookAt="0,4,0" verticalFov="45" />
 
 <CameraPath>
-    <Keyframe frame="0" position="24,7,28" lookAt="0,4,0" />
-    <Keyframe frame="120" position="14,5,16" lookAt="0,3,0" />
-    <Keyframe frame="240" position="-4,4,14" lookAt="-2,3,6" />
-    <Keyframe frame="360" position="-18,5,18" lookAt="-12,4,20" />
-    <Keyframe frame="480" position="-26,6,6" lookAt="-12,3,4" />
-    <Keyframe frame="600" position="-24,6,-10" lookAt="-8,3,-6" />
-    <Keyframe frame="720" position="16,5,-14" lookAt="6,3,-4" />
-    <Keyframe frame="840" position="26,6,4" lookAt="4,4,6" />
+    <Keyframe frame="0" position="24,7,30" lookAt="0,4,0" />
+    <Keyframe frame="160" position="14,5,18" lookAt="4,3,6" />
+    <Keyframe frame="320" position="-6,4,14" lookAt="-10,3,12" />
+    <Keyframe frame="480" position="-20,5,22" lookAt="-28,4,32" />
+    <Keyframe frame="640" position="-30,6,8" lookAt="-32,4,4" />
+    <Keyframe frame="800" position="-26,6,-12" lookAt="-16,3,-10" />
+    <Keyframe frame="960" position="18,5,-18" lookAt="6,3,-8" />
+    <Keyframe frame="1080" position="32,6,10" lookAt="24,4,28" />
 </CameraPath>
 
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
@@ -58,110 +58,78 @@
 <Rectangle position="0,0,12" u="8,0,0" v="0,0,12" albedo="0.37,0.36,0.34"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
-<Mesh file="assets/casa.obj" position="0,0,0" scale="10"
-      rotation="0,45,0" clusterMaxTriangles="4096" clusterMaxExtent="32"
-      albedo="0.82,0.78,0.74" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <!-- Zone 1: Foreground kept open for the residency ramp -->
+    <Mesh file="assets/casa.obj" position="0,0,0" scale="9.5"
+          rotation="0,45,0" clusterMaxTriangles="4096" clusterMaxExtent="28"
+          albedo="0.82,0.78,0.74" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/casa.obj" position="32,0,32" scale="8"
-      rotation="0,-20,0" clusterMaxTriangles="4096" clusterMaxExtent="32"
-      albedo="0.78,0.76,0.72" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <!-- Zone 2: Mid-ground tree line that eases into frame -->
+    <Mesh file="assets/Tree.obj" position="18,0,28" scale="6.5"
+          rotation="0,18,0" clusterMaxTriangles="480" clusterMaxExtent="16"
+          albedo="0.9,0.88,0.84" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/casa.obj" position="-42,0,-28" scale="9"
-      rotation="0,120,0" clusterMaxTriangles="4096" clusterMaxExtent="32"
-      albedo="0.79,0.75,0.7" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-24,0,24" scale="6.4"
+          rotation="0,-34,0" clusterMaxTriangles="480" clusterMaxExtent="16"
+          albedo="0.88,0.9,0.86" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-22,0,24" scale="6.4"
-      rotation="0,-20,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.9,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-22,0,-24" scale="6.2"
+          rotation="0,-120,0" clusterMaxTriangles="480" clusterMaxExtent="16"
+          albedo="0.86,0.88,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-8,0,28" scale="5.8"
-      rotation="0,10,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.86,0.9,0.88" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="24,0,-26" scale="6.4"
+          rotation="0,138,0" clusterMaxTriangles="480" clusterMaxExtent="16"
+          albedo="0.9,0.86,0.88" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="10,0,28" scale="6.0"
-      rotation="0,-5,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.9,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <!-- Zone 3: Massive far-distance villas stress distance residency -->
+    <Mesh file="assets/casa.obj" position="60,0,54" scale="8.6"
+          rotation="0,18,0" clusterMaxTriangles="7168" clusterMaxExtent="60"
+          albedo="0.8,0.77,0.73" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="24,0,20" scale="6.8"
-      rotation="0,35,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.88,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="4,0,68" scale="8.3"
+          rotation="0,2,0" clusterMaxTriangles="7168" clusterMaxExtent="60"
+          albedo="0.79,0.76,0.72" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="28,0,6" scale="6.5"
-      rotation="0,60,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.92,0.9,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="-66,0,46" scale="8.9"
+          rotation="0,-70,0" clusterMaxTriangles="7168" clusterMaxExtent="60"
+          albedo="0.78,0.75,0.71" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="28,0,-10" scale="6.3"
-      rotation="0,100,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.92,0.88" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="-52,0,-62" scale="8.4"
+          rotation="0,108,0" clusterMaxTriangles="7168" clusterMaxExtent="60"
+          albedo="0.77,0.74,0.7" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="20,0,-26" scale="6.7"
-      rotation="0,130,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.9,0.92" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="46,0,-64" scale="8.2"
+          rotation="0,152,0" clusterMaxTriangles="7168" clusterMaxExtent="60"
+          albedo="0.81,0.78,0.74" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="8,0,-28" scale="6.0"
-      rotation="0,160,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.88,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="44,0,50" scale="6.7"
+          rotation="0,40,0" clusterMaxTriangles="560" clusterMaxExtent="22"
+          albedo="0.88,0.9,0.84" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-10,0,-26" scale="6.2"
-      rotation="0,-140,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.9,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-46,0,52" scale="6.8"
+          rotation="0,-48,0" clusterMaxTriangles="560" clusterMaxExtent="22"
+          albedo="0.86,0.9,0.88" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-24,0,-18" scale="6.6"
-      rotation="0,-110,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.86,0.88" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-42,0,-52" scale="6.5"
+          rotation="0,116,0" clusterMaxTriangles="560" clusterMaxExtent="22"
+          albedo="0.9,0.88,0.86" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-30,0,-2" scale="6.7"
-      rotation="0,-80,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.88,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-26,0,14" scale="6.3"
-      rotation="0,-50,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.86,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="14,0,14" scale="4.5"
-      rotation="0,15,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.84,0.88,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-12,0,14" scale="4.7"
-      rotation="0,-25,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.86,0.84,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="16,0,-6" scale="4.2"
-      rotation="0,45,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.9,0.86,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-14,0,-4" scale="4.4"
-      rotation="0,-65,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.86,0.88,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="4,0,20" scale="4.3"
-      rotation="0,0,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.88,0.86,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-4,0,20" scale="4.1"
-      rotation="0,0,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.86,0.88,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="40,0,-52" scale="6.4"
+          rotation="0,142,0" clusterMaxTriangles="560" clusterMaxExtent="22"
+          albedo="0.88,0.86,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
       rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"

--- a/MetalCpp Path Tracer/scene_casa_cinematic_energy.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_energy.xml
@@ -5,13 +5,13 @@
 
 <CameraPath>
     <Keyframe frame="0" position="24,7,28" lookAt="0,4,0" />
-    <Keyframe frame="120" position="14,5,16" lookAt="0,3,0" />
-    <Keyframe frame="240" position="-4,4,14" lookAt="-2,3,6" />
-    <Keyframe frame="360" position="-18,5,18" lookAt="-12,4,20" />
-    <Keyframe frame="480" position="-26,6,6" lookAt="-12,3,4" />
-    <Keyframe frame="600" position="-24,6,-10" lookAt="-8,3,-6" />
-    <Keyframe frame="720" position="16,5,-14" lookAt="6,3,-4" />
-    <Keyframe frame="840" position="26,6,4" lookAt="4,4,6" />
+    <Keyframe frame="140" position="13,5,14" lookAt="4,3,6" />
+    <Keyframe frame="280" position="0,4,12" lookAt="-4,3,10" />
+    <Keyframe frame="420" position="-16,5,22" lookAt="-20,4,28" />
+    <Keyframe frame="560" position="-24,6,8" lookAt="-20,4,6" />
+    <Keyframe frame="700" position="-18,6,-12" lookAt="-10,4,-8" />
+    <Keyframe frame="840" position="14,5,-20" lookAt="4,3,-10" />
+    <Keyframe frame="980" position="26,6,6" lookAt="18,4,18" />
 </CameraPath>
 
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
@@ -57,110 +57,73 @@
 <Rectangle position="0,0,12" u="8,0,0" v="0,0,12" albedo="0.37,0.36,0.34"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
-<Mesh file="assets/casa.obj" position="0,0,0" scale="10"
-      rotation="0,45,0" clusterMaxTriangles="4096" clusterMaxExtent="32"
-      albedo="0.82,0.78,0.74" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <!-- Zone 1: Quiet courtyard to stage the energy spikes later on -->
+    <Mesh file="assets/casa.obj" position="0,0,0" scale="9.4"
+          rotation="0,45,0" clusterMaxTriangles="4096" clusterMaxExtent="26"
+          albedo="0.82,0.78,0.74" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/casa.obj" position="32,0,32" scale="8"
-      rotation="0,-20,0" clusterMaxTriangles="4096" clusterMaxExtent="32"
-      albedo="0.78,0.76,0.72" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <!-- Zone 2: Hero props with boosted emission to stress energy residency -->
+    <Mesh file="assets/Tree.obj" position="16,0,22" scale="6.0"
+          rotation="0,12,0" clusterMaxTriangles="320" clusterMaxExtent="14"
+          albedo="0.9,0.88,0.82" emission="0.8,0.7,0.6" materialType="0"
+          emissionPower="0.5" />
 
-<Mesh file="assets/casa.obj" position="-42,0,-28" scale="9"
-      rotation="0,120,0" clusterMaxTriangles="4096" clusterMaxExtent="32"
-      albedo="0.79,0.75,0.7" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="-14,0,18" scale="5.8"
+          rotation="0,-30,0" clusterMaxTriangles="2048" clusterMaxExtent="20"
+          albedo="0.83,0.8,0.76" emission="0.4,0.35,0.3" materialType="0"
+          emissionPower="0.35" />
 
-<Mesh file="assets/Tree.obj" position="-22,0,24" scale="6.4"
-      rotation="0,-20,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.9,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-18,0,-14" scale="6.1"
+          rotation="0,-128,0" clusterMaxTriangles="320" clusterMaxExtent="14"
+          albedo="0.88,0.86,0.9" emission="0.7,0.75,0.8" materialType="0"
+          emissionPower="0.45" />
 
-<Mesh file="assets/Tree.obj" position="-8,0,28" scale="5.8"
-      rotation="0,10,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.86,0.9,0.88" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="12,0,-16" scale="5.9"
+          rotation="0,130,0" clusterMaxTriangles="320" clusterMaxExtent="14"
+          albedo="0.9,0.86,0.84" emission="0.6,0.5,0.45" materialType="0"
+          emissionPower="0.4" />
 
-<Mesh file="assets/Tree.obj" position="10,0,28" scale="6.0"
-      rotation="0,-5,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.9,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <!-- Zone 3: Distant energy anchors keep the budget busy late in the shot -->
+    <Mesh file="assets/casa.obj" position="44,0,36" scale="7.4"
+          rotation="0,18,0" clusterMaxTriangles="5120" clusterMaxExtent="44"
+          albedo="0.8,0.77,0.73" emission="0.2,0.2,0.18" materialType="0"
+          emissionPower="0.25" />
 
-<Mesh file="assets/Tree.obj" position="24,0,20" scale="6.8"
-      rotation="0,35,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.88,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="-46,0,34" scale="7.6"
+          rotation="0,-62,0" clusterMaxTriangles="5120" clusterMaxExtent="44"
+          albedo="0.79,0.76,0.72" emission="0.18,0.2,0.22" materialType="0"
+          emissionPower="0.22" />
 
-<Mesh file="assets/Tree.obj" position="28,0,6" scale="6.5"
-      rotation="0,60,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.92,0.9,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="-34,0,-44" scale="7.2"
+          rotation="0,104,0" clusterMaxTriangles="5120" clusterMaxExtent="44"
+          albedo="0.78,0.75,0.71" emission="0.2,0.22,0.25" materialType="0"
+          emissionPower="0.24" />
 
-<Mesh file="assets/Tree.obj" position="28,0,-10" scale="6.3"
-      rotation="0,100,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.92,0.88" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="36,0,-46" scale="7.0"
+          rotation="0,150,0" clusterMaxTriangles="5120" clusterMaxExtent="44"
+          albedo="0.81,0.78,0.74" emission="0.16,0.18,0.2" materialType="0"
+          emissionPower="0.2" />
 
-<Mesh file="assets/Tree.obj" position="20,0,-26" scale="6.7"
-      rotation="0,130,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.9,0.92" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="34,0,32" scale="6.3"
+          rotation="0,32,0" clusterMaxTriangles="360" clusterMaxExtent="16"
+          albedo="0.9,0.88,0.86" emission="0.55,0.52,0.5" materialType="0"
+          emissionPower="0.35" />
 
-<Mesh file="assets/Tree.obj" position="8,0,-28" scale="6.0"
-      rotation="0,160,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.88,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-32,0,30" scale="6.2"
+          rotation="0,-44,0" clusterMaxTriangles="360" clusterMaxExtent="16"
+          albedo="0.88,0.9,0.88" emission="0.5,0.54,0.58" materialType="0"
+          emissionPower="0.33" />
 
-<Mesh file="assets/Tree.obj" position="-10,0,-26" scale="6.2"
-      rotation="0,-140,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.9,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-30,0,-32" scale="6.1"
+          rotation="0,118,0" clusterMaxTriangles="360" clusterMaxExtent="16"
+          albedo="0.9,0.86,0.9" emission="0.52,0.5,0.6" materialType="0"
+          emissionPower="0.32" />
 
-<Mesh file="assets/Tree.obj" position="-24,0,-18" scale="6.6"
-      rotation="0,-110,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.86,0.88" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-30,0,-2" scale="6.7"
-      rotation="0,-80,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.88,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-26,0,14" scale="6.3"
-      rotation="0,-50,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.86,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="14,0,14" scale="4.5"
-      rotation="0,15,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.84,0.88,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-12,0,14" scale="4.7"
-      rotation="0,-25,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.86,0.84,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="16,0,-6" scale="4.2"
-      rotation="0,45,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.9,0.86,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-14,0,-4" scale="4.4"
-      rotation="0,-65,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.86,0.88,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="4,0,20" scale="4.3"
-      rotation="0,0,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.88,0.86,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-4,0,20" scale="4.1"
-      rotation="0,0,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.86,0.88,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="30,0,-34" scale="6.0"
+          rotation="0,148,0" clusterMaxTriangles="360" clusterMaxExtent="16"
+          albedo="0.86,0.88,0.9" emission="0.48,0.5,0.46" materialType="0"
+          emissionPower="0.3" />
 
 <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
       rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"

--- a/MetalCpp Path Tracer/scene_casa_cinematic_rayhit.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_rayhit.xml
@@ -5,13 +5,13 @@
 
 <CameraPath>
     <Keyframe frame="0" position="24,7,28" lookAt="0,4,0" />
-    <Keyframe frame="120" position="14,5,16" lookAt="0,3,0" />
-    <Keyframe frame="240" position="-4,4,14" lookAt="-2,3,6" />
-    <Keyframe frame="360" position="-18,5,18" lookAt="-12,4,20" />
-    <Keyframe frame="480" position="-26,6,6" lookAt="-12,3,4" />
-    <Keyframe frame="600" position="-24,6,-10" lookAt="-8,3,-6" />
-    <Keyframe frame="720" position="16,5,-14" lookAt="6,3,-4" />
-    <Keyframe frame="840" position="26,6,4" lookAt="4,4,6" />
+    <Keyframe frame="140" position="13,5,14" lookAt="3,3,4" />
+    <Keyframe frame="280" position="-2,4,12" lookAt="-6,3,10" />
+    <Keyframe frame="420" position="-18,5,22" lookAt="-24,4,28" />
+    <Keyframe frame="560" position="-26,6,6" lookAt="-22,4,4" />
+    <Keyframe frame="700" position="-20,6,-14" lookAt="-12,4,-10" />
+    <Keyframe frame="840" position="16,5,-18" lookAt="6,3,-6" />
+    <Keyframe frame="980" position="28,6,6" lookAt="20,4,18" />
 </CameraPath>
 
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
@@ -57,110 +57,83 @@
 <Rectangle position="0,0,12" u="8,0,0" v="0,0,12" albedo="0.37,0.36,0.34"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
-<Mesh file="assets/casa.obj" position="0,0,0" scale="10"
-      rotation="0,45,0" clusterMaxTriangles="4096" clusterMaxExtent="32"
-      albedo="0.82,0.78,0.74" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <!-- Zone 1: Open plaza keeps initial ray budget light -->
+    <Mesh file="assets/casa.obj" position="0,0,0" scale="9.3"
+          rotation="0,45,0" clusterMaxTriangles="4096" clusterMaxExtent="26"
+          albedo="0.82,0.78,0.74" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/casa.obj" position="32,0,32" scale="8"
-      rotation="0,-20,0" clusterMaxTriangles="4096" clusterMaxExtent="32"
-      albedo="0.78,0.76,0.72" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <!-- Zone 2: Tight ray-hit corridor built from narrow tree clusters -->
+    <Mesh file="assets/Tree.obj" position="14,0,20" scale="6.1"
+          rotation="0,18,0" clusterMaxTriangles="256" clusterMaxExtent="12"
+          albedo="0.88,0.9,0.84" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/casa.obj" position="-42,0,-28" scale="9"
-      rotation="0,120,0" clusterMaxTriangles="4096" clusterMaxExtent="32"
-      albedo="0.79,0.75,0.7" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-12,0,18" scale="6.0"
+          rotation="0,-26,0" clusterMaxTriangles="256" clusterMaxExtent="12"
+          albedo="0.86,0.9,0.88" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-22,0,24" scale="6.4"
-      rotation="0,-20,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.9,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-14,0,-12" scale="6.2"
+          rotation="0,-134,0" clusterMaxTriangles="256" clusterMaxExtent="12"
+          albedo="0.88,0.86,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-8,0,28" scale="5.8"
-      rotation="0,10,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.86,0.9,0.88" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="16,0,-14" scale="6.0"
+          rotation="0,138,0" clusterMaxTriangles="256" clusterMaxExtent="12"
+          albedo="0.9,0.88,0.86" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="10,0,28" scale="6.0"
-      rotation="0,-5,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.9,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="6,0,18" scale="5.8"
+          rotation="0,6,0" clusterMaxTriangles="256" clusterMaxExtent="12"
+          albedo="0.9,0.88,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="24,0,20" scale="6.8"
-      rotation="0,35,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.88,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-4,0,-16" scale="5.7"
+          rotation="0,-152,0" clusterMaxTriangles="256" clusterMaxExtent="12"
+          albedo="0.88,0.86,0.88" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="28,0,6" scale="6.5"
-      rotation="0,60,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.92,0.9,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <!-- Zone 3: Angular villa perimeter catches late-frame rays -->
+    <Mesh file="assets/casa.obj" position="42,0,34" scale="7.2"
+          rotation="0,22,0" clusterMaxTriangles="4608" clusterMaxExtent="40"
+          albedo="0.8,0.77,0.73" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="28,0,-10" scale="6.3"
-      rotation="0,100,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.92,0.88" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="-44,0,32" scale="7.4"
+          rotation="0,-66,0" clusterMaxTriangles="4608" clusterMaxExtent="40"
+          albedo="0.79,0.76,0.72" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="20,0,-26" scale="6.7"
-      rotation="0,130,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.9,0.92" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="-32,0,-46" scale="7.0"
+          rotation="0,108,0" clusterMaxTriangles="4608" clusterMaxExtent="40"
+          albedo="0.78,0.75,0.71" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="8,0,-28" scale="6.0"
-      rotation="0,160,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.88,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="34,0,-44" scale="6.9"
+          rotation="0,152,0" clusterMaxTriangles="4608" clusterMaxExtent="40"
+          albedo="0.81,0.78,0.74" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-10,0,-26" scale="6.2"
-      rotation="0,-140,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.9,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="32,0,28" scale="6.2"
+          rotation="0,34,0" clusterMaxTriangles="320" clusterMaxExtent="14"
+          albedo="0.88,0.9,0.84" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-24,0,-18" scale="6.6"
-      rotation="0,-110,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.86,0.88" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-30,0,28" scale="6.1"
+          rotation="0,-48,0" clusterMaxTriangles="320" clusterMaxExtent="14"
+          albedo="0.86,0.9,0.88" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-30,0,-2" scale="6.7"
-      rotation="0,-80,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.88,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-28,0,-36" scale="6.0"
+          rotation="0,122,0" clusterMaxTriangles="320" clusterMaxExtent="14"
+          albedo="0.9,0.88,0.86" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-26,0,14" scale="6.3"
-      rotation="0,-50,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.86,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="14,0,14" scale="4.5"
-      rotation="0,15,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.84,0.88,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-12,0,14" scale="4.7"
-      rotation="0,-25,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.86,0.84,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="16,0,-6" scale="4.2"
-      rotation="0,45,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.9,0.86,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-14,0,-4" scale="4.4"
-      rotation="0,-65,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.86,0.88,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="4,0,20" scale="4.3"
-      rotation="0,0,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.88,0.86,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-4,0,20" scale="4.1"
-      rotation="0,0,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.86,0.88,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="28,0,-34" scale="5.9"
+          rotation="0,148,0" clusterMaxTriangles="320" clusterMaxExtent="14"
+          albedo="0.88,0.86,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
       rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"

--- a/MetalCpp Path Tracer/scene_casa_cinematic_screenspace.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_screenspace.xml
@@ -5,13 +5,13 @@
 
 <CameraPath>
     <Keyframe frame="0" position="24,7,28" lookAt="0,4,0" />
-    <Keyframe frame="120" position="14,5,16" lookAt="0,3,0" />
-    <Keyframe frame="240" position="-4,4,14" lookAt="-2,3,6" />
-    <Keyframe frame="360" position="-18,5,18" lookAt="-12,4,20" />
-    <Keyframe frame="480" position="-26,6,6" lookAt="-12,3,4" />
-    <Keyframe frame="600" position="-24,6,-10" lookAt="-8,3,-6" />
-    <Keyframe frame="720" position="16,5,-14" lookAt="6,3,-4" />
-    <Keyframe frame="840" position="26,6,4" lookAt="4,4,6" />
+    <Keyframe frame="140" position="12,5,16" lookAt="3,3,6" />
+    <Keyframe frame="280" position="-2,4,14" lookAt="-6,3,10" />
+    <Keyframe frame="420" position="-18,5,22" lookAt="-24,4,30" />
+    <Keyframe frame="560" position="-26,6,4" lookAt="-20,4,2" />
+    <Keyframe frame="700" position="-18,6,-14" lookAt="-10,4,-10" />
+    <Keyframe frame="840" position="16,5,-18" lookAt="6,3,-8" />
+    <Keyframe frame="980" position="28,6,6" lookAt="18,4,18" />
 </CameraPath>
 
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
@@ -57,110 +57,78 @@
 <Rectangle position="0,0,12" u="8,0,0" v="0,0,12" albedo="0.37,0.36,0.34"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
-<Mesh file="assets/casa.obj" position="0,0,0" scale="10"
-      rotation="0,45,0" clusterMaxTriangles="4096" clusterMaxExtent="32"
-      albedo="0.82,0.78,0.74" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <!-- Zone 1: Foreground runway left open for screenspace sweeps -->
+    <Mesh file="assets/casa.obj" position="0,0,0" scale="9.4"
+          rotation="0,45,0" clusterMaxTriangles="4096" clusterMaxExtent="26"
+          albedo="0.82,0.78,0.74" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/casa.obj" position="32,0,32" scale="8"
-      rotation="0,-20,0" clusterMaxTriangles="4096" clusterMaxExtent="32"
-      albedo="0.78,0.76,0.72" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <!-- Zone 2: Broad tree arcs that glide across the frame -->
+    <Mesh file="assets/Tree.obj" position="20,0,26" scale="6.6"
+          rotation="0,24,0" clusterMaxTriangles="512" clusterMaxExtent="22"
+          albedo="0.9,0.88,0.84" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/casa.obj" position="-42,0,-28" scale="9"
-      rotation="0,120,0" clusterMaxTriangles="4096" clusterMaxExtent="32"
-      albedo="0.79,0.75,0.7" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="0,0,28" scale="6.4"
+          rotation="0,0,0" clusterMaxTriangles="512" clusterMaxExtent="22"
+          albedo="0.88,0.9,0.86" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-22,0,24" scale="6.4"
-      rotation="0,-20,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.9,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-22,0,24" scale="6.7"
+          rotation="0,-32,0" clusterMaxTriangles="512" clusterMaxExtent="22"
+          albedo="0.86,0.9,0.88" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-8,0,28" scale="5.8"
-      rotation="0,10,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.86,0.9,0.88" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-24,0,-20" scale="6.5"
+          rotation="0,-118,0" clusterMaxTriangles="512" clusterMaxExtent="22"
+          albedo="0.88,0.86,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="10,0,28" scale="6.0"
-      rotation="0,-5,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.9,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="22,0,-22" scale="6.4"
+          rotation="0,140,0" clusterMaxTriangles="512" clusterMaxExtent="22"
+          albedo="0.9,0.88,0.86" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="24,0,20" scale="6.8"
-      rotation="0,35,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.88,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <!-- Zone 3: Oversized villa belt to fill late frame coverage -->
+    <Mesh file="assets/casa.obj" position="48,0,40" scale="7.8"
+          rotation="0,18,0" clusterMaxTriangles="5632" clusterMaxExtent="54"
+          albedo="0.8,0.77,0.73" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="28,0,6" scale="6.5"
-      rotation="0,60,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.92,0.9,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="-50,0,38" scale="8.0"
+          rotation="0,-64,0" clusterMaxTriangles="5632" clusterMaxExtent="54"
+          albedo="0.79,0.76,0.72" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="28,0,-10" scale="6.3"
-      rotation="0,100,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.92,0.88" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="-36,0,-48" scale="7.4"
+          rotation="0,110,0" clusterMaxTriangles="5632" clusterMaxExtent="54"
+          albedo="0.78,0.75,0.71" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="20,0,-26" scale="6.7"
-      rotation="0,130,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.9,0.92" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/casa.obj" position="40,0,-50" scale="7.2"
+          rotation="0,150,0" clusterMaxTriangles="5632" clusterMaxExtent="54"
+          albedo="0.81,0.78,0.74" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="8,0,-28" scale="6.0"
-      rotation="0,160,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.88,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="32,0,34" scale="6.5"
+          rotation="0,30,0" clusterMaxTriangles="560" clusterMaxExtent="20"
+          albedo="0.88,0.9,0.84" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-10,0,-26" scale="6.2"
-      rotation="0,-140,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.9,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-32,0,32" scale="6.4"
+          rotation="0,-44,0" clusterMaxTriangles="560" clusterMaxExtent="20"
+          albedo="0.86,0.9,0.88" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-24,0,-18" scale="6.6"
-      rotation="0,-110,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.86,0.88" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="-30,0,-36" scale="6.3"
+          rotation="0,118,0" clusterMaxTriangles="560" clusterMaxExtent="20"
+          albedo="0.9,0.88,0.86" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-<Mesh file="assets/Tree.obj" position="-30,0,-2" scale="6.7"
-      rotation="0,-80,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.9,0.88,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-26,0,14" scale="6.3"
-      rotation="0,-50,0" clusterMaxTriangles="640" clusterMaxExtent="20"
-      albedo="0.88,0.86,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="14,0,14" scale="4.5"
-      rotation="0,15,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.84,0.88,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-12,0,14" scale="4.7"
-      rotation="0,-25,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.86,0.84,0.9" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="16,0,-6" scale="4.2"
-      rotation="0,45,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.9,0.86,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-14,0,-4" scale="4.4"
-      rotation="0,-65,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.86,0.88,0.84" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="4,0,20" scale="4.3"
-      rotation="0,0,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.88,0.86,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
-
-<Mesh file="assets/Tree.obj" position="-4,0,20" scale="4.1"
-      rotation="0,0,0" clusterMaxTriangles="512" clusterMaxExtent="16"
-      albedo="0.86,0.88,0.86" emission="0,0,0"
-      materialType="0" emissionPower="0" />
+    <Mesh file="assets/Tree.obj" position="30,0,-32" scale="6.2"
+          rotation="0,146,0" clusterMaxTriangles="560" clusterMaxExtent="20"
+          albedo="0.88,0.86,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
       rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"


### PR DESCRIPTION
## Summary
- Reorganize the casa cinematic baseline into foreground, mid-ground, and far villas so geometry enters the frame sequentially.
- Tailor tree and casa clusters per residency preset (distance, always-resident, energy, ray-hit, and screenspace) to emphasize their respective streaming stresses with adjusted cluster budgets and energy/emission traits.
- Nudge each camera path so the updated zones have time to read as the fly-through transitions between near, mid, and far sets.

## Testing
- Not run (rendering previews requires the full renderer environment).

------
https://chatgpt.com/codex/tasks/task_e_6900efa7380c832d8cad100c9bf479cb