### PR TITLE
Wait for pending command buffer completion before releasing

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -80,7 +80,22 @@ TaskLimiter &sceneBvhTaskLimiter() {
 namespace MetalCppPathTracer {
 
 void ResidentObjectGpuResources::clearPendingCommand() {
-  if (pendingCommand) {
+  if (!pendingCommand)
+    return;
+
+  using Status = MTL::CommandBufferStatus;
+  auto status = pendingCommand->status();
+
+  if (status == Status::CommandBufferStatusNotEnqueued ||
+      status == Status::CommandBufferStatusEnqueued ||
+      status == Status::CommandBufferStatusCommitted ||
+      status == Status::CommandBufferStatusScheduled) {
+    pendingCommand->waitUntilCompleted();
+    status = pendingCommand->status();
+  }
+
+  if (status == Status::CommandBufferStatusCompleted ||
+      status == Status::CommandBufferStatusError) {
     pendingCommand->release();
     pendingCommand = nullptr;
   }


### PR DESCRIPTION
## Summary
- wait for resident object command buffers to finish execution before releasing the pending reference

## Testing
- not run (Metal runtime unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_69016e7efb88832db0c0f1af801702ab