### PR TITLE
Handle newly tracked frame commands during wait

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -7666,6 +7666,7 @@ void Renderer::trackFrameCommandBuffer(MTL::CommandBuffer *commandBuffer) {
 
 bool Renderer::waitForPendingFrameCommands(std::chrono::milliseconds timeout) {
   std::vector<FrameCommandBufferRecord> pending;
+  std::chrono::steady_clock::time_point waitStart;
   {
     std::lock_guard<std::mutex> lock(_frameCommandBufferMutex);
     pending.reserve(_frameCommandBuffers.size());
@@ -7674,6 +7675,7 @@ bool Renderer::waitForPendingFrameCommands(std::chrono::milliseconds timeout) {
         record.buffer->retain();
       pending.push_back(record);
     }
+    waitStart = std::chrono::steady_clock::now();
   }
 
   const bool infiniteTimeout = timeout == std::chrono::milliseconds::max();
@@ -7708,10 +7710,24 @@ bool Renderer::waitForPendingFrameCommands(std::chrono::milliseconds timeout) {
       allComplete = false;
   }
 
+  bool newCommandTracked = false;
+  {
+    std::lock_guard<std::mutex> lock(_frameCommandBufferMutex);
+    for (const auto &record : _frameCommandBuffers) {
+      if (record.trackedSince > waitStart) {
+        newCommandTracked = true;
+        break;
+      }
+    }
+  }
+
   for (auto &record : pending) {
     if (record.buffer)
       record.buffer->release();
   }
+
+  if (newCommandTracked)
+    return false;
 
   return allComplete;
 }

--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -37,6 +37,7 @@
 #include <string>
 #include <utility>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #define TINYEXR_IMPLEMENTATION
@@ -7666,14 +7667,18 @@ void Renderer::trackFrameCommandBuffer(MTL::CommandBuffer *commandBuffer) {
 
 bool Renderer::waitForPendingFrameCommands(std::chrono::milliseconds timeout) {
   std::vector<FrameCommandBufferRecord> pending;
+  std::vector<MTL::CommandBuffer *> snapshotBuffers;
   std::chrono::steady_clock::time_point waitStart;
   {
     std::lock_guard<std::mutex> lock(_frameCommandBufferMutex);
     pending.reserve(_frameCommandBuffers.size());
+    snapshotBuffers.reserve(_frameCommandBuffers.size());
     for (const auto &record : _frameCommandBuffers) {
       if (record.buffer)
         record.buffer->retain();
       pending.push_back(record);
+      if (record.buffer)
+        snapshotBuffers.push_back(record.buffer);
     }
     waitStart = std::chrono::steady_clock::now();
   }
@@ -7710,11 +7715,16 @@ bool Renderer::waitForPendingFrameCommands(std::chrono::milliseconds timeout) {
       allComplete = false;
   }
 
+  std::unordered_set<MTL::CommandBuffer *> snapshotSet(snapshotBuffers.begin(),
+                                                       snapshotBuffers.end());
   bool newCommandTracked = false;
   {
     std::lock_guard<std::mutex> lock(_frameCommandBufferMutex);
     for (const auto &record : _frameCommandBuffers) {
-      if (record.trackedSince > waitStart) {
+      if (!record.buffer)
+        continue;
+      bool presentInSnapshot = snapshotSet.find(record.buffer) != snapshotSet.end();
+      if (!presentInSnapshot || record.trackedSince >= waitStart) {
         newCommandTracked = true;
         break;
       }


### PR DESCRIPTION
## Summary
- capture the wait snapshot timestamp when copying frame command buffer records
- treat the wait as incomplete if newer frame command buffers appear while waiting
- still release the retained command buffers from the initial snapshot before returning

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690347296510832d8326172beac91a3a