### PR TITLE
Align Casa cinematic residency variants with baseline layout

### DIFF
--- a/MetalCpp Path Tracer/scene_casa_cinematic.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic.xml
@@ -1,118 +1,162 @@
-<Scene width="1280" height="720" maxRayDepth="8" startCompacted="true"
+<Scene width="960" height="540" maxRayDepth="5" startCompacted="true"
        residencyStrategy="distance" textureResidencyMemoryCapMB="256"
        lodEnterDistance="60" lodExitDistance="90" residencyCooldown="1" lodToggleBudget="12000">
-    <ObserverCamera position="18,12,18" lookAt="0,4,0" verticalFov="45" />
+    <ObserverCamera position="22,10,26" lookAt="0,4,0" verticalFov="45" />
 
     <CameraPath>
-        <Keyframe frame="0" position="16,6,24" lookAt="0,4,0" />
-        <Keyframe frame="120" position="9,4,10" lookAt="2.5,3.5,4" />
-        <Keyframe frame="240" position="-4,3,12" lookAt="-6,3,10" />
-        <Keyframe frame="360" position="-14,5,20" lookAt="-18,4,24" />
-        <Keyframe frame="480" position="-18,5,-2" lookAt="-16,3,-10" />
-        <Keyframe frame="600" position="18,4,-2" lookAt="24,3,12" />
-        <Keyframe frame="720" position="8,5,-18" lookAt="0,3,-12" />
+        <Keyframe frame="0" position="24,7,30" lookAt="0,4,0" />
+        <Keyframe frame="150" position="12,5,14" lookAt="3,3,4" />
+        <Keyframe frame="300" position="-6,4,14" lookAt="-10,3,12" />
+        <Keyframe frame="450" position="-18,5,24" lookAt="-24,4,30" />
+        <Keyframe frame="600" position="-26,6,6" lookAt="-22,4,8" />
+        <Keyframe frame="750" position="-22,6,-12" lookAt="-14,4,-12" />
+        <Keyframe frame="900" position="18,5,-18" lookAt="6,3,-8" />
+        <Keyframe frame="1020" position="30,6,6" lookAt="20,4,20" />
     </CameraPath>
 
+    <!-- Layout matches scene_casa_cinematic_alwaysresident.xml for SSIM comparisons -->
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
-    <Sphere position="16.293294,6.036662,22.40328" radius="0.20"
+    <Sphere position="24.324324,7.040541,28.378378" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
             emissionPower="2.0" />
-    <Sphere position="8.35218,4.044023,8.35218" radius="0.20"
+    <Sphere position="14.327805,5.046829,16.374634" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
             emissionPower="2.0" />
-    <Sphere position="-6.423999,3.159,10.212" radius="0.20"
+    <Sphere position="-4.120386,4.060193,14.481543" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
             emissionPower="2.0" />
-    <Sphere position="-16.288675,5.288675,17.711325" radius="0.20"
+    <Sphere position="-18.468521,5.078087,17.843826" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
             emissionPower="2.0" />
-    <Sphere position="-20.204124,5.204124,-3.591752" radius="0.20"
+    <Sphere position="-26.4842,6.103757,6.069171" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
             emissionPower="2.0" />
-    <Sphere position="18.0,4.062017,1.503861" radius="0.20"
+    <Sphere position="-24.47724,6.089482,-10.11931" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
             emissionPower="2.0" />
-    <Sphere position="10.288675,5.057735,-14.404145" radius="0.20"
+    <Sphere position="16.35007,5.070014,-14.35007" radius="0.20"
+            albedo="0,0,0" emission="12,11.5,11" materialType="0"
+            emissionPower="2.0" />
+    <Sphere position="26.495918,6.045083,3.954917" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
             emissionPower="2.0" />
 
-    <Sphere position="0,-1000,0" radius="1000" albedo="0.75,0.78,0.82"
-            emission="0.08,0.08,0.1" materialType="0" emissionPower="2.2" />
+    <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
+            emission="0.05,0.05,0.06" materialType="0" emissionPower="2.2" />
 
-    <Rectangle position="0,0,0" u="20,0,0" v="0,0,-20" albedo="0.36,0.28,0.22"
+    <Rectangle position="0,0,0" u="28,0,0" v="0,0,-28" albedo="0.36,0.28,0.22"
                emission="0,0,0" materialType="0" emissionPower="0" />
 
-    <Rectangle position="-3,12,-3" u="12,0,0" v="0,0,12" rotation="180,0,0"
-               albedo="1,1,1" emission="1.0,0.92,0.82" materialType="-1" emissionPower="4.5" />
+    <Rectangle position="-5,12,-5" u="20,0,0" v="0,0,20" rotation="180,0,0"
+               albedo="1,1,1" emission="1.0,0.94,0.84" materialType="-1" emissionPower="6.5" />
 
-    <Rectangle position="-20,18,16" u="8,0,0" v="0,0,-16" rotation="140,35,0"
-               albedo="1,1,1" emission="1.0,0.95,0.85" materialType="-1" emissionPower="7.5" />
+    <Rectangle position="-23,18,17" u="12,0,0" v="0,0,-20" rotation="140,25,0"
+               albedo="1,1,1" emission="1.0,0.97,0.9" materialType="-1" emissionPower="8.5" />
 
-    <!-- Zone 1: Foreground plaza kept mostly clear so the fly-through opens up -->
-    <Mesh file="assets/casa.obj" position="0,0,0" scale="9.5"
-          rotation="0,45,0" clusterMaxTriangles="4096" clusterMaxExtent="28"
+    <Rectangle position="2,9,-21" u="16,0,0" v="0,0,12" rotation="160,-10,0"
+               albedo="1,1,1" emission="0.85,0.9,1.0" materialType="-1" emissionPower="4.5" />
+
+    <Rectangle position="0,0,12" u="8,0,0" v="0,0,12" albedo="0.37,0.36,0.34"
+               emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Zone 1: Always-resident plaza stays breathable up close -->
+    <Mesh file="assets/casa.obj" position="0,0,0" scale="9.6"
+          rotation="0,45,0" clusterMaxTriangles="5120" clusterMaxExtent="30"
           albedo="0.82,0.78,0.74" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <!-- Zone 2: Mid-ground grove that slides into view as the camera rounds the house -->
-    <Mesh file="assets/Tree.obj" position="18,0,26" scale="6.3"
-          rotation="0,12,0" clusterMaxTriangles="528" clusterMaxExtent="18"
-          albedo="0.88,0.9,0.86" emission="0,0,0" materialType="0"
-          emissionPower="0" />
-
-    <Mesh file="assets/Tree.obj" position="-24,0,22" scale="6.1"
-          rotation="0,-32,0" clusterMaxTriangles="528" clusterMaxExtent="18"
-          albedo="0.86,0.88,0.9" emission="0,0,0" materialType="0"
-          emissionPower="0" />
-
-    <Mesh file="assets/Tree.obj" position="-20,0,-20" scale="5.9"
-          rotation="0,-118,0" clusterMaxTriangles="528" clusterMaxExtent="18"
-          albedo="0.88,0.86,0.9" emission="0,0,0" materialType="0"
-          emissionPower="0" />
-
-    <Mesh file="assets/Tree.obj" position="22,0,-18" scale="6.2"
-          rotation="0,128,0" clusterMaxTriangles="528" clusterMaxExtent="18"
+    <!-- Zone 2: Dense but offset mid-ground landscaping kept loaded at all times -->
+    <Mesh file="assets/Tree.obj" position="18,0,24" scale="6.4"
+          rotation="0,20,0" clusterMaxTriangles="640" clusterMaxExtent="18"
           albedo="0.9,0.88,0.84" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <!-- Zone 3: Distant villas form a high-contrast ring for the closing shots -->
-    <Mesh file="assets/casa.obj" position="44,0,40" scale="7.6"
-          rotation="0,20,0" clusterMaxTriangles="5120" clusterMaxExtent="46"
+    <Mesh file="assets/Tree.obj" position="0,0,26" scale="6.2"
+          rotation="0,0,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.88,0.9,0.86" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <Mesh file="assets/Tree.obj" position="-20,0,24" scale="6.5"
+          rotation="0,-32,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.86,0.88,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <Mesh file="assets/Tree.obj" position="-22,0,-18" scale="6.3"
+          rotation="0,-120,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.9,0.88,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <Mesh file="assets/Tree.obj" position="20,0,-20" scale="6.1"
+          rotation="0,132,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.88,0.86,0.88" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <!-- Zone 3: Full perimeter of villas showcases the always-loaded budget -->
+    <Mesh file="assets/casa.obj" position="48,0,44" scale="8.0"
+          rotation="0,16,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
           albedo="0.8,0.77,0.73" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/casa.obj" position="-48,0,28" scale="8.1"
-          rotation="0,-60,0" clusterMaxTriangles="5120" clusterMaxExtent="46"
+    <Mesh file="assets/casa.obj" position="6,0,56" scale="7.8"
+          rotation="0,-4,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
           albedo="0.79,0.76,0.72" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/casa.obj" position="-36,0,-46" scale="7.8"
-          rotation="0,95,0" clusterMaxTriangles="5120" clusterMaxExtent="46"
+    <Mesh file="assets/casa.obj" position="-50,0,42" scale="8.2"
+          rotation="0,-70,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
           albedo="0.78,0.75,0.71" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="36,0,-38" scale="6.5"
-          rotation="0,146,0" clusterMaxTriangles="600" clusterMaxExtent="20"
-          albedo="0.87,0.89,0.85" emission="0,0,0" materialType="0"
+    <Mesh file="assets/casa.obj" position="-40,0,-52" scale="7.9"
+          rotation="0,110,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
+          albedo="0.77,0.74,0.7" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="34,0,30" scale="6.4"
-          rotation="0,32,0" clusterMaxTriangles="600" clusterMaxExtent="20"
+    <Mesh file="assets/casa.obj" position="40,0,-50" scale="7.7"
+          rotation="0,148,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
+          albedo="0.81,0.78,0.74" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <Mesh file="assets/Tree.obj" position="32,0,40" scale="6.6"
+          rotation="0,28,0" clusterMaxTriangles="600" clusterMaxExtent="22"
+          albedo="0.88,0.9,0.84" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <Mesh file="assets/Tree.obj" position="-34,0,42" scale="6.7"
+          rotation="0,-40,0" clusterMaxTriangles="600" clusterMaxExtent="22"
+          albedo="0.86,0.9,0.88" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <Mesh file="assets/Tree.obj" position="-32,0,-40" scale="6.5"
+          rotation="0,120,0" clusterMaxTriangles="600" clusterMaxExtent="22"
           albedo="0.9,0.88,0.86" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.8"
-          rotation="0,5,0" albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
+    <Mesh file="assets/Tree.obj" position="30,0,-38" scale="6.4"
+          rotation="0,152,0" clusterMaxTriangles="600" clusterMaxExtent="22"
+          albedo="0.88,0.86,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
+          rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"
+          albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
           materialType="0" transmission="1,1,1" roughness="0.25"
           emissionPower="0" />
 
-    <Mesh file="assets/bunny.obj" position="3.5,0.1,2.5" scale="0.65"
-          rotation="0,-15,0" albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
+    <Mesh file="assets/bunny.obj" position="4.8,0.1,3.5" scale="0.75"
+          rotation="0,-15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
+          albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
           materialType="0" transmission="1,1,1" roughness="0.28"
           emissionPower="0" />
 
-    <Mesh file="assets/bunny.obj" position="-6,0.1,4" scale="0.7"
-          rotation="0,35,0" albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
-          materialType="0" transmission="1,1,1" roughness="0.26"
+    <Mesh file="assets/bunny.obj" position="-5.5,0.1,4.2" scale="0.9"
+          rotation="0,35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
+          albedo="0.55,0.82,0.92" emission="0,0,0" opacity="1"
+          materialType="0" transmission="1,1,1" roughness="0.27"
           emissionPower="0" />
+
+    <Mesh file="assets/bunny.obj" position="7.0,0.1,13.5" scale="0.95"
+          rotation="0,-30,0" clusterMaxTriangles="384" clusterMaxExtent="6"
+          albedo="0.55,0.82,0.92" emission="0,0,0"
+          materialType="0" roughness="0.18" emissionPower="0" />
 </Scene>

--- a/MetalCpp Path Tracer/scene_casa_cinematic_distance.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_distance.xml
@@ -5,15 +5,16 @@
 
 <CameraPath>
     <Keyframe frame="0" position="24,7,30" lookAt="0,4,0" />
-    <Keyframe frame="160" position="14,5,18" lookAt="4,3,6" />
-    <Keyframe frame="320" position="-6,4,14" lookAt="-10,3,12" />
-    <Keyframe frame="480" position="-20,5,22" lookAt="-28,4,32" />
-    <Keyframe frame="640" position="-30,6,8" lookAt="-32,4,4" />
-    <Keyframe frame="800" position="-26,6,-12" lookAt="-16,3,-10" />
-    <Keyframe frame="960" position="18,5,-18" lookAt="6,3,-8" />
-    <Keyframe frame="1080" position="32,6,10" lookAt="24,4,28" />
+    <Keyframe frame="150" position="12,5,14" lookAt="3,3,4" />
+    <Keyframe frame="300" position="-6,4,14" lookAt="-10,3,12" />
+    <Keyframe frame="450" position="-18,5,24" lookAt="-24,4,30" />
+    <Keyframe frame="600" position="-26,6,6" lookAt="-22,4,8" />
+    <Keyframe frame="750" position="-22,6,-12" lookAt="-14,4,-12" />
+    <Keyframe frame="900" position="18,5,-18" lookAt="6,3,-8" />
+    <Keyframe frame="1020" position="30,6,6" lookAt="20,4,20" />
 </CameraPath>
 
+    <!-- Layout matches scene_casa_cinematic_alwaysresident.xml for SSIM comparisons -->
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
     <Sphere position="24.324324,7.040541,28.378378" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
@@ -39,7 +40,6 @@
     <Sphere position="26.495918,6.045083,3.954917" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
             emissionPower="2.0" />
-
     <Sphere position="0,-1000,0" radius="1000" albedo="0.74,0.76,0.78"
             emission="0.05,0.05,0.06" materialType="0" emissionPower="2.2" />
 
@@ -58,76 +58,81 @@
 <Rectangle position="0,0,12" u="8,0,0" v="0,0,12" albedo="0.37,0.36,0.34"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
-    <!-- Zone 1: Foreground kept open for the residency ramp -->
-    <Mesh file="assets/casa.obj" position="0,0,0" scale="9.5"
-          rotation="0,45,0" clusterMaxTriangles="4096" clusterMaxExtent="28"
+    <!-- Zone 1: Always-resident plaza stays breathable up close -->
+    <Mesh file="assets/casa.obj" position="0,0,0" scale="9.6"
+          rotation="0,45,0" clusterMaxTriangles="5120" clusterMaxExtent="30"
           albedo="0.82,0.78,0.74" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <!-- Zone 2: Mid-ground tree line that eases into frame -->
-    <Mesh file="assets/Tree.obj" position="18,0,28" scale="6.5"
-          rotation="0,18,0" clusterMaxTriangles="480" clusterMaxExtent="16"
+    <!-- Zone 2: Dense but offset mid-ground landscaping kept loaded at all times -->
+    <Mesh file="assets/Tree.obj" position="18,0,24" scale="6.4"
+          rotation="0,20,0" clusterMaxTriangles="640" clusterMaxExtent="18"
           albedo="0.9,0.88,0.84" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-24,0,24" scale="6.4"
-          rotation="0,-34,0" clusterMaxTriangles="480" clusterMaxExtent="16"
+    <Mesh file="assets/Tree.obj" position="0,0,26" scale="6.2"
+          rotation="0,0,0" clusterMaxTriangles="640" clusterMaxExtent="18"
           albedo="0.88,0.9,0.86" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-22,0,-24" scale="6.2"
-          rotation="0,-120,0" clusterMaxTriangles="480" clusterMaxExtent="16"
+    <Mesh file="assets/Tree.obj" position="-20,0,24" scale="6.5"
+          rotation="0,-32,0" clusterMaxTriangles="640" clusterMaxExtent="18"
           albedo="0.86,0.88,0.9" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="24,0,-26" scale="6.4"
-          rotation="0,138,0" clusterMaxTriangles="480" clusterMaxExtent="16"
-          albedo="0.9,0.86,0.88" emission="0,0,0" materialType="0"
+    <Mesh file="assets/Tree.obj" position="-22,0,-18" scale="6.3"
+          rotation="0,-120,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.9,0.88,0.9" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <!-- Zone 3: Massive far-distance villas stress distance residency -->
-    <Mesh file="assets/casa.obj" position="60,0,54" scale="8.6"
-          rotation="0,18,0" clusterMaxTriangles="7168" clusterMaxExtent="60"
+    <Mesh file="assets/Tree.obj" position="20,0,-20" scale="6.1"
+          rotation="0,132,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.88,0.86,0.88" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <!-- Zone 3: Full perimeter of villas showcases the always-loaded budget -->
+    <Mesh file="assets/casa.obj" position="48,0,44" scale="8.0"
+          rotation="0,16,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
           albedo="0.8,0.77,0.73" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/casa.obj" position="4,0,68" scale="8.3"
-          rotation="0,2,0" clusterMaxTriangles="7168" clusterMaxExtent="60"
+    <Mesh file="assets/casa.obj" position="6,0,56" scale="7.8"
+          rotation="0,-4,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
           albedo="0.79,0.76,0.72" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/casa.obj" position="-66,0,46" scale="8.9"
-          rotation="0,-70,0" clusterMaxTriangles="7168" clusterMaxExtent="60"
+    <Mesh file="assets/casa.obj" position="-50,0,42" scale="8.2"
+          rotation="0,-70,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
           albedo="0.78,0.75,0.71" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/casa.obj" position="-52,0,-62" scale="8.4"
-          rotation="0,108,0" clusterMaxTriangles="7168" clusterMaxExtent="60"
+    <Mesh file="assets/casa.obj" position="-40,0,-52" scale="7.9"
+          rotation="0,110,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
           albedo="0.77,0.74,0.7" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/casa.obj" position="46,0,-64" scale="8.2"
-          rotation="0,152,0" clusterMaxTriangles="7168" clusterMaxExtent="60"
+    <Mesh file="assets/casa.obj" position="40,0,-50" scale="7.7"
+          rotation="0,148,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
           albedo="0.81,0.78,0.74" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="44,0,50" scale="6.7"
-          rotation="0,40,0" clusterMaxTriangles="560" clusterMaxExtent="22"
+    <Mesh file="assets/Tree.obj" position="32,0,40" scale="6.6"
+          rotation="0,28,0" clusterMaxTriangles="600" clusterMaxExtent="22"
           albedo="0.88,0.9,0.84" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-46,0,52" scale="6.8"
-          rotation="0,-48,0" clusterMaxTriangles="560" clusterMaxExtent="22"
+    <Mesh file="assets/Tree.obj" position="-34,0,42" scale="6.7"
+          rotation="0,-40,0" clusterMaxTriangles="600" clusterMaxExtent="22"
           albedo="0.86,0.9,0.88" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-42,0,-52" scale="6.5"
-          rotation="0,116,0" clusterMaxTriangles="560" clusterMaxExtent="22"
+    <Mesh file="assets/Tree.obj" position="-32,0,-40" scale="6.5"
+          rotation="0,120,0" clusterMaxTriangles="600" clusterMaxExtent="22"
           albedo="0.9,0.88,0.86" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="40,0,-52" scale="6.4"
-          rotation="0,142,0" clusterMaxTriangles="560" clusterMaxExtent="22"
+    <Mesh file="assets/Tree.obj" position="30,0,-38" scale="6.4"
+          rotation="0,152,0" clusterMaxTriangles="600" clusterMaxExtent="22"
           albedo="0.88,0.86,0.9" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
@@ -153,30 +158,5 @@
       rotation="0,-30,0" clusterMaxTriangles="384" clusterMaxExtent="6"
       albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.18" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="-8.5,0.1,11.0" scale="1.0"
-      rotation="0,20,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.12" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="2.5,0.1,-2.0" scale="0.8"
-      rotation="0,-10,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.16" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="-1.5,0.1,-4.5" scale="0.82"
-      rotation="0,15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.14" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="6.0,0.1,-8.0" scale="0.88"
-      rotation="0,45,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.2" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="-6.0,0.1,-7.0" scale="0.86"
-      rotation="0,-35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.22" emissionPower="0" />
 
 </Scene>

--- a/MetalCpp Path Tracer/scene_casa_cinematic_energy.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_energy.xml
@@ -4,16 +4,17 @@
 <ObserverCamera position="22,10,26" lookAt="0,4,0" verticalFov="45" />
 
 <CameraPath>
-    <Keyframe frame="0" position="24,7,28" lookAt="0,4,0" />
-    <Keyframe frame="140" position="13,5,14" lookAt="4,3,6" />
-    <Keyframe frame="280" position="0,4,12" lookAt="-4,3,10" />
-    <Keyframe frame="420" position="-16,5,22" lookAt="-20,4,28" />
-    <Keyframe frame="560" position="-24,6,8" lookAt="-20,4,6" />
-    <Keyframe frame="700" position="-18,6,-12" lookAt="-10,4,-8" />
-    <Keyframe frame="840" position="14,5,-20" lookAt="4,3,-10" />
-    <Keyframe frame="980" position="26,6,6" lookAt="18,4,18" />
+    <Keyframe frame="0" position="24,7,30" lookAt="0,4,0" />
+    <Keyframe frame="150" position="12,5,14" lookAt="3,3,4" />
+    <Keyframe frame="300" position="-6,4,14" lookAt="-10,3,12" />
+    <Keyframe frame="450" position="-18,5,24" lookAt="-24,4,30" />
+    <Keyframe frame="600" position="-26,6,6" lookAt="-22,4,8" />
+    <Keyframe frame="750" position="-22,6,-12" lookAt="-14,4,-12" />
+    <Keyframe frame="900" position="18,5,-18" lookAt="6,3,-8" />
+    <Keyframe frame="1020" position="30,6,6" lookAt="20,4,20" />
 </CameraPath>
 
+    <!-- Layout matches scene_casa_cinematic_alwaysresident.xml for SSIM comparisons -->
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
     <Sphere position="24.324324,7.040541,28.378378" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
@@ -57,73 +58,83 @@
 <Rectangle position="0,0,12" u="8,0,0" v="0,0,12" albedo="0.37,0.36,0.34"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
-    <!-- Zone 1: Quiet courtyard to stage the energy spikes later on -->
-    <Mesh file="assets/casa.obj" position="0,0,0" scale="9.4"
-          rotation="0,45,0" clusterMaxTriangles="4096" clusterMaxExtent="26"
+    <!-- Zone 1: Always-resident plaza stays breathable up close -->
+    <Mesh file="assets/casa.obj" position="0,0,0" scale="9.6"
+          rotation="0,45,0" clusterMaxTriangles="5120" clusterMaxExtent="30"
           albedo="0.82,0.78,0.74" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <!-- Zone 2: Hero props with boosted emission to stress energy residency -->
-    <Mesh file="assets/Tree.obj" position="16,0,22" scale="6.0"
-          rotation="0,12,0" clusterMaxTriangles="320" clusterMaxExtent="14"
-          albedo="0.9,0.88,0.82" emission="0.8,0.7,0.6" materialType="0"
-          emissionPower="0.5" />
+    <!-- Zone 2: Dense but offset mid-ground landscaping kept loaded at all times -->
+    <Mesh file="assets/Tree.obj" position="18,0,24" scale="6.4"
+          rotation="0,20,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.9,0.88,0.84" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-    <Mesh file="assets/casa.obj" position="-14,0,18" scale="5.8"
-          rotation="0,-30,0" clusterMaxTriangles="2048" clusterMaxExtent="20"
-          albedo="0.83,0.8,0.76" emission="0.4,0.35,0.3" materialType="0"
-          emissionPower="0.35" />
+    <Mesh file="assets/Tree.obj" position="0,0,26" scale="6.2"
+          rotation="0,0,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.88,0.9,0.86" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-18,0,-14" scale="6.1"
-          rotation="0,-128,0" clusterMaxTriangles="320" clusterMaxExtent="14"
-          albedo="0.88,0.86,0.9" emission="0.7,0.75,0.8" materialType="0"
-          emissionPower="0.45" />
+    <Mesh file="assets/Tree.obj" position="-20,0,24" scale="6.5"
+          rotation="0,-32,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.86,0.88,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="12,0,-16" scale="5.9"
-          rotation="0,130,0" clusterMaxTriangles="320" clusterMaxExtent="14"
-          albedo="0.9,0.86,0.84" emission="0.6,0.5,0.45" materialType="0"
-          emissionPower="0.4" />
+    <Mesh file="assets/Tree.obj" position="-22,0,-18" scale="6.3"
+          rotation="0,-120,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.9,0.88,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-    <!-- Zone 3: Distant energy anchors keep the budget busy late in the shot -->
-    <Mesh file="assets/casa.obj" position="44,0,36" scale="7.4"
-          rotation="0,18,0" clusterMaxTriangles="5120" clusterMaxExtent="44"
-          albedo="0.8,0.77,0.73" emission="0.2,0.2,0.18" materialType="0"
-          emissionPower="0.25" />
+    <Mesh file="assets/Tree.obj" position="20,0,-20" scale="6.1"
+          rotation="0,132,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.88,0.86,0.88" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-    <Mesh file="assets/casa.obj" position="-46,0,34" scale="7.6"
-          rotation="0,-62,0" clusterMaxTriangles="5120" clusterMaxExtent="44"
-          albedo="0.79,0.76,0.72" emission="0.18,0.2,0.22" materialType="0"
-          emissionPower="0.22" />
+    <!-- Zone 3: Full perimeter of villas showcases the always-loaded budget -->
+    <Mesh file="assets/casa.obj" position="48,0,44" scale="8.0"
+          rotation="0,16,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
+          albedo="0.8,0.77,0.73" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-    <Mesh file="assets/casa.obj" position="-34,0,-44" scale="7.2"
-          rotation="0,104,0" clusterMaxTriangles="5120" clusterMaxExtent="44"
-          albedo="0.78,0.75,0.71" emission="0.2,0.22,0.25" materialType="0"
-          emissionPower="0.24" />
+    <Mesh file="assets/casa.obj" position="6,0,56" scale="7.8"
+          rotation="0,-4,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
+          albedo="0.79,0.76,0.72" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-    <Mesh file="assets/casa.obj" position="36,0,-46" scale="7.0"
-          rotation="0,150,0" clusterMaxTriangles="5120" clusterMaxExtent="44"
-          albedo="0.81,0.78,0.74" emission="0.16,0.18,0.2" materialType="0"
-          emissionPower="0.2" />
+    <Mesh file="assets/casa.obj" position="-50,0,42" scale="8.2"
+          rotation="0,-70,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
+          albedo="0.78,0.75,0.71" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="34,0,32" scale="6.3"
-          rotation="0,32,0" clusterMaxTriangles="360" clusterMaxExtent="16"
-          albedo="0.9,0.88,0.86" emission="0.55,0.52,0.5" materialType="0"
-          emissionPower="0.35" />
+    <Mesh file="assets/casa.obj" position="-40,0,-52" scale="7.9"
+          rotation="0,110,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
+          albedo="0.77,0.74,0.7" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-32,0,30" scale="6.2"
-          rotation="0,-44,0" clusterMaxTriangles="360" clusterMaxExtent="16"
-          albedo="0.88,0.9,0.88" emission="0.5,0.54,0.58" materialType="0"
-          emissionPower="0.33" />
+    <Mesh file="assets/casa.obj" position="40,0,-50" scale="7.7"
+          rotation="0,148,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
+          albedo="0.81,0.78,0.74" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-30,0,-32" scale="6.1"
-          rotation="0,118,0" clusterMaxTriangles="360" clusterMaxExtent="16"
-          albedo="0.9,0.86,0.9" emission="0.52,0.5,0.6" materialType="0"
-          emissionPower="0.32" />
+    <Mesh file="assets/Tree.obj" position="32,0,40" scale="6.6"
+          rotation="0,28,0" clusterMaxTriangles="600" clusterMaxExtent="22"
+          albedo="0.88,0.9,0.84" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="30,0,-34" scale="6.0"
-          rotation="0,148,0" clusterMaxTriangles="360" clusterMaxExtent="16"
-          albedo="0.86,0.88,0.9" emission="0.48,0.5,0.46" materialType="0"
-          emissionPower="0.3" />
+    <Mesh file="assets/Tree.obj" position="-34,0,42" scale="6.7"
+          rotation="0,-40,0" clusterMaxTriangles="600" clusterMaxExtent="22"
+          albedo="0.86,0.9,0.88" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <Mesh file="assets/Tree.obj" position="-32,0,-40" scale="6.5"
+          rotation="0,120,0" clusterMaxTriangles="600" clusterMaxExtent="22"
+          albedo="0.9,0.88,0.86" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <Mesh file="assets/Tree.obj" position="30,0,-38" scale="6.4"
+          rotation="0,152,0" clusterMaxTriangles="600" clusterMaxExtent="22"
+          albedo="0.88,0.86,0.9" emission="0,0,0" materialType="0"
+          emissionPower="0" />
 
 <Mesh file="assets/bunny.obj" position="-2,0.1,8" scale="0.85"
       rotation="0,5,0" clusterMaxTriangles="384" clusterMaxExtent="6"
@@ -147,30 +158,5 @@
       rotation="0,-30,0" clusterMaxTriangles="384" clusterMaxExtent="6"
       albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.18" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="-8.5,0.1,11.0" scale="1.0"
-      rotation="0,20,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.12" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="2.5,0.1,-2.0" scale="0.8"
-      rotation="0,-10,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.16" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="-1.5,0.1,-4.5" scale="0.82"
-      rotation="0,15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.14" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="6.0,0.1,-8.0" scale="0.88"
-      rotation="0,45,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.2" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="-6.0,0.1,-7.0" scale="0.86"
-      rotation="0,-35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.22" emissionPower="0" />
 
 </Scene>

--- a/MetalCpp Path Tracer/scene_casa_cinematic_rayhit.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_rayhit.xml
@@ -4,16 +4,17 @@
 <ObserverCamera position="22,10,26" lookAt="0,4,0" verticalFov="45" />
 
 <CameraPath>
-    <Keyframe frame="0" position="24,7,28" lookAt="0,4,0" />
-    <Keyframe frame="140" position="13,5,14" lookAt="3,3,4" />
-    <Keyframe frame="280" position="-2,4,12" lookAt="-6,3,10" />
-    <Keyframe frame="420" position="-18,5,22" lookAt="-24,4,28" />
-    <Keyframe frame="560" position="-26,6,6" lookAt="-22,4,4" />
-    <Keyframe frame="700" position="-20,6,-14" lookAt="-12,4,-10" />
-    <Keyframe frame="840" position="16,5,-18" lookAt="6,3,-6" />
-    <Keyframe frame="980" position="28,6,6" lookAt="20,4,18" />
+    <Keyframe frame="0" position="24,7,30" lookAt="0,4,0" />
+    <Keyframe frame="150" position="12,5,14" lookAt="3,3,4" />
+    <Keyframe frame="300" position="-6,4,14" lookAt="-10,3,12" />
+    <Keyframe frame="450" position="-18,5,24" lookAt="-24,4,30" />
+    <Keyframe frame="600" position="-26,6,6" lookAt="-22,4,8" />
+    <Keyframe frame="750" position="-22,6,-12" lookAt="-14,4,-12" />
+    <Keyframe frame="900" position="18,5,-18" lookAt="6,3,-8" />
+    <Keyframe frame="1020" position="30,6,6" lookAt="20,4,20" />
 </CameraPath>
 
+    <!-- Layout matches scene_casa_cinematic_alwaysresident.xml for SSIM comparisons -->
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
     <Sphere position="24.324324,7.040541,28.378378" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
@@ -57,81 +58,81 @@
 <Rectangle position="0,0,12" u="8,0,0" v="0,0,12" albedo="0.37,0.36,0.34"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
-    <!-- Zone 1: Open plaza keeps initial ray budget light -->
-    <Mesh file="assets/casa.obj" position="0,0,0" scale="9.3"
-          rotation="0,45,0" clusterMaxTriangles="4096" clusterMaxExtent="26"
+    <!-- Zone 1: Always-resident plaza stays breathable up close -->
+    <Mesh file="assets/casa.obj" position="0,0,0" scale="9.6"
+          rotation="0,45,0" clusterMaxTriangles="5120" clusterMaxExtent="30"
           albedo="0.82,0.78,0.74" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <!-- Zone 2: Tight ray-hit corridor built from narrow tree clusters -->
-    <Mesh file="assets/Tree.obj" position="14,0,20" scale="6.1"
-          rotation="0,18,0" clusterMaxTriangles="256" clusterMaxExtent="12"
-          albedo="0.88,0.9,0.84" emission="0,0,0" materialType="0"
+    <!-- Zone 2: Dense but offset mid-ground landscaping kept loaded at all times -->
+    <Mesh file="assets/Tree.obj" position="18,0,24" scale="6.4"
+          rotation="0,20,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.9,0.88,0.84" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-12,0,18" scale="6.0"
-          rotation="0,-26,0" clusterMaxTriangles="256" clusterMaxExtent="12"
-          albedo="0.86,0.9,0.88" emission="0,0,0" materialType="0"
+    <Mesh file="assets/Tree.obj" position="0,0,26" scale="6.2"
+          rotation="0,0,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.88,0.9,0.86" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-14,0,-12" scale="6.2"
-          rotation="0,-134,0" clusterMaxTriangles="256" clusterMaxExtent="12"
-          albedo="0.88,0.86,0.9" emission="0,0,0" materialType="0"
+    <Mesh file="assets/Tree.obj" position="-20,0,24" scale="6.5"
+          rotation="0,-32,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.86,0.88,0.9" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="16,0,-14" scale="6.0"
-          rotation="0,138,0" clusterMaxTriangles="256" clusterMaxExtent="12"
-          albedo="0.9,0.88,0.86" emission="0,0,0" materialType="0"
-          emissionPower="0" />
-
-    <Mesh file="assets/Tree.obj" position="6,0,18" scale="5.8"
-          rotation="0,6,0" clusterMaxTriangles="256" clusterMaxExtent="12"
+    <Mesh file="assets/Tree.obj" position="-22,0,-18" scale="6.3"
+          rotation="0,-120,0" clusterMaxTriangles="640" clusterMaxExtent="18"
           albedo="0.9,0.88,0.9" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-4,0,-16" scale="5.7"
-          rotation="0,-152,0" clusterMaxTriangles="256" clusterMaxExtent="12"
+    <Mesh file="assets/Tree.obj" position="20,0,-20" scale="6.1"
+          rotation="0,132,0" clusterMaxTriangles="640" clusterMaxExtent="18"
           albedo="0.88,0.86,0.88" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <!-- Zone 3: Angular villa perimeter catches late-frame rays -->
-    <Mesh file="assets/casa.obj" position="42,0,34" scale="7.2"
-          rotation="0,22,0" clusterMaxTriangles="4608" clusterMaxExtent="40"
+    <!-- Zone 3: Full perimeter of villas showcases the always-loaded budget -->
+    <Mesh file="assets/casa.obj" position="48,0,44" scale="8.0"
+          rotation="0,16,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
           albedo="0.8,0.77,0.73" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/casa.obj" position="-44,0,32" scale="7.4"
-          rotation="0,-66,0" clusterMaxTriangles="4608" clusterMaxExtent="40"
+    <Mesh file="assets/casa.obj" position="6,0,56" scale="7.8"
+          rotation="0,-4,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
           albedo="0.79,0.76,0.72" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/casa.obj" position="-32,0,-46" scale="7.0"
-          rotation="0,108,0" clusterMaxTriangles="4608" clusterMaxExtent="40"
+    <Mesh file="assets/casa.obj" position="-50,0,42" scale="8.2"
+          rotation="0,-70,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
           albedo="0.78,0.75,0.71" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/casa.obj" position="34,0,-44" scale="6.9"
-          rotation="0,152,0" clusterMaxTriangles="4608" clusterMaxExtent="40"
+    <Mesh file="assets/casa.obj" position="-40,0,-52" scale="7.9"
+          rotation="0,110,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
+          albedo="0.77,0.74,0.7" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <Mesh file="assets/casa.obj" position="40,0,-50" scale="7.7"
+          rotation="0,148,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
           albedo="0.81,0.78,0.74" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="32,0,28" scale="6.2"
-          rotation="0,34,0" clusterMaxTriangles="320" clusterMaxExtent="14"
+    <Mesh file="assets/Tree.obj" position="32,0,40" scale="6.6"
+          rotation="0,28,0" clusterMaxTriangles="600" clusterMaxExtent="22"
           albedo="0.88,0.9,0.84" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-30,0,28" scale="6.1"
-          rotation="0,-48,0" clusterMaxTriangles="320" clusterMaxExtent="14"
+    <Mesh file="assets/Tree.obj" position="-34,0,42" scale="6.7"
+          rotation="0,-40,0" clusterMaxTriangles="600" clusterMaxExtent="22"
           albedo="0.86,0.9,0.88" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-28,0,-36" scale="6.0"
-          rotation="0,122,0" clusterMaxTriangles="320" clusterMaxExtent="14"
+    <Mesh file="assets/Tree.obj" position="-32,0,-40" scale="6.5"
+          rotation="0,120,0" clusterMaxTriangles="600" clusterMaxExtent="22"
           albedo="0.9,0.88,0.86" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="28,0,-34" scale="5.9"
-          rotation="0,148,0" clusterMaxTriangles="320" clusterMaxExtent="14"
+    <Mesh file="assets/Tree.obj" position="30,0,-38" scale="6.4"
+          rotation="0,152,0" clusterMaxTriangles="600" clusterMaxExtent="22"
           albedo="0.88,0.86,0.9" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
@@ -157,30 +158,5 @@
       rotation="0,-30,0" clusterMaxTriangles="384" clusterMaxExtent="6"
       albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.18" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="-8.5,0.1,11.0" scale="1.0"
-      rotation="0,20,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.12" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="2.5,0.1,-2.0" scale="0.8"
-      rotation="0,-10,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.16" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="-1.5,0.1,-4.5" scale="0.82"
-      rotation="0,15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.14" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="6.0,0.1,-8.0" scale="0.88"
-      rotation="0,45,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.2" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="-6.0,0.1,-7.0" scale="0.86"
-      rotation="0,-35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.22" emissionPower="0" />
 
 </Scene>

--- a/MetalCpp Path Tracer/scene_casa_cinematic_screenspace.xml
+++ b/MetalCpp Path Tracer/scene_casa_cinematic_screenspace.xml
@@ -4,16 +4,17 @@
 <ObserverCamera position="22,10,26" lookAt="0,4,0" verticalFov="45" />
 
 <CameraPath>
-    <Keyframe frame="0" position="24,7,28" lookAt="0,4,0" />
-    <Keyframe frame="140" position="12,5,16" lookAt="3,3,6" />
-    <Keyframe frame="280" position="-2,4,14" lookAt="-6,3,10" />
-    <Keyframe frame="420" position="-18,5,22" lookAt="-24,4,30" />
-    <Keyframe frame="560" position="-26,6,4" lookAt="-20,4,2" />
-    <Keyframe frame="700" position="-18,6,-14" lookAt="-10,4,-10" />
-    <Keyframe frame="840" position="16,5,-18" lookAt="6,3,-8" />
-    <Keyframe frame="980" position="28,6,6" lookAt="18,4,18" />
+    <Keyframe frame="0" position="24,7,30" lookAt="0,4,0" />
+    <Keyframe frame="150" position="12,5,14" lookAt="3,3,4" />
+    <Keyframe frame="300" position="-6,4,14" lookAt="-10,3,12" />
+    <Keyframe frame="450" position="-18,5,24" lookAt="-24,4,30" />
+    <Keyframe frame="600" position="-26,6,6" lookAt="-22,4,8" />
+    <Keyframe frame="750" position="-22,6,-12" lookAt="-14,4,-12" />
+    <Keyframe frame="900" position="18,5,-18" lookAt="6,3,-8" />
+    <Keyframe frame="1020" position="30,6,6" lookAt="20,4,20" />
 </CameraPath>
 
+    <!-- Layout matches scene_casa_cinematic_alwaysresident.xml for SSIM comparisons -->
     <!-- Camera-adjacent fill lights to reduce path tracing noise -->
     <Sphere position="24.324324,7.040541,28.378378" radius="0.20"
             albedo="0,0,0" emission="12,11.5,11" materialType="0"
@@ -57,76 +58,81 @@
 <Rectangle position="0,0,12" u="8,0,0" v="0,0,12" albedo="0.37,0.36,0.34"
            emission="0,0,0" materialType="0" emissionPower="0" />
 
-    <!-- Zone 1: Foreground runway left open for screenspace sweeps -->
-    <Mesh file="assets/casa.obj" position="0,0,0" scale="9.4"
-          rotation="0,45,0" clusterMaxTriangles="4096" clusterMaxExtent="26"
+    <!-- Zone 1: Always-resident plaza stays breathable up close -->
+    <Mesh file="assets/casa.obj" position="0,0,0" scale="9.6"
+          rotation="0,45,0" clusterMaxTriangles="5120" clusterMaxExtent="30"
           albedo="0.82,0.78,0.74" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <!-- Zone 2: Broad tree arcs that glide across the frame -->
-    <Mesh file="assets/Tree.obj" position="20,0,26" scale="6.6"
-          rotation="0,24,0" clusterMaxTriangles="512" clusterMaxExtent="22"
+    <!-- Zone 2: Dense but offset mid-ground landscaping kept loaded at all times -->
+    <Mesh file="assets/Tree.obj" position="18,0,24" scale="6.4"
+          rotation="0,20,0" clusterMaxTriangles="640" clusterMaxExtent="18"
           albedo="0.9,0.88,0.84" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="0,0,28" scale="6.4"
-          rotation="0,0,0" clusterMaxTriangles="512" clusterMaxExtent="22"
+    <Mesh file="assets/Tree.obj" position="0,0,26" scale="6.2"
+          rotation="0,0,0" clusterMaxTriangles="640" clusterMaxExtent="18"
           albedo="0.88,0.9,0.86" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-22,0,24" scale="6.7"
-          rotation="0,-32,0" clusterMaxTriangles="512" clusterMaxExtent="22"
-          albedo="0.86,0.9,0.88" emission="0,0,0" materialType="0"
+    <Mesh file="assets/Tree.obj" position="-20,0,24" scale="6.5"
+          rotation="0,-32,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.86,0.88,0.9" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-24,0,-20" scale="6.5"
-          rotation="0,-118,0" clusterMaxTriangles="512" clusterMaxExtent="22"
-          albedo="0.88,0.86,0.9" emission="0,0,0" materialType="0"
+    <Mesh file="assets/Tree.obj" position="-22,0,-18" scale="6.3"
+          rotation="0,-120,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.9,0.88,0.9" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="22,0,-22" scale="6.4"
-          rotation="0,140,0" clusterMaxTriangles="512" clusterMaxExtent="22"
-          albedo="0.9,0.88,0.86" emission="0,0,0" materialType="0"
+    <Mesh file="assets/Tree.obj" position="20,0,-20" scale="6.1"
+          rotation="0,132,0" clusterMaxTriangles="640" clusterMaxExtent="18"
+          albedo="0.88,0.86,0.88" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <!-- Zone 3: Oversized villa belt to fill late frame coverage -->
-    <Mesh file="assets/casa.obj" position="48,0,40" scale="7.8"
-          rotation="0,18,0" clusterMaxTriangles="5632" clusterMaxExtent="54"
+    <!-- Zone 3: Full perimeter of villas showcases the always-loaded budget -->
+    <Mesh file="assets/casa.obj" position="48,0,44" scale="8.0"
+          rotation="0,16,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
           albedo="0.8,0.77,0.73" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/casa.obj" position="-50,0,38" scale="8.0"
-          rotation="0,-64,0" clusterMaxTriangles="5632" clusterMaxExtent="54"
+    <Mesh file="assets/casa.obj" position="6,0,56" scale="7.8"
+          rotation="0,-4,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
           albedo="0.79,0.76,0.72" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/casa.obj" position="-36,0,-48" scale="7.4"
-          rotation="0,110,0" clusterMaxTriangles="5632" clusterMaxExtent="54"
+    <Mesh file="assets/casa.obj" position="-50,0,42" scale="8.2"
+          rotation="0,-70,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
           albedo="0.78,0.75,0.71" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/casa.obj" position="40,0,-50" scale="7.2"
-          rotation="0,150,0" clusterMaxTriangles="5632" clusterMaxExtent="54"
+    <Mesh file="assets/casa.obj" position="-40,0,-52" scale="7.9"
+          rotation="0,110,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
+          albedo="0.77,0.74,0.7" emission="0,0,0" materialType="0"
+          emissionPower="0" />
+
+    <Mesh file="assets/casa.obj" position="40,0,-50" scale="7.7"
+          rotation="0,148,0" clusterMaxTriangles="6144" clusterMaxExtent="48"
           albedo="0.81,0.78,0.74" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="32,0,34" scale="6.5"
-          rotation="0,30,0" clusterMaxTriangles="560" clusterMaxExtent="20"
+    <Mesh file="assets/Tree.obj" position="32,0,40" scale="6.6"
+          rotation="0,28,0" clusterMaxTriangles="600" clusterMaxExtent="22"
           albedo="0.88,0.9,0.84" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-32,0,32" scale="6.4"
-          rotation="0,-44,0" clusterMaxTriangles="560" clusterMaxExtent="20"
+    <Mesh file="assets/Tree.obj" position="-34,0,42" scale="6.7"
+          rotation="0,-40,0" clusterMaxTriangles="600" clusterMaxExtent="22"
           albedo="0.86,0.9,0.88" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="-30,0,-36" scale="6.3"
-          rotation="0,118,0" clusterMaxTriangles="560" clusterMaxExtent="20"
+    <Mesh file="assets/Tree.obj" position="-32,0,-40" scale="6.5"
+          rotation="0,120,0" clusterMaxTriangles="600" clusterMaxExtent="22"
           albedo="0.9,0.88,0.86" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
-    <Mesh file="assets/Tree.obj" position="30,0,-32" scale="6.2"
-          rotation="0,146,0" clusterMaxTriangles="560" clusterMaxExtent="20"
+    <Mesh file="assets/Tree.obj" position="30,0,-38" scale="6.4"
+          rotation="0,152,0" clusterMaxTriangles="600" clusterMaxExtent="22"
           albedo="0.88,0.86,0.9" emission="0,0,0" materialType="0"
           emissionPower="0" />
 
@@ -152,30 +158,5 @@
       rotation="0,-30,0" clusterMaxTriangles="384" clusterMaxExtent="6"
       albedo="0.55,0.82,0.92" emission="0,0,0"
       materialType="0" roughness="0.18" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="-8.5,0.1,11.0" scale="1.0"
-      rotation="0,20,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.12" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="2.5,0.1,-2.0" scale="0.8"
-      rotation="0,-10,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.16" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="-1.5,0.1,-4.5" scale="0.82"
-      rotation="0,15,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.14" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="6.0,0.1,-8.0" scale="0.88"
-      rotation="0,45,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.2" emissionPower="0" />
-
-<Mesh file="assets/bunny.obj" position="-6.0,0.1,-7.0" scale="0.86"
-      rotation="0,-35,0" clusterMaxTriangles="384" clusterMaxExtent="6"
-      albedo="0.55,0.82,0.92" emission="0,0,0"
-      materialType="0" roughness="0.22" emissionPower="0" />
 
 </Scene>


### PR DESCRIPTION
## Summary
- realign the camera path, lighting and geometry placements in the Casa cinematic scene variants to match the always-resident baseline layout
- retain each residency strategy's configuration while adding a note that the layout mirrors the baseline for SSIM comparisons

## Testing
- not run (data files only)


------
https://chatgpt.com/codex/tasks/task_e_69014a53ad84832da8284eef440d55d3