### PR TITLE
Adjust Casa cinematic palette and denoiser strength

### DIFF
--- a/MetalCpp Path Tracer/offline/denoiser_settings.h
+++ b/MetalCpp Path Tracer/offline/denoiser_settings.h
@@ -7,18 +7,18 @@
 namespace MetalCppPathTracer::DenoiserSettings {
 
 // Spatial Gaussian sigma controlling the bilateral filter footprint.
-inline constexpr float kSharpenedSpatialSigma = 0.5f;
+inline constexpr float kSharpenedSpatialSigma = 1.25f;
 
 // Albedo Gaussian sigma used to reject neighbors with differing base colors.
-inline constexpr float kSharpenedAlbedoSigma = 0.15f;
+inline constexpr float kSharpenedAlbedoSigma = 0.35f;
 
 // Normal Gaussian sigma controlling how aggressively surface orientation
 // differences suppress contributions from neighbors.
-inline constexpr float kSharpenedNormalSigma = 0.05f;
+inline constexpr float kSharpenedNormalSigma = 0.1f;
 
 // Blend factor between the noisy input color and the filtered color.
 // 0 keeps the original, 1 fully replaces it with the filtered estimate.
-inline constexpr float kSharpenedDenoiseStrength = 0.8f;
+inline constexpr float kSharpenedDenoiseStrength = 1.0f;
 
 // Optional clamp to [0, 1] for LDR previews. Disabled by default so HDR
 // highlights are preserved when writing EXR outputs.

--- a/MetalCpp Path Tracer/scene_casa_cinematic.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic.xml
@@ -39,7 +39,7 @@
     <Sphere position="0,-1000,0" radius="1000" albedo="0.75,0.78,0.82"
             emission="0.08,0.08,0.1" materialType="0" emissionPower="2.2" />
 
-    <Rectangle position="0,0,0" u="20,0,0" v="0,0,-20" albedo="0.32,0.31,0.3"
+    <Rectangle position="0,0,0" u="20,0,0" v="0,0,-20" albedo="0.36,0.28,0.22"
                emission="0,0,0" materialType="0" emissionPower="0" />
 
     <Rectangle position="-3,12,-3" u="12,0,0" v="0,0,12" rotation="180,0,0"
@@ -102,17 +102,17 @@
           emissionPower="0" />
 
     <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.8"
-          rotation="0,5,0" albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+          rotation="0,5,0" albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
           materialType="0" transmission="1,1,1" roughness="0.25"
           emissionPower="0" />
 
     <Mesh file="assets/bunny.obj" position="3.5,0.1,2.5" scale="0.65"
-          rotation="0,-15,0" albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+          rotation="0,-15,0" albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
           materialType="0" transmission="1,1,1" roughness="0.28"
           emissionPower="0" />
 
     <Mesh file="assets/bunny.obj" position="-6,0.1,4" scale="0.7"
-          rotation="0,35,0" albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+          rotation="0,35,0" albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
           materialType="0" transmission="1,1,1" roughness="0.26"
           emissionPower="0" />
 </Scene>

--- a/MetalCpp Path Tracer/scene_casa_cinematic_alwaysresident.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_alwaysresident.xml
@@ -42,7 +42,7 @@
     <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
             emission="0.05,0.05,0.06" materialType="0" emissionPower="2.2" />
 
-<Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.34,0.33,0.32"
+    <Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.36,0.28,0.22"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
 <Rectangle position="-5,12,-5" u="20,0,0" v="0,0,20" rotation="180,0,0"
@@ -137,50 +137,50 @@
 
 <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
       rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
       materialType="0" transmission="1,1,1" roughness="0.25"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="4.8,0.1,3.5" scale="0.75"
       rotation="0,-15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
       materialType="0" transmission="1,1,1" roughness="0.28"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-5.5,0.1,4.2" scale="0.9"
       rotation="0,35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
       materialType="0" transmission="1,1,1" roughness="0.27"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="7.0,0.1,13.5" scale="0.95"
       rotation="0,-30,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.85,0.84,0.82" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.18" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-8.5,0.1,11.0" scale="1.0"
       rotation="0,20,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.84,0.86,0.88" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.12" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="2.5,0.1,-2.0" scale="0.8"
       rotation="0,-10,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.78,0.8,0.82" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.16" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-1.5,0.1,-4.5" scale="0.82"
       rotation="0,15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.82,0.8,0.78" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.14" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="6.0,0.1,-8.0" scale="0.88"
       rotation="0,45,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.8,0.78,0.76" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.2" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-6.0,0.1,-7.0" scale="0.86"
       rotation="0,-35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.76,0.78,0.8" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.22" emissionPower="0" />
 
 </Scene>

--- a/MetalCpp Path Tracer/scene_casa_cinematic_distance.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_distance.xml
@@ -43,7 +43,7 @@
     <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
             emission="0.05,0.05,0.06" materialType="0" emissionPower="2.2" />
 
-<Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.34,0.33,0.32"
+    <Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.36,0.28,0.22"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
 <Rectangle position="-5,12,-5" u="20,0,0" v="0,0,20" rotation="180,0,0"
@@ -133,50 +133,50 @@
 
 <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
       rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
       materialType="0" transmission="1,1,1" roughness="0.25"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="4.8,0.1,3.5" scale="0.75"
       rotation="0,-15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
       materialType="0" transmission="1,1,1" roughness="0.28"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-5.5,0.1,4.2" scale="0.9"
       rotation="0,35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
       materialType="0" transmission="1,1,1" roughness="0.27"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="7.0,0.1,13.5" scale="0.95"
       rotation="0,-30,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.85,0.84,0.82" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.18" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-8.5,0.1,11.0" scale="1.0"
       rotation="0,20,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.84,0.86,0.88" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.12" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="2.5,0.1,-2.0" scale="0.8"
       rotation="0,-10,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.78,0.8,0.82" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.16" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-1.5,0.1,-4.5" scale="0.82"
       rotation="0,15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.82,0.8,0.78" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.14" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="6.0,0.1,-8.0" scale="0.88"
       rotation="0,45,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.8,0.78,0.76" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.2" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-6.0,0.1,-7.0" scale="0.86"
       rotation="0,-35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.76,0.78,0.8" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.22" emissionPower="0" />
 
 </Scene>

--- a/MetalCpp Path Tracer/scene_casa_cinematic_energy.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_energy.xml
@@ -42,7 +42,7 @@
     <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
             emission="0.05,0.05,0.06" materialType="0" emissionPower="2.2" />
 
-<Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.34,0.33,0.32"
+    <Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.36,0.28,0.22"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
 <Rectangle position="-5,12,-5" u="20,0,0" v="0,0,20" rotation="180,0,0"
@@ -127,50 +127,50 @@
 
 <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
       rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
       materialType="0" transmission="1,1,1" roughness="0.25"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="4.8,0.1,3.5" scale="0.75"
       rotation="0,-15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
       materialType="0" transmission="1,1,1" roughness="0.28"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-5.5,0.1,4.2" scale="0.9"
       rotation="0,35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
       materialType="0" transmission="1,1,1" roughness="0.27"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="7.0,0.1,13.5" scale="0.95"
       rotation="0,-30,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.85,0.84,0.82" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.18" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-8.5,0.1,11.0" scale="1.0"
       rotation="0,20,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.84,0.86,0.88" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.12" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="2.5,0.1,-2.0" scale="0.8"
       rotation="0,-10,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.78,0.8,0.82" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.16" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-1.5,0.1,-4.5" scale="0.82"
       rotation="0,15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.82,0.8,0.78" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.14" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="6.0,0.1,-8.0" scale="0.88"
       rotation="0,45,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.8,0.78,0.76" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.2" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-6.0,0.1,-7.0" scale="0.86"
       rotation="0,-35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.76,0.78,0.8" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.22" emissionPower="0" />
 
 </Scene>

--- a/MetalCpp Path Tracer/scene_casa_cinematic_rayhit.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_rayhit.xml
@@ -42,7 +42,7 @@
     <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
             emission="0.05,0.05,0.06" materialType="0" emissionPower="2.2" />
 
-<Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.34,0.33,0.32"
+    <Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.36,0.28,0.22"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
 <Rectangle position="-5,12,-5" u="20,0,0" v="0,0,20" rotation="180,0,0"
@@ -137,50 +137,50 @@
 
 <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
       rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
       materialType="0" transmission="1,1,1" roughness="0.25"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="4.8,0.1,3.5" scale="0.75"
       rotation="0,-15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
       materialType="0" transmission="1,1,1" roughness="0.28"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-5.5,0.1,4.2" scale="0.9"
       rotation="0,35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
       materialType="0" transmission="1,1,1" roughness="0.27"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="7.0,0.1,13.5" scale="0.95"
       rotation="0,-30,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.85,0.84,0.82" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.18" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-8.5,0.1,11.0" scale="1.0"
       rotation="0,20,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.84,0.86,0.88" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.12" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="2.5,0.1,-2.0" scale="0.8"
       rotation="0,-10,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.78,0.8,0.82" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.16" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-1.5,0.1,-4.5" scale="0.82"
       rotation="0,15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.82,0.8,0.78" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.14" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="6.0,0.1,-8.0" scale="0.88"
       rotation="0,45,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.8,0.78,0.76" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.2" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-6.0,0.1,-7.0" scale="0.86"
       rotation="0,-35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.76,0.78,0.8" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.22" emissionPower="0" />
 
 </Scene>

--- a/MetalCpp Path Tracer/scene_casa_cinematic_screenspace.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_screenspace.xml
@@ -42,7 +42,7 @@
     <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
             emission="0.05,0.05,0.06" materialType="0" emissionPower="2.2" />
 
-<Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.34,0.33,0.32"
+    <Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.36,0.28,0.22"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
 <Rectangle position="-5,12,-5" u="20,0,0" v="0,0,20" rotation="180,0,0"
@@ -132,50 +132,50 @@
 
 <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
       rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
       materialType="0" transmission="1,1,1" roughness="0.25"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="4.8,0.1,3.5" scale="0.75"
       rotation="0,-15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
       materialType="0" transmission="1,1,1" roughness="0.28"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-5.5,0.1,4.2" scale="0.9"
       rotation="0,35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.98,0.99,1.0" emission="0,0,0" opacity="1"
+      albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
       materialType="0" transmission="1,1,1" roughness="0.27"
       emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="7.0,0.1,13.5" scale="0.95"
       rotation="0,-30,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.85,0.84,0.82" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.18" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-8.5,0.1,11.0" scale="1.0"
       rotation="0,20,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.84,0.86,0.88" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.12" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="2.5,0.1,-2.0" scale="0.8"
       rotation="0,-10,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.78,0.8,0.82" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.16" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-1.5,0.1,-4.5" scale="0.82"
       rotation="0,15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.82,0.8,0.78" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.14" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="6.0,0.1,-8.0" scale="0.88"
       rotation="0,45,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.8,0.78,0.76" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.2" emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-6.0,0.1,-7.0" scale="0.86"
       rotation="0,-35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.76,0.78,0.8" emission="0,0,0"
+      albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.22" emissionPower="0" />
 
 </Scene>


### PR DESCRIPTION
## Summary
- warm up the Casa cinematic ground planes and recolor the bunny meshes for easier visual separation across all scene variants
- increase the offline denoiser's sharpened preset sigmas and blend strength so the filter removes more residual noise

## Testing
- not run (data-only changes)


------
https://chatgpt.com/codex/tasks/task_e_69013399efb8832da4b28f3059ecaae4