### PR TITLE
Implement BLAS scratch buffer pool reuse and logging

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -201,8 +201,13 @@ void Renderer::PendingBlasBuild::releaseResources() {
     indexStaging = nullptr;
   }
   if (scratchBuffer) {
-    scratchBuffer->release();
+    if (renderer) {
+      renderer->recycleBlasScratchBuffer(scratchBuffer, scratchSize);
+    } else {
+      scratchBuffer->release();
+    }
     scratchBuffer = nullptr;
+    scratchSize = 0;
   }
   if (geometryArray) {
     geometryArray->release();
@@ -218,6 +223,113 @@ void Renderer::PendingBlasBuild::releaseResources() {
   }
   accelerationStructure = nullptr;
   commandBuffer = nullptr;
+}
+
+MTL::Buffer *Renderer::acquireBlasScratchBuffer(NS::UInteger requestedSize,
+                                                NS::UInteger &allocatedSize,
+                                                bool &reused) {
+  allocatedSize = requestedSize;
+  reused = false;
+  if (!_pDevice || requestedSize == 0)
+    return nullptr;
+
+  auto it = _blasScratchPool.lower_bound(requestedSize);
+  while (it != _blasScratchPool.end()) {
+    auto &bucket = it->second;
+    if (!bucket.empty()) {
+      auto *buffer = bucket.back();
+      bucket.pop_back();
+      NS::UInteger bucketSize = it->first;
+      if (bucket.empty())
+        _blasScratchPool.erase(it);
+      allocatedSize = bucketSize;
+      reused = true;
+      if (_blasScratchPoolAvailableBytes >= bucketSize)
+        _blasScratchPoolAvailableBytes -= bucketSize;
+      else
+        _blasScratchPoolAvailableBytes = 0;
+      _blasScratchPoolInUseBytes += bucketSize;
+      ++_blasScratchPoolReusedCount;
+      std::printf(
+          "[BLAS] Reusing scratch buffer (%llu bytes, requested %llu). Pool "
+          "in-flight: %zu bytes, available: %zu bytes. (created=%zu, reused=%zu)\n",
+          static_cast<unsigned long long>(bucketSize),
+          static_cast<unsigned long long>(requestedSize),
+          _blasScratchPoolInUseBytes, _blasScratchPoolAvailableBytes,
+          _blasScratchPoolCreatedCount, _blasScratchPoolReusedCount);
+      return buffer;
+    }
+    it = _blasScratchPool.erase(it);
+  }
+
+  auto *buffer = _pDevice->newBuffer(requestedSize,
+                                     MTL::ResourceStorageModePrivate);
+  if (buffer) {
+    allocatedSize = requestedSize;
+    _blasScratchPoolInUseBytes += requestedSize;
+    ++_blasScratchPoolCreatedCount;
+    std::printf(
+        "[BLAS] Allocated scratch buffer (%llu bytes). Pool in-flight: %zu "
+        "bytes, available: %zu bytes. (created=%zu, reused=%zu)\n",
+        static_cast<unsigned long long>(requestedSize),
+        _blasScratchPoolInUseBytes, _blasScratchPoolAvailableBytes,
+        _blasScratchPoolCreatedCount, _blasScratchPoolReusedCount);
+  }
+  return buffer;
+}
+
+void Renderer::recycleBlasScratchBuffer(MTL::Buffer *buffer, NS::UInteger size) {
+  if (!buffer)
+    return;
+
+  if (size == 0) {
+    buffer->release();
+    return;
+  }
+
+  if (_blasScratchPoolInUseBytes >= size)
+    _blasScratchPoolInUseBytes -= size;
+  else
+    _blasScratchPoolInUseBytes = 0;
+
+  _blasScratchPoolAvailableBytes += size;
+  _blasScratchPool[size].push_back(buffer);
+
+  std::printf(
+      "[BLAS] Recycled scratch buffer (%llu bytes). Pool in-flight: %zu bytes, "
+      "available: %zu bytes. (created=%zu, reused=%zu)\n",
+      static_cast<unsigned long long>(size), _blasScratchPoolInUseBytes,
+      _blasScratchPoolAvailableBytes, _blasScratchPoolCreatedCount,
+      _blasScratchPoolReusedCount);
+}
+
+void Renderer::releaseBlasScratchPool() {
+  if (!_blasScratchPool.empty() || _blasScratchPoolInUseBytes != 0 ||
+      _blasScratchPoolCreatedCount != 0 || _blasScratchPoolReusedCount != 0) {
+    std::printf(
+        "[BLAS] Releasing scratch pool (available=%zu bytes, in-flight=%zu "
+        "bytes, created=%zu, reused=%zu).\n",
+        _blasScratchPoolAvailableBytes, _blasScratchPoolInUseBytes,
+        _blasScratchPoolCreatedCount, _blasScratchPoolReusedCount);
+  }
+
+  for (auto &entry : _blasScratchPool) {
+    for (auto *buffer : entry.second) {
+      if (buffer)
+        buffer->release();
+    }
+  }
+
+  _blasScratchPool.clear();
+  _blasScratchPoolAvailableBytes = 0;
+
+  if (_blasScratchPoolInUseBytes != 0) {
+    std::printf(
+        "[BLAS] Warning: scratch pool destroyed with %zu bytes still in "
+        "flight.\n",
+        _blasScratchPoolInUseBytes);
+    _blasScratchPoolInUseBytes = 0;
+  }
 }
 
 struct UniformsData {
@@ -936,6 +1048,8 @@ Renderer::~Renderer() {
     resident.resources.destroy();
   }
   _residentObjectGpuResources.clear();
+
+  releaseBlasScratchPool();
 
   if (_pPSO)
     _pPSO->release();
@@ -2490,16 +2604,40 @@ bool Renderer::startBlasBuild(
     return false;
   }
 
-  NS::UInteger scratchSize = sizes.buildScratchBufferSize;
+  NS::UInteger requestedScratchSize = sizes.buildScratchBufferSize;
   MTL::Buffer *scratchBuffer = nullptr;
-  if (scratchSize > 0)
-    scratchBuffer =
-        _pDevice->newBuffer(scratchSize, MTL::ResourceStorageModePrivate);
+  buildRequest->scratchBuffer = nullptr;
+  buildRequest->scratchSize = 0;
+  if (requestedScratchSize > 0) {
+    bool scratchReused = false;
+    NS::UInteger allocatedScratchSize = requestedScratchSize;
+    scratchBuffer = acquireBlasScratchBuffer(requestedScratchSize,
+                                            allocatedScratchSize,
+                                            scratchReused);
+    if (!scratchBuffer) {
+      if (indexStaging)
+        indexStaging->release();
+      if (vertexStaging)
+        vertexStaging->release();
+      geometryArray->release();
+      geometryDesc->release();
+      accelDesc->release();
+      cleanupPool();
+      return false;
+    }
+
+    buildRequest->scratchBuffer = scratchBuffer;
+    buildRequest->scratchSize = allocatedScratchSize;
+    (void)scratchReused;
+  }
 
   auto commandBuffer = _pCommandQueue->commandBuffer();
   if (!commandBuffer) {
-    if (scratchBuffer)
-      scratchBuffer->release();
+    if (scratchBuffer) {
+      recycleBlasScratchBuffer(scratchBuffer, buildRequest->scratchSize);
+      buildRequest->scratchBuffer = nullptr;
+      buildRequest->scratchSize = 0;
+    }
     if (indexStaging)
       indexStaging->release();
     if (vertexStaging)
@@ -2530,8 +2668,11 @@ bool Renderer::startBlasBuild(
 
   auto asEncoder = commandBuffer->accelerationStructureCommandEncoder();
   if (!asEncoder) {
-    if (scratchBuffer)
-      scratchBuffer->release();
+    if (scratchBuffer) {
+      recycleBlasScratchBuffer(scratchBuffer, buildRequest->scratchSize);
+      buildRequest->scratchBuffer = nullptr;
+      buildRequest->scratchSize = 0;
+    }
     if (indexStaging)
       indexStaging->release();
     if (vertexStaging)
@@ -2607,6 +2748,13 @@ void Renderer::handleCompletedBlasBuild(
   }
 
   buildRequest->releaseResources();
+
+  std::printf(
+      "[BLAS] Build %s for object %zu complete. Scratch pool in-flight=%zu "
+      "bytes, available=%zu bytes (created=%zu, reused=%zu).\n",
+      success ? "succeeded" : "failed", buildRequest->objectIndex,
+      _blasScratchPoolInUseBytes, _blasScratchPoolAvailableBytes,
+      _blasScratchPoolCreatedCount, _blasScratchPoolReusedCount);
 
   auto it = std::find(_activeBlasBuilds.begin(), _activeBlasBuilds.end(),
                       buildRequest);

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -10,6 +10,7 @@
 #include <deque>
 #include <fstream>
 #include <functional>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <simd/simd.h>
@@ -202,7 +203,12 @@ private:
   std::array<simd::float3, 8>
   buildFrustumCorners(const Camera::State &state, float nearDistance,
                       float farDistance) const;
-
+  MTL::Buffer *acquireBlasScratchBuffer(NS::UInteger requestedSize,
+                                       NS::UInteger &allocatedSize,
+                                       bool &reused);
+  void recycleBlasScratchBuffer(MTL::Buffer *buffer, NS::UInteger size);
+  void releaseBlasScratchPool();
+  
   MTL::Device *_pDevice = nullptr;
   MTL::CommandQueue *_pCommandQueue = nullptr;
   MTL::RenderPipelineState *_pPSO = nullptr;
@@ -282,6 +288,7 @@ private:
     MTL::Buffer *vertexStaging = nullptr;
     MTL::Buffer *indexStaging = nullptr;
     MTL::Buffer *scratchBuffer = nullptr;
+    NS::UInteger scratchSize = 0;
     MTL::CommandBuffer *commandBuffer = nullptr;
 
     void releaseResources();
@@ -290,6 +297,11 @@ private:
   static constexpr size_t kMaxBlasBuildsInFlight = 3;
   std::deque<std::shared_ptr<PendingBlasBuild>> _pendingBlasBuilds;
   std::deque<std::shared_ptr<PendingBlasBuild>> _activeBlasBuilds;
+  std::map<NS::UInteger, std::vector<MTL::Buffer *>> _blasScratchPool;
+  size_t _blasScratchPoolAvailableBytes = 0;
+  size_t _blasScratchPoolInUseBytes = 0;
+  size_t _blasScratchPoolCreatedCount = 0;
+  size_t _blasScratchPoolReusedCount = 0;
 
   struct BenchmarkSample {
     size_t frameIndex = 0;


### PR DESCRIPTION
## Summary
- add a size-keyed scratch buffer freelist for BLAS builds and track pool metrics
- use the pool when constructing command buffers and recycle allocations on completion
- emit logging on allocation, reuse, recycling, and teardown to monitor for leaks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6901d2248514832dae346895677716c3