### PR TITLE
Defer BLAS eviction until TLAS completion

### DIFF
--- a/MetalCpp Path Tracer/Renderer/DeferredPurgeQueue.h
+++ b/MetalCpp Path Tracer/Renderer/DeferredPurgeQueue.h
@@ -1,0 +1,112 @@
+#ifndef DEFERRED_PURGE_QUEUE_H
+#define DEFERRED_PURGE_QUEUE_H
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <utility>
+#include <vector>
+
+// A small helper for deferring resource purges until an associated command
+// buffer completes.  The queue tracks which resource should be released once
+// the GPU command finishes and takes care of retaining/releasing the command
+// buffer while it is referenced by queued entries.
+template <typename ResourceT, typename CommandBufferT>
+class DeferredPurgeQueue {
+public:
+  using ResourceType = ResourceT;
+  using CommandType = CommandBufferT;
+  using RetainFn = std::function<void(CommandType *)>;
+  using ReleaseFn = std::function<void(CommandType *)>;
+  using PurgeFn = std::function<void(ResourceType &, size_t)>;
+
+  DeferredPurgeQueue(RetainFn retain = RetainFn(),
+                     ReleaseFn release = ReleaseFn())
+      : _retain(std::move(retain)), _release(std::move(release)) {}
+
+  void enqueue(size_t objectIndex, ResourceType &resource) {
+    auto it = std::find_if(_entries.begin(), _entries.end(),
+                           [&](const Entry &entry) {
+                             return entry.objectIndex == objectIndex &&
+                                    entry.resource == &resource;
+                           });
+    if (it == _entries.end())
+      _entries.push_back({objectIndex, &resource, nullptr});
+  }
+
+  bool cancel(size_t objectIndex, ResourceType &resource) {
+    auto it = std::find_if(_entries.begin(), _entries.end(),
+                           [&](const Entry &entry) {
+                             return entry.objectIndex == objectIndex &&
+                                    entry.resource == &resource;
+                           });
+    if (it == _entries.end())
+      return false;
+    if (it->command && _release)
+      _release(it->command);
+    _entries.erase(it);
+    return true;
+  }
+
+  void assign(CommandType *command) {
+    if (!command)
+      return;
+    for (auto &entry : _entries) {
+      if (entry.command)
+        continue;
+      if (_retain)
+        _retain(command);
+      entry.command = command;
+    }
+  }
+
+  void complete(CommandType *command, bool success, PurgeFn purge) {
+    if (!command)
+      return;
+    auto it = _entries.begin();
+    while (it != _entries.end()) {
+      Entry &entry = *it;
+      if (entry.command != command) {
+        ++it;
+        continue;
+      }
+
+      if (entry.command && _release)
+        _release(entry.command);
+
+      if (success) {
+        if (purge)
+          purge(*entry.resource, entry.objectIndex);
+        it = _entries.erase(it);
+      } else {
+        entry.command = nullptr;
+        ++it;
+      }
+    }
+  }
+
+  void clear() {
+    if (_release) {
+      for (auto &entry : _entries) {
+        if (entry.command)
+          _release(entry.command);
+      }
+    }
+    _entries.clear();
+  }
+
+  bool empty() const { return _entries.empty(); }
+
+private:
+  struct Entry {
+    size_t objectIndex = 0;
+    ResourceType *resource = nullptr;
+    CommandType *command = nullptr;
+  };
+
+  std::vector<Entry> _entries;
+  RetainFn _retain;
+  ReleaseFn _release;
+};
+
+#endif // DEFERRED_PURGE_QUEUE_H

--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -134,6 +134,8 @@ void ResidentObjectGpuResources::transitionToCold(
 bool ResidentObjectGpuResources::ensureResident(
     Renderer &renderer, size_t objectIndex, const SceneObject &object,
     BlasInstanceRecord &instanceRecord, bool forceRebuild) {
+  renderer.cancelPendingResidentEviction(objectIndex, *this);
+
   if (isResident() && !forceRebuild) {
     lastStateChange = std::chrono::steady_clock::now();
     return true;
@@ -143,7 +145,7 @@ bool ResidentObjectGpuResources::ensureResident(
   geometryValid = false;
   bool built = renderer.buildObjectBlas(objectIndex, object, *this);
   if (!built) {
-    renderer.transitionResidentToCold(*this, instanceRecord);
+    renderer.transitionResidentToCold(objectIndex, *this, instanceRecord);
     return false;
   }
   return true;
@@ -959,7 +961,16 @@ bool Renderer::isInView(const BoundingSphere &b) {
 }
 
 Renderer::Renderer(MTL::Device *pDevice)
-    : _pDevice(pDevice->retain()), _pScene(new Scene()) {
+    : _pDevice(pDevice->retain()), _pScene(new Scene()),
+      _pendingBlasEvictions(
+          [](MTL::CommandBuffer *command) {
+            if (command)
+              command->retain();
+          },
+          [](MTL::CommandBuffer *command) {
+            if (command)
+              command->release();
+          }) {
   _pCommandQueue = _pDevice->newCommandQueue();
   _tlasHeap.initialize(_pDevice);
   _dummyBlasResources.initialize(_pDevice);
@@ -980,6 +991,9 @@ Renderer::Renderer(MTL::Device *pDevice)
 Renderer::~Renderer() {
   processPendingCapturedFrames();
   waitForPendingFrameCommands();
+
+  _pendingBlasEvictions.clear();
+  assert(_pendingBlasEvictions.empty());
 
   if (_pSphereBuffer)
     _pSphereBuffer->release();
@@ -2439,9 +2453,9 @@ void Renderer::processBlasBuildQueue() {
       _pendingBlasBuilds.pop_front();
       if (buildRequest && buildRequest->resident &&
           buildRequest->objectIndex < _instanceRecords.size()) {
-        transitionResidentToCold(
-            *buildRequest->resident,
-            _instanceRecords[buildRequest->objectIndex]);
+        transitionResidentToCold(buildRequest->objectIndex,
+                                 *buildRequest->resident,
+                                 _instanceRecords[buildRequest->objectIndex]);
       }
       continue;
     }
@@ -2764,7 +2778,7 @@ void Renderer::handleCompletedBlasBuild(
     resident.state = ResidentObjectGpuResources::ResidencyState::Resident;
     resident.lastStateChange = std::chrono::steady_clock::now();
   } else if (buildRequest->objectIndex < _instanceRecords.size()) {
-    transitionResidentToCold(resident,
+    transitionResidentToCold(buildRequest->objectIndex, resident,
                              _instanceRecords[buildRequest->objectIndex]);
   } else {
     resident.geometryValid = false;
@@ -2787,11 +2801,58 @@ void Renderer::handleCompletedBlasBuild(
   processBlasBuildQueue();
 }
 
-void Renderer::transitionResidentToCold(ResidentObjectGpuResources &resident,
-                                        BlasInstanceRecord &instanceRecord) {
+void Renderer::transitionResidentToCold(size_t objectIndex,
+                                        ResidentObjectGpuResources &resident,
+                                        BlasInstanceRecord &instanceRecord,
+                                        bool removePending) {
+  if (removePending)
+    _pendingBlasEvictions.cancel(objectIndex, resident);
+
   waitForPendingFrameCommands();
   waitForPendingTlasBuild();
   resident.transitionToCold(instanceRecord);
+}
+
+void Renderer::requestResidentEviction(size_t objectIndex,
+                                       ResidentObjectGpuResources &resident,
+                                       BlasInstanceRecord &instanceRecord) {
+  if (objectIndex >= _residentObjectGpuResources.size())
+    return;
+
+  bool hasPendingCommand = resident.pendingCommand &&
+                           resident.pendingCommand->status() !=
+                               MTL::CommandBufferStatusCompleted;
+  if (!resident.isResident() && !hasPendingCommand) {
+    transitionResidentToCold(objectIndex, resident, instanceRecord);
+    return;
+  }
+
+  resident.transitionToStreaming();
+  resident.geometryValid = false;
+  _pendingBlasEvictions.enqueue(objectIndex, resident);
+}
+
+void Renderer::cancelPendingResidentEviction(size_t objectIndex,
+                                             ResidentObjectGpuResources &resident) {
+  _pendingBlasEvictions.cancel(objectIndex, resident);
+}
+
+void Renderer::handleDeferredBlasEvictions(MTL::CommandBuffer *commandBuffer,
+                                           bool success) {
+  if (!commandBuffer)
+    return;
+
+  if (success)
+    waitForPendingFrameCommands();
+
+  _pendingBlasEvictions.complete(
+      commandBuffer, success, [this](ResidentObjectGpuResources &resident,
+                                     size_t objectIndex) {
+        if (objectIndex >= _instanceRecords.size())
+          return;
+        auto &instanceRecord = _instanceRecords[objectIndex];
+        resident.transitionToCold(instanceRecord);
+      });
 }
 
 bool Renderer::submitAsyncCommandBuffer(
@@ -3445,16 +3506,23 @@ void Renderer::updateTopLevelAccelerationStructure(
   if (signalValue > 0) {
     commandBuffer->addCompletedHandler(
         [this, signalValue](MTL::CommandBuffer *cmd) {
-          (void)cmd;
+          bool success =
+              cmd->status() == MTL::CommandBufferStatusCompleted;
+          this->handleDeferredBlasEvictions(cmd, success);
           this->_tlasCompletedEventValue.store(signalValue,
                                                std::memory_order_release);
         });
   }
 
+  _pendingBlasEvictions.assign(commandBuffer);
+
   commandBuffer->commit();
 
   if (!_pTlasBuildEvent) {
     commandBuffer->waitUntilCompleted();
+    bool success =
+        commandBuffer->status() == MTL::CommandBufferStatusCompleted;
+    handleDeferredBlasEvictions(commandBuffer, success);
     _tlasCompletedEventValue.store(_tlasBuildEventValue,
                                    std::memory_order_release);
     finalizePendingTlasScratchResize(true);
@@ -4270,7 +4338,7 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     }
 
     if (!shouldBeResident) {
-      transitionResidentToCold(gpuResident, instanceRecord);
+      requestResidentEviction(objectIndex, gpuResident, instanceRecord);
     }
   }
 
@@ -7294,7 +7362,7 @@ void Renderer::flushResidencyChanges(bool forceFullRebuild) {
         resident.clearPendingCommand();
 
       if (!resident.isResident() && !pending) {
-        transitionResidentToCold(resident, record);
+        transitionResidentToCold(objectIndex, resident, record);
       }
     }
     return;

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "AlwaysResidentCache.h"
+#include "DeferredPurgeQueue.h"
 #include "GpuHeapResources.h"
 #include "ResidencyBudget.h"
 #include "TlasScratchTracker.h"
@@ -181,8 +182,17 @@ private:
   bool startBlasBuild(const std::shared_ptr<PendingBlasBuild> &buildRequest);
   void handleCompletedBlasBuild(
       const std::shared_ptr<PendingBlasBuild> &buildRequest, bool success);
-  void transitionResidentToCold(ResidentObjectGpuResources &resident,
-                                BlasInstanceRecord &instanceRecord);
+  void requestResidentEviction(size_t objectIndex,
+                               ResidentObjectGpuResources &resident,
+                               BlasInstanceRecord &instanceRecord);
+  void cancelPendingResidentEviction(size_t objectIndex,
+                                     ResidentObjectGpuResources &resident);
+  void handleDeferredBlasEvictions(MTL::CommandBuffer *commandBuffer,
+                                   bool success);
+  void transitionResidentToCold(size_t objectIndex,
+                                ResidentObjectGpuResources &resident,
+                                BlasInstanceRecord &instanceRecord,
+                                bool removePending = true);
   bool submitAsyncCommandBuffer(MTL::CommandBuffer *commandBuffer,
                                std::function<void(bool)> completion);
   void updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd);
@@ -398,6 +408,9 @@ private:
   std::vector<bool> _objectResidentState;
 
   std::vector<ResidentObjectGpuResources> _residentObjectGpuResources;
+
+  DeferredPurgeQueue<ResidentObjectGpuResources, MTL::CommandBuffer>
+      _pendingBlasEvictions;
 
   GpuHeapResources _tlasHeap;
   GpuHeapResources _dummyBlasResources;

--- a/tests/DeferredPurgeQueueTests.cpp
+++ b/tests/DeferredPurgeQueueTests.cpp
@@ -1,0 +1,59 @@
+#include "MetalCpp Path Tracer/Renderer/DeferredPurgeQueue.h"
+
+#include <cassert>
+
+struct DummyResource {
+  int purgeCount = 0;
+};
+
+struct DummyCommand {
+  int retainCount = 0;
+};
+
+int main() {
+  DummyResource resourceA;
+  DummyResource resourceB;
+  DummyCommand command{};
+
+  DeferredPurgeQueue<DummyResource, DummyCommand> queue(
+      [](DummyCommand *cmd) {
+        if (cmd)
+          ++cmd->retainCount;
+      },
+      [](DummyCommand *cmd) {
+        if (cmd)
+          --cmd->retainCount;
+      });
+
+  queue.enqueue(0, resourceA);
+  queue.assign(&command);
+  queue.complete(&command, false, [](DummyResource &res, size_t) {
+    ++res.purgeCount;
+  });
+  assert(queue.empty() == false);
+  assert(command.retainCount == 0);
+  assert(resourceA.purgeCount == 0);
+
+  queue.assign(&command);
+  queue.complete(&command, true, [](DummyResource &res, size_t) {
+    ++res.purgeCount;
+  });
+  assert(resourceA.purgeCount == 1);
+  assert(queue.empty());
+  assert(command.retainCount == 0);
+
+  queue.enqueue(1, resourceB);
+  queue.assign(&command);
+  bool cancelled = queue.cancel(1, resourceB);
+  assert(cancelled);
+  assert(queue.empty());
+  assert(command.retainCount == 0);
+
+  queue.enqueue(2, resourceA);
+  queue.assign(&command);
+  queue.clear();
+  assert(queue.empty());
+  assert(command.retainCount == 0);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- introduce a reusable deferred purge queue to pair BLAS evictions with their command buffers
- update residency and TLAS update paths to defer BLAS heap purges until the associated command buffer completes and cancel purges on reactivation
- add coverage ensuring deferred entries are cancelled and cleared when expected

## Testing
- `clang++ -std=c++17 tests/DeferredPurgeQueueTests.cpp -I. -o /tmp/DeferredPurgeQueueTests` *(fails: clang++ not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_6901fdb96884832da0c45843235c776b