### PR TITLE
Ensure frame wait tracks prep command buffers

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -2820,6 +2820,7 @@ void Renderer::transitionResidentToCold(size_t objectIndex,
 
   waitForPendingFrameCommands();
   waitForPendingTlasBuild();
+  debugAssertNoPendingFrameCommands("GpuHeapResources::makeResourcesPurgeable");
   resident.transitionToCold(instanceRecord);
 }
 
@@ -2861,6 +2862,7 @@ void Renderer::handleDeferredBlasEvictions(MTL::CommandBuffer *commandBuffer,
         if (objectIndex >= _instanceRecords.size())
           return;
         auto &instanceRecord = _instanceRecords[objectIndex];
+        debugAssertNoPendingFrameCommands("GpuHeapResources::makeResourcesPurgeable");
         resident.transitionToCold(instanceRecord);
       });
 }
@@ -5620,6 +5622,7 @@ void Renderer::draw(MTK::View *pView) {
   updateAdaptiveSamplingMaps(prepCmd);
 
   prepCmd->commit();
+  trackFrameCommandBuffer(prepCmd);
 
   if (!haveAllTextures) {
     MTL::CommandBuffer *presentCmd = _pCommandQueue->commandBuffer();
@@ -7627,64 +7630,106 @@ void Renderer::trackFrameCommandBuffer(MTL::CommandBuffer *commandBuffer) {
 
   commandBuffer->retain();
 
-  MTL::CommandBuffer *previous = nullptr;
   {
     std::lock_guard<std::mutex> lock(_frameCommandBufferMutex);
-    previous = _lastFrameCommandBuffer;
-    _lastFrameCommandBuffer = commandBuffer;
+    _frameCommandBuffers.push_back(commandBuffer);
   }
-  if (previous)
-    previous->release();
 
   commandBuffer->addCompletedHandler([this](MTL::CommandBuffer *completed) {
-    bool release = false;
-    {
-      std::lock_guard<std::mutex> lock(_frameCommandBufferMutex);
-      if (_lastFrameCommandBuffer == completed) {
-        _lastFrameCommandBuffer = nullptr;
-        release = true;
-      }
+    std::lock_guard<std::mutex> lock(_frameCommandBufferMutex);
+    auto it = std::find(_frameCommandBuffers.begin(),
+                        _frameCommandBuffers.end(), completed);
+    if (it != _frameCommandBuffers.end()) {
+      (*it)->release();
+      _frameCommandBuffers.erase(it);
     }
-    if (release)
-      completed->release();
   });
 }
 
 void Renderer::waitForPendingFrameCommands() {
-  MTL::CommandBuffer *buffer = nullptr;
-  {
-    std::lock_guard<std::mutex> lock(_frameCommandBufferMutex);
-    buffer = _lastFrameCommandBuffer;
-    if (buffer)
-      buffer->retain();
-  }
+  using Status = MTL::CommandBufferStatus;
 
-  if (!buffer)
-    return;
+  while (true) {
+    std::vector<MTL::CommandBuffer *> buffersToWait;
+    {
+      std::lock_guard<std::mutex> lock(_frameCommandBufferMutex);
+      if (_frameCommandBuffers.empty())
+        break;
 
-  auto status = buffer->status();
-  switch (status) {
-  case MTL::CommandBufferStatus::CommandBufferStatusNotEnqueued:
-  case MTL::CommandBufferStatus::CommandBufferStatusEnqueued:
-  case MTL::CommandBufferStatus::CommandBufferStatusCommitted:
-  case MTL::CommandBufferStatus::CommandBufferStatusScheduled:
-    buffer->waitUntilCompleted();
-    break;
-  case MTL::CommandBufferStatus::CommandBufferStatusCompleted:
-  case MTL::CommandBufferStatus::CommandBufferStatusError:
-  default:
-    break;
-  }
+      buffersToWait.reserve(_frameCommandBuffers.size());
+      for (auto *buffer : _frameCommandBuffers) {
+        if (!buffer)
+          continue;
+        buffer->retain();
+        buffersToWait.push_back(buffer);
+      }
+    }
 
-  {
-    std::lock_guard<std::mutex> lock(_frameCommandBufferMutex);
-    if (_lastFrameCommandBuffer == buffer) {
-      _lastFrameCommandBuffer->release();
-      _lastFrameCommandBuffer = nullptr;
+    if (buffersToWait.empty())
+      break;
+
+    for (MTL::CommandBuffer *buffer : buffersToWait) {
+      auto status = buffer->status();
+      switch (status) {
+      case Status::CommandBufferStatusNotEnqueued:
+      case Status::CommandBufferStatusEnqueued:
+      case Status::CommandBufferStatusCommitted:
+      case Status::CommandBufferStatusScheduled:
+        buffer->waitUntilCompleted();
+        break;
+      case Status::CommandBufferStatusCompleted:
+      case Status::CommandBufferStatusError:
+      default:
+        break;
+      }
+      buffer->release();
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(_frameCommandBufferMutex);
+      auto it = _frameCommandBuffers.begin();
+      while (it != _frameCommandBuffers.end()) {
+        MTL::CommandBuffer *buffer = *it;
+        if (!buffer) {
+          it = _frameCommandBuffers.erase(it);
+          continue;
+        }
+
+        auto status = buffer->status();
+        if (status == Status::CommandBufferStatusCompleted ||
+            status == Status::CommandBufferStatusError) {
+          buffer->release();
+          it = _frameCommandBuffers.erase(it);
+        } else {
+          ++it;
+        }
+      }
+
+      if (_frameCommandBuffers.empty())
+        break;
     }
   }
+}
 
-  buffer->release();
+void Renderer::debugAssertNoPendingFrameCommands(const char *reason) {
+#if !defined(NDEBUG)
+  std::lock_guard<std::mutex> lock(_frameCommandBufferMutex);
+  if (_frameCommandBuffers.empty())
+    return;
+
+  std::printf(
+      "[Renderer] Pending frame command buffers detected before %s (%zu).\n",
+      reason ? reason : "frame purge",
+      static_cast<unsigned long>(_frameCommandBuffers.size()));
+  for (const auto &entry : _frameCommandBuffers) {
+    if (!entry)
+      continue;
+    std::printf("  status=%d\n", static_cast<int>(entry->status()));
+  }
+  assert(_frameCommandBuffers.empty());
+#else
+  (void)reason;
+#endif
 }
 
 void Renderer::beginFrameMetrics() {

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -223,7 +223,8 @@ private:
   void updateBlasScratchResidencyBudget();
   double scratchMemoryMB() const;
   double residencyMemoryMB() const;
-  
+  void debugAssertNoPendingFrameCommands(const char *reason);
+
   MTL::Device *_pDevice = nullptr;
   MTL::CommandQueue *_pCommandQueue = nullptr;
   MTL::RenderPipelineState *_pPSO = nullptr;
@@ -247,7 +248,7 @@ private:
   MTL::Buffer *_pPrimitiveRemapBuffer = nullptr;
   MTL::Buffer *_pPrimitiveHitBufferGPU = nullptr;
   MTL::Buffer *_pPrimitiveHitReadback = nullptr;
-  MTL::CommandBuffer *_lastFrameCommandBuffer = nullptr;
+  std::vector<MTL::CommandBuffer *> _frameCommandBuffers;
   std::mutex _frameCommandBufferMutex;
   MTL::CommandBuffer *_lastRayHitCommandBuffer = nullptr;
   bool _rayHitCopyError = false;


### PR DESCRIPTION
## Summary
- track both prep and present frame command buffers so pending work is flushed before purging resources
- update frame command buffer waiting logic to drain all tracked buffers and add a debug assertion before residency purges

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69032bc5ead0832db757b00e426f87c2