### PR TITLE
Throttle BLAS build concurrency under GPU memory pressure

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -2409,8 +2409,11 @@ void Renderer::processBlasBuildQueue() {
   if (!_pDevice || !_pCommandQueue)
     return;
 
+  adjustBlasBuildLimitForMemory();
+  size_t maxInFlight = std::max<size_t>(_currentBlasBuildLimit, size_t(1));
+
   while (!_pendingBlasBuilds.empty() &&
-         _activeBlasBuilds.size() < kMaxBlasBuildsInFlight) {
+         _activeBlasBuilds.size() < maxInFlight) {
     auto buildRequest = _pendingBlasBuilds.front();
     if (!startBlasBuild(buildRequest)) {
       _pendingBlasBuilds.pop_front();
@@ -2425,6 +2428,35 @@ void Renderer::processBlasBuildQueue() {
 
     _pendingBlasBuilds.pop_front();
     _activeBlasBuilds.push_back(buildRequest);
+  }
+}
+
+void Renderer::adjustBlasBuildLimitForMemory() {
+  double cap = _textureResidencyMemoryCapMB;
+  if (cap <= 0.0) {
+    if (_currentBlasBuildLimit != kMaxBlasBuildsInFlight)
+      _currentBlasBuildLimit = kMaxBlasBuildsInFlight;
+    return;
+  }
+
+  double usage = currentGPUMemoryMB();
+  double highWatermark = cap * kBlasMemoryPressureRatio;
+  double lowWatermark = cap * kBlasMemoryRecoveryRatio;
+
+  size_t desiredLimit = _currentBlasBuildLimit;
+  if (usage >= highWatermark)
+    desiredLimit = 1;
+  else if (usage <= lowWatermark)
+    desiredLimit = kMaxBlasBuildsInFlight;
+
+  desiredLimit = std::max<size_t>(desiredLimit, size_t(1));
+
+  if (desiredLimit != _currentBlasBuildLimit) {
+    std::printf(
+        "[BLAS] GPU memory %.1f MB (cap %.1f MB): adjusting in-flight build "
+        "limit to %zu\n",
+        usage, cap, desiredLimit);
+    _currentBlasBuildLimit = desiredLimit;
   }
 }
 

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -177,6 +177,7 @@ private:
   struct PendingBlasBuild;
   void enqueueBlasBuild(const std::shared_ptr<PendingBlasBuild> &buildRequest);
   void processBlasBuildQueue();
+  void adjustBlasBuildLimitForMemory();
   bool startBlasBuild(const std::shared_ptr<PendingBlasBuild> &buildRequest);
   void handleCompletedBlasBuild(
       const std::shared_ptr<PendingBlasBuild> &buildRequest, bool success);
@@ -295,6 +296,8 @@ private:
   };
 
   static constexpr size_t kMaxBlasBuildsInFlight = 3;
+  static constexpr double kBlasMemoryPressureRatio = 0.95;
+  static constexpr double kBlasMemoryRecoveryRatio = 0.85;
   std::deque<std::shared_ptr<PendingBlasBuild>> _pendingBlasBuilds;
   std::deque<std::shared_ptr<PendingBlasBuild>> _activeBlasBuilds;
   std::map<NS::UInteger, std::vector<MTL::Buffer *>> _blasScratchPool;
@@ -302,6 +305,7 @@ private:
   size_t _blasScratchPoolInUseBytes = 0;
   size_t _blasScratchPoolCreatedCount = 0;
   size_t _blasScratchPoolReusedCount = 0;
+  size_t _currentBlasBuildLimit = kMaxBlasBuildsInFlight;
 
   struct BenchmarkSample {
     size_t frameIndex = 0;


### PR DESCRIPTION
## Summary
- monitor GPU memory usage when scheduling BLAS builds
- dynamically clamp the number of in-flight BLAS builds under memory pressure and restore capacity when usage drops
- add logging so memory-driven throttling is visible during residency scheduling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901d4d01d94832d8a24710e2081eb78