### PR TITLE
Adjust residency memory accounting for scratch buffers

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -257,6 +257,7 @@ MTL::Buffer *Renderer::acquireBlasScratchBuffer(NS::UInteger requestedSize,
           static_cast<unsigned long long>(requestedSize),
           _blasScratchPoolInUseBytes, _blasScratchPoolAvailableBytes,
           _blasScratchPoolCreatedCount, _blasScratchPoolReusedCount);
+      updateBlasScratchResidencyBudget();
       return buffer;
     }
     it = _blasScratchPool.erase(it);
@@ -275,6 +276,7 @@ MTL::Buffer *Renderer::acquireBlasScratchBuffer(NS::UInteger requestedSize,
         _blasScratchPoolInUseBytes, _blasScratchPoolAvailableBytes,
         _blasScratchPoolCreatedCount, _blasScratchPoolReusedCount);
   }
+  updateBlasScratchResidencyBudget();
   return buffer;
 }
 
@@ -294,6 +296,8 @@ void Renderer::recycleBlasScratchBuffer(MTL::Buffer *buffer, NS::UInteger size) 
 
   _blasScratchPoolAvailableBytes += size;
   _blasScratchPool[size].push_back(buffer);
+
+  updateBlasScratchResidencyBudget();
 
   std::printf(
       "[BLAS] Recycled scratch buffer (%llu bytes). Pool in-flight: %zu bytes, "
@@ -330,6 +334,22 @@ void Renderer::releaseBlasScratchPool() {
         _blasScratchPoolInUseBytes);
     _blasScratchPoolInUseBytes = 0;
   }
+
+  updateBlasScratchResidencyBudget();
+}
+
+void Renderer::updateBlasScratchResidencyBudget() {
+  _residencyBudget.setBlasScratchBytes(_blasScratchPoolAvailableBytes,
+                                       _blasScratchPoolInUseBytes);
+}
+
+double Renderer::scratchMemoryMB() const {
+  return _residencyBudget.scratchMemoryMB();
+}
+
+double Renderer::residencyMemoryMB() const {
+  double totalMB = currentGPUMemoryMB();
+  return _residencyBudget.residencyMemoryMB(totalMB);
 }
 
 struct UniformsData {
@@ -1166,7 +1186,8 @@ void Renderer::writeBenchmarkHeader() {
          "object_deactivations,active_primitives,resident_primitives,total_primitives,"
          "active_triangles,resident_triangles,total_triangles,active_nodes,"
          "resident_nodes,total_nodes,active_objects,resident_objects,gpu_memory_mb,"
-         "texture_memory_cap_mb,over_memory_cap,residency_compacted,"
+         "scratch_memory_mb,residency_memory_mb,texture_memory_cap_mb,"
+         "over_memory_cap,residency_compacted,"
          "accumulation_reset,ray_hit_decay,state_cooldown_frames,lod_toggle_budget,"
          "energy_toggle_budget,screen_toggle_budget,rayhit_toggle_budget,"
          "rayhit_target_fraction,rayhit_min_active,rayhit_rebuild_cooldown,"
@@ -1207,6 +1228,8 @@ void Renderer::writeBenchmarkRow(const BenchmarkSample &sample) {
       << sample.totalNodeCount << ',' << sample.activeObjectCount << ','
       << sample.residentObjectCount << ','
       << formatFixed(sample.gpuMemoryMB, 3) << ','
+      << formatFixed(sample.scratchMemoryMB, 3) << ','
+      << formatFixed(sample.residencyMemoryMB, 3) << ','
       << formatFixed(sample.textureMemoryCapMB, 3) << ','
       << boolToInt(sample.overMemoryCap) << ','
       << boolToInt(sample.residentCompacted) << ','
@@ -3179,6 +3202,7 @@ void Renderer::finalizePendingTlasScratchResize(bool force) {
 
 void Renderer::updateTlasScratchResidentBytes(NS::UInteger bytes) {
   _tlasScratchResidentBytes = static_cast<size_t>(bytes);
+  _residencyBudget.setTlasScratchBytes(_tlasScratchResidentBytes);
 }
 
 void Renderer::updateTopLevelAccelerationStructure(
@@ -4975,9 +4999,25 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
     return;
 
   bool belowBudget = _residentPrimitiveCount < kTextureResidencyPrimitiveBudget;
-  bool overMemory = currentGPUMemoryMB() > _textureResidencyMemoryCapMB;
+  double totalMemoryMB = currentGPUMemoryMB();
+  double scratchMB = scratchMemoryMB();
+  double residencyMB = std::max(0.0, totalMemoryMB - scratchMB);
+  bool overMemory = residencyMB > _textureResidencyMemoryCapMB;
+
+  if (!overMemory && totalMemoryMB > _textureResidencyMemoryCapMB &&
+      scratchMB > 0.0) {
+    std::printf("[TextureResidency] Skipping eviction: total=%.2f MB, scratch=%.2f MB, "
+                "residency=%.2f MB (cap=%.2f MB).\n",
+                totalMemoryMB, scratchMB, residencyMB, _textureResidencyMemoryCapMB);
+  }
   if (!belowBudget && !overMemory)
     return;
+
+  if (overMemory) {
+    std::printf("[TextureResidency] Triggering eviction: residency=%.2f MB (total=%.2f MB, "
+                "scratch=%.2f MB, cap=%.2f MB).\n",
+                residencyMB, totalMemoryMB, scratchMB, _textureResidencyMemoryCapMB);
+  }
 
   std::array<ManagedTextureSlot *, 6> slots = {
       &_accumulationSlots[0], &_accumulationSlots[1], &_sampleCountSlot,
@@ -5449,8 +5489,8 @@ void Renderer::draw(MTK::View *pView) {
 
   bool belowBudget =
       _residentPrimitiveCount < kTextureResidencyPrimitiveBudget;
-  double currentMemory = currentGPUMemoryMB();
-  bool overCap = currentMemory > _textureResidencyMemoryCapMB;
+  double contentMemory = residencyMemoryMB();
+  bool overCap = contentMemory > _textureResidencyMemoryCapMB;
 
   if (!_needsAccumulationReset && (belowBudget || overCap))
     updateTextureResidency(prepCmd);
@@ -7590,6 +7630,9 @@ void Renderer::beginFrameMetrics() {
         ++residentObjects;
     sample.residentObjectCount = residentObjects;
     sample.gpuMemoryMB = currentGPUMemoryMB();
+    sample.scratchMemoryMB = scratchMemoryMB();
+    sample.residencyMemoryMB =
+        std::max(0.0, sample.gpuMemoryMB - sample.scratchMemoryMB);
     sample.textureMemoryCapMB = _textureResidencyMemoryCapMB;
     sample.deltaTimeSeconds = _deltaTimeSeconds;
     sample.wallSeconds = std::chrono::duration<double>(
@@ -7601,7 +7644,8 @@ void Renderer::beginFrameMetrics() {
     sample.maxSamplesPerPixel = _maxSamplesPerPixel;
     sample.accumulationReset = _needsAccumulationReset;
     sample.residentCompacted = _residentCompacted;
-    sample.overMemoryCap = sample.gpuMemoryMB > _textureResidencyMemoryCapMB;
+    sample.overMemoryCap =
+        sample.residencyMemoryMB > _textureResidencyMemoryCapMB;
     _pendingBenchmarkSamples.push_back(std::move(sample));
   }
 }

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -19,6 +19,7 @@
 
 #include "AlwaysResidentCache.h"
 #include "GpuHeapResources.h"
+#include "ResidencyBudget.h"
 #include "TlasScratchTracker.h"
 #include "Camera.h"
 #include "Scene.h"
@@ -208,6 +209,9 @@ private:
                                        bool &reused);
   void recycleBlasScratchBuffer(MTL::Buffer *buffer, NS::UInteger size);
   void releaseBlasScratchPool();
+  void updateBlasScratchResidencyBudget();
+  double scratchMemoryMB() const;
+  double residencyMemoryMB() const;
   
   MTL::Device *_pDevice = nullptr;
   MTL::CommandQueue *_pCommandQueue = nullptr;
@@ -246,6 +250,7 @@ private:
   NS::UInteger _tlasScratchCapacity = 0;
   size_t _tlasScratchResidentBytes = 0;
   TlasScratchTracker _tlasScratchTracker;
+  ResidencyBudget _residencyBudget;
   size_t _blasNodeCount = 0;
   size_t _tlasNodeCount = 0;
   size_t _activeNodeCount = 0;
@@ -322,6 +327,8 @@ private:
     size_t activeObjectCount = 0;
     size_t residentObjectCount = 0;
     double gpuMemoryMB = 0.0;
+    double scratchMemoryMB = 0.0;
+    double residencyMemoryMB = 0.0;
     double textureMemoryCapMB = 0.0;
     double deltaTimeSeconds = 0.0;
     double wallSeconds = 0.0;

--- a/MetalCpp Path Tracer/Renderer/ResidencyBudget.h
+++ b/MetalCpp Path Tracer/Renderer/ResidencyBudget.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstddef>
+
+namespace MetalCppPathTracer {
+
+class ResidencyBudget {
+public:
+  void setTlasScratchBytes(std::size_t bytes) { _tlasScratchBytes = bytes; }
+
+  void setBlasScratchBytes(std::size_t availableBytes, std::size_t inUseBytes) {
+    _blasScratchAvailableBytes = availableBytes;
+    _blasScratchInUseBytes = inUseBytes;
+  }
+
+  std::size_t totalScratchBytes() const {
+    return _tlasScratchBytes + _blasScratchAvailableBytes + _blasScratchInUseBytes;
+  }
+
+  double scratchMemoryMB() const { return bytesToMB(totalScratchBytes()); }
+
+  double residencyMemoryMB(double totalMemoryMB) const {
+    double adjusted = totalMemoryMB - scratchMemoryMB();
+    return adjusted > 0.0 ? adjusted : 0.0;
+  }
+
+private:
+  static double bytesToMB(std::size_t bytes) {
+    constexpr double kBytesPerMB = 1024.0 * 1024.0;
+    return static_cast<double>(bytes) / kBytesPerMB;
+  }
+
+  std::size_t _tlasScratchBytes = 0;
+  std::size_t _blasScratchAvailableBytes = 0;
+  std::size_t _blasScratchInUseBytes = 0;
+};
+
+} // namespace MetalCppPathTracer
+

--- a/tests/ResidencyBudgetTests.cpp
+++ b/tests/ResidencyBudgetTests.cpp
@@ -1,0 +1,39 @@
+#include "MetalCpp Path Tracer/Renderer/ResidencyBudget.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+
+using MetalCppPathTracer::ResidencyBudget;
+
+int main() {
+  ResidencyBudget budget;
+
+  assert(budget.totalScratchBytes() == 0);
+  assert(budget.scratchMemoryMB() == 0.0);
+  assert(budget.residencyMemoryMB(5.0) == 5.0);
+
+  const std::size_t tlasBytes = 2 * 1024 * 1024;
+  const std::size_t blasAvailable = 1 * 1024 * 1024;
+  const std::size_t blasInUse = 512 * 1024;
+
+  budget.setTlasScratchBytes(tlasBytes);
+  budget.setBlasScratchBytes(blasAvailable, blasInUse);
+
+  double scratchMB = budget.scratchMemoryMB();
+  assert(std::abs(scratchMB - 3.5) < 1e-6);
+
+  double adjusted = budget.residencyMemoryMB(10.0);
+  assert(std::abs(adjusted - 6.5) < 1e-6);
+
+  double clamped = budget.residencyMemoryMB(2.0);
+  assert(clamped == 0.0);
+
+  budget.setBlasScratchBytes(0, 0);
+  budget.setTlasScratchBytes(0);
+  assert(budget.totalScratchBytes() == 0);
+  assert(budget.residencyMemoryMB(1.0) == 1.0);
+
+  return 0;
+}
+


### PR DESCRIPTION
## Summary
- add a ResidencyBudget helper to track TLAS/BLAS scratch allocation totals
- subtract scratch usage from residency memory decisions, benchmarks, and add logs clarifying when scratch spikes are ignored
- add a ResidencyBudget unit test to verify the adjusted accounting logic

## Testing
- g++ -std=c++17 -I"." tests/ResidencyBudgetTests.cpp -o /tmp/residency_budget_test
- /tmp/residency_budget_test


------
https://chatgpt.com/codex/tasks/task_e_6901d69f339c832dadf3a0da6b70416a