### PR TITLE
Reduce TLAS scratch buffer after rebuilds

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -892,6 +892,8 @@ Renderer::~Renderer() {
   _tlasDescriptorStagingCapacity = 0;
   _pTlasScratchBuffer = nullptr;
   _tlasScratchCapacity = 0;
+  _tlasScratchTracker.reset();
+  updateTlasScratchResidentBytes(0);
   _pTlasBuildEvent = nullptr;
   _tlasBuildEventValue = 0;
   _tlasCompletedEventValue.store(0, std::memory_order_relaxed);
@@ -2982,6 +2984,53 @@ void Renderer::waitForPendingTlasBuild() {
   if (latest < targetValue)
     latest = targetValue;
   _tlasCompletedEventValue.store(latest, std::memory_order_release);
+
+  finalizePendingTlasScratchResize(true);
+}
+
+void Renderer::finalizePendingTlasScratchResize(bool force) {
+  if (!_tlasScratchTracker.hasPendingResize())
+    return;
+
+  bool ready = force;
+  if (!ready) {
+    uint64_t completed = _tlasCompletedEventValue.load(std::memory_order_acquire);
+    ready = _tlasScratchTracker.ready(completed);
+  }
+
+  if (!ready)
+    return;
+
+  size_t previousCapacity = static_cast<size_t>(_tlasScratchCapacity);
+  size_t desiredSize = _tlasScratchTracker.targetRefitSize();
+  size_t retiredBytes = _tlasScratchTracker.retiredBytes();
+
+  if (_pTlasScratchBuffer) {
+    _pTlasScratchBuffer->release();
+    _pTlasScratchBuffer = nullptr;
+    _tlasScratchCapacity = 0;
+  }
+
+  if (desiredSize > 0 && _pDevice) {
+    _pTlasScratchBuffer = _pDevice->newBuffer(
+        static_cast<NS::UInteger>(desiredSize), MTL::ResourceStorageModePrivate);
+    _tlasScratchCapacity =
+        _pTlasScratchBuffer ? static_cast<NS::UInteger>(desiredSize)
+                            : static_cast<NS::UInteger>(0);
+  }
+
+  _tlasScratchTracker.noteAllocation(_tlasScratchCapacity);
+  _tlasScratchTracker.finalizeResize();
+  updateTlasScratchResidentBytes(_tlasScratchCapacity);
+
+  if (retiredBytes > 0) {
+    std::printf("[TLAS] Shrunk scratch buffer from %zu to %zu bytes (retired %zu bytes).\n",
+                previousCapacity, static_cast<size_t>(_tlasScratchCapacity), retiredBytes);
+  }
+}
+
+void Renderer::updateTlasScratchResidentBytes(NS::UInteger bytes) {
+  _tlasScratchResidentBytes = static_cast<size_t>(bytes);
 }
 
 void Renderer::updateTopLevelAccelerationStructure(
@@ -2989,6 +3038,8 @@ void Renderer::updateTopLevelAccelerationStructure(
     const std::vector<MTL::AccelerationStructure *> &structures) {
   if (!_pDevice || !_pCommandQueue)
     return;
+
+  finalizePendingTlasScratchResize();
 
   if (!ensureDummyBlas())
     return;
@@ -3129,6 +3180,9 @@ void Renderer::updateTopLevelAccelerationStructure(
 
   NS::UInteger scratchSize = needsRebuild ? sizes.buildScratchBufferSize
                                           : sizes.refitScratchBufferSize;
+  size_t buildScratchBytes = static_cast<size_t>(scratchSize);
+  size_t refitScratchBytes =
+      static_cast<size_t>(sizes.refitScratchBufferSize);
   MTL::Buffer *scratchBuffer = nullptr;
   if (scratchSize > 0) {
     if (!_pTlasScratchBuffer || _tlasScratchCapacity < scratchSize) {
@@ -3145,6 +3199,9 @@ void Renderer::updateTopLevelAccelerationStructure(
       return;
     }
   }
+
+  _tlasScratchTracker.noteAllocation(_tlasScratchCapacity);
+  updateTlasScratchResidentBytes(_tlasScratchCapacity);
 
   MTL::CommandBuffer *commandBuffer = _pCommandQueue->commandBuffer();
   if (!commandBuffer) {
@@ -3209,6 +3266,10 @@ void Renderer::updateTopLevelAccelerationStructure(
     commandBuffer->encodeSignalEvent(_pTlasBuildEvent, signalValue);
   }
 
+  if (needsRebuild)
+    _tlasScratchTracker.registerRebuild(signalValue, buildScratchBytes,
+                                        refitScratchBytes);
+
   if (signalValue > 0) {
     commandBuffer->addCompletedHandler(
         [this, signalValue](MTL::CommandBuffer *cmd) {
@@ -3224,6 +3285,7 @@ void Renderer::updateTopLevelAccelerationStructure(
     commandBuffer->waitUntilCompleted();
     _tlasCompletedEventValue.store(_tlasBuildEventValue,
                                    std::memory_order_release);
+    finalizePendingTlasScratchResize(true);
   }
 
   instanceDesc->release();

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -18,6 +18,7 @@
 
 #include "AlwaysResidentCache.h"
 #include "GpuHeapResources.h"
+#include "TlasScratchTracker.h"
 #include "Camera.h"
 #include "Scene.h"
 
@@ -170,6 +171,8 @@ private:
   void ensureTlasBuildEvent();
   void waitForPendingTlasBuild();
   bool hasPendingTlasBuild() const;
+  void finalizePendingTlasScratchResize(bool force = false);
+  void updateTlasScratchResidentBytes(NS::UInteger bytes);
   struct PendingBlasBuild;
   void enqueueBlasBuild(const std::shared_ptr<PendingBlasBuild> &buildRequest);
   void processBlasBuildQueue();
@@ -235,6 +238,8 @@ private:
   MTL::Buffer *_pFrustumVertexBuffer = nullptr;
   MTL::Buffer *_pTlasScratchBuffer = nullptr;
   NS::UInteger _tlasScratchCapacity = 0;
+  size_t _tlasScratchResidentBytes = 0;
+  TlasScratchTracker _tlasScratchTracker;
   size_t _blasNodeCount = 0;
   size_t _tlasNodeCount = 0;
   size_t _activeNodeCount = 0;

--- a/MetalCpp Path Tracer/Renderer/TlasScratchTracker.h
+++ b/MetalCpp Path Tracer/Renderer/TlasScratchTracker.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace MetalCppPathTracer {
+
+class TlasScratchTracker {
+public:
+  void reset() {
+    _currentCapacity = 0;
+    _pendingRefitSize = 0;
+    _pendingRetiredBytes = 0;
+    _pendingEventValue = 0;
+    _pendingResize = false;
+  }
+
+  void noteAllocation(std::size_t capacity) { _currentCapacity = capacity; }
+
+  void registerRebuild(uint64_t eventValue, std::size_t buildScratchSize,
+                       std::size_t refitScratchSize) {
+    if (refitScratchSize >= buildScratchSize) {
+      _pendingResize = false;
+      _pendingEventValue = eventValue;
+      _pendingRefitSize = refitScratchSize;
+      _pendingRetiredBytes = 0;
+      return;
+    }
+
+    _pendingResize = true;
+    _pendingEventValue = eventValue;
+    _pendingRefitSize = refitScratchSize;
+
+    std::size_t basis = _currentCapacity > 0 ? _currentCapacity : buildScratchSize;
+    if (basis > refitScratchSize)
+      _pendingRetiredBytes = basis - refitScratchSize;
+    else
+      _pendingRetiredBytes = buildScratchSize - refitScratchSize;
+  }
+
+  bool hasPendingResize() const { return _pendingResize; }
+
+  bool ready(uint64_t completedEventValue) const {
+    if (!_pendingResize)
+      return false;
+    if (_pendingEventValue == 0)
+      return true;
+    return completedEventValue >= _pendingEventValue;
+  }
+
+  std::size_t targetRefitSize() const { return _pendingRefitSize; }
+
+  std::size_t retiredBytes() const { return _pendingRetiredBytes; }
+
+  void finalizeResize() {
+    _pendingRefitSize = 0;
+    _pendingRetiredBytes = 0;
+    _pendingEventValue = 0;
+    _pendingResize = false;
+  }
+
+private:
+  std::size_t _currentCapacity = 0;
+  std::size_t _pendingRefitSize = 0;
+  std::size_t _pendingRetiredBytes = 0;
+  uint64_t _pendingEventValue = 0;
+  bool _pendingResize = false;
+};
+
+} // namespace MetalCppPathTracer
+

--- a/tests/TlasScratchTrackerTests.cpp
+++ b/tests/TlasScratchTrackerTests.cpp
@@ -1,0 +1,31 @@
+#include "MetalCpp Path Tracer/Renderer/TlasScratchTracker.h"
+
+#include <cassert>
+
+using MetalCppPathTracer::TlasScratchTracker;
+
+int main() {
+  TlasScratchTracker tracker;
+
+  tracker.noteAllocation(8192);
+  tracker.registerRebuild(5, 8192, 2048);
+  assert(tracker.hasPendingResize());
+  assert(!tracker.ready(4));
+  assert(tracker.ready(5));
+  assert(tracker.targetRefitSize() == 2048);
+  assert(tracker.retiredBytes() == 8192 - 2048);
+
+  tracker.noteAllocation(2048);
+  tracker.finalizeResize();
+  assert(!tracker.hasPendingResize());
+
+  tracker.registerRebuild(0, 2048, 2048);
+  assert(!tracker.hasPendingResize());
+
+  tracker.noteAllocation(0);
+  tracker.registerRebuild(7, 0, 0);
+  assert(!tracker.hasPendingResize());
+  assert(!tracker.ready(7));
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add a TLAS scratch tracker to monitor when a rebuild completes and a refit-sized scratch buffer is sufficient
- update the TLAS build path to shrink or release the scratch allocation once the rebuild fence signals and keep residency bytes in sync
- cover the new tracker logic with a lightweight unit test exercising the resize bookkeeping

## Testing
- `g++ -std=c++17 tests/IncrementalUpdateUtilsTests.cpp -I. -o /tmp/inc && /tmp/inc`
- `g++ -std=c++17 tests/AlwaysResidentCacheTests.cpp -I. -o /tmp/arc && /tmp/arc`
- `g++ -std=c++17 tests/TlasScratchTrackerTests.cpp -I. -o /tmp/tlas && /tmp/tlas`


------
https://chatgpt.com/codex/tasks/task_e_6901ce2acf04832d8d695d4014f66bde