### PR TITLE
Preserve always resident BLAS resources on build failure

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -136,6 +136,10 @@ bool ResidentObjectGpuResources::ensureResident(
     BlasInstanceRecord &instanceRecord, bool forceRebuild) {
   renderer.cancelPendingResidentEviction(objectIndex, *this);
 
+  const auto previousState = state;
+  const auto previousStateChange = lastStateChange;
+  const bool previousGeometryValid = geometryValid;
+
   if (isResident() && !forceRebuild) {
     lastStateChange = std::chrono::steady_clock::now();
     return true;
@@ -145,6 +149,12 @@ bool ResidentObjectGpuResources::ensureResident(
   geometryValid = false;
   bool built = renderer.buildObjectBlas(objectIndex, object, *this);
   if (!built) {
+    if (renderer.isAlwaysResidentStrategy()) {
+      state = previousState;
+      geometryValid = previousGeometryValid;
+      lastStateChange = previousStateChange;
+      return false;
+    }
     renderer.transitionResidentToCold(objectIndex, *this, instanceRecord);
     return false;
   }
@@ -7770,3 +7780,6 @@ double Renderer::lastRaysPerSecond() const { return _lastRaysPerSecond; }
 size_t Renderer::activeNodeCount() const { return _activeNodeCount; }
 size_t Renderer::residentNodeCount() const { return _residentNodeCount; }
 size_t Renderer::totalNodeCount() const { return _totalNodeCount; }
+bool Renderer::isAlwaysResidentStrategy() const {
+  return _frameStrategy == ResidencyStrategy::AlwaysResident;
+}

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -114,6 +114,7 @@ public:
   size_t activeNodeCount() const;
   size_t residentNodeCount() const;
   size_t totalNodeCount() const;
+  bool isAlwaysResidentStrategy() const;
 
   std::vector<std::pair<simd::float3, float>> _allSpheres;
 

--- a/tests/AlwaysResidentCacheTests.cpp
+++ b/tests/AlwaysResidentCacheTests.cpp
@@ -4,6 +4,89 @@
 
 using MetalCppPathTracer::AlwaysResidentCache;
 
+namespace {
+
+enum class FakeResidencyStrategy { AlwaysResident, Streaming };
+
+struct FakeSceneObject {};
+
+struct FakeBlasInstanceRecord {
+  int primitiveCount = 1;
+};
+
+struct FakeResidentResources {
+  enum class State { Cold, Streaming, Resident };
+
+  State state = State::Resident;
+  bool geometryValid = true;
+  bool transitionedToCold = false;
+
+  void transitionToStreaming() { state = State::Streaming; }
+
+  void transitionToCold(FakeBlasInstanceRecord &record) {
+    state = State::Cold;
+    geometryValid = false;
+    transitionedToCold = true;
+    record.primitiveCount = 0;
+  }
+};
+
+struct FakeRenderer {
+  FakeResidencyStrategy strategy = FakeResidencyStrategy::Streaming;
+  bool buildResult = true;
+  bool transitionToColdCalled = false;
+
+  void cancelPendingResidentEviction(size_t, FakeResidentResources &) {}
+
+  bool buildObjectBlas(size_t, const FakeSceneObject &,
+                       FakeResidentResources &) {
+    return buildResult;
+  }
+
+  void transitionResidentToCold(size_t, FakeResidentResources &resources,
+                                FakeBlasInstanceRecord &record) {
+    transitionToColdCalled = true;
+    resources.transitionToCold(record);
+  }
+
+  bool isAlwaysResidentStrategy() const {
+    return strategy == FakeResidencyStrategy::AlwaysResident;
+  }
+};
+
+bool ensureResident(FakeRenderer &renderer, size_t objectIndex,
+                    const FakeSceneObject &object,
+                    FakeResidentResources &resources,
+                    FakeBlasInstanceRecord &instanceRecord,
+                    bool forceRebuild) {
+  renderer.cancelPendingResidentEviction(objectIndex, resources);
+
+  auto previousState = resources.state;
+  auto previousGeometryValid = resources.geometryValid;
+
+  if (resources.state == FakeResidentResources::State::Resident && !forceRebuild)
+    return true;
+
+  resources.transitionToStreaming();
+  resources.geometryValid = false;
+
+  if (!renderer.buildObjectBlas(objectIndex, object, resources)) {
+    if (renderer.isAlwaysResidentStrategy()) {
+      resources.state = previousState;
+      resources.geometryValid = previousGeometryValid;
+      return false;
+    }
+    renderer.transitionResidentToCold(objectIndex, resources, instanceRecord);
+    return false;
+  }
+
+  resources.state = FakeResidentResources::State::Resident;
+  resources.geometryValid = true;
+  return true;
+}
+
+} // namespace
+
 int main() {
   AlwaysResidentCache cache;
 
@@ -26,7 +109,41 @@ int main() {
   cache.markUpdated(6, 2);
 
   assert(cache.needsUpdate(true, 6, 2, false));
+  cache.markUpdated(6, 2);
+
+  {
+    FakeRenderer renderer;
+    renderer.strategy = FakeResidencyStrategy::AlwaysResident;
+    renderer.buildResult = false;
+    FakeResidentResources resources;
+    FakeSceneObject object;
+    FakeBlasInstanceRecord record;
+
+    bool result = ensureResident(renderer, 0, object, resources, record, true);
+    assert(!result);
+    assert(resources.state == FakeResidentResources::State::Resident);
+    assert(resources.geometryValid);
+    assert(!resources.transitionedToCold);
+    assert(!renderer.transitionToColdCalled);
+    assert(record.primitiveCount == 1);
+  }
+
+  {
+    FakeRenderer renderer;
+    renderer.strategy = FakeResidencyStrategy::Streaming;
+    renderer.buildResult = false;
+    FakeResidentResources resources;
+    FakeSceneObject object;
+    FakeBlasInstanceRecord record;
+
+    bool result = ensureResident(renderer, 0, object, resources, record, true);
+    assert(!result);
+    assert(resources.state == FakeResidentResources::State::Cold);
+    assert(!resources.geometryValid);
+    assert(resources.transitionedToCold);
+    assert(renderer.transitionToColdCalled);
+    assert(record.primitiveCount == 0);
+  }
 
   return 0;
 }
-


### PR DESCRIPTION
## Summary
- add a helper to expose the active residency strategy from the renderer
- keep always-resident GPU allocations alive when a BLAS build fails
- add residency failure simulations to the AlwaysResidentCache test covering both strategies

## Testing
- g++ tests/AlwaysResidentCacheTests.cpp -std=c++17 -I. -o always_resident_test
- ./always_resident_test

------
https://chatgpt.com/codex/tasks/task_e_69025c044ce0832d8f05c9c3e15600c9