### PR TITLE
Clamp screen-space coverage calculation

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -7425,7 +7425,9 @@ bool Renderer::updateScreenSpaceFootprint(bool forceAllToggles) {
               _screenCoverageSortedIndices.end(), size_t(0));
   }
 
-  const float screenArea = Camera::screenSize.x * Camera::screenSize.y;
+  float screenArea = Camera::screenSize.x * Camera::screenSize.y;
+  if (screenArea <= 0.0f)
+    screenArea = 1.0f;
   float halfFov = Camera::verticalFov * static_cast<float>(M_PI) / 180.0f * 0.5f;
   float tanHalfFov = std::tan(halfFov);
   if (tanHalfFov <= 0.0f)


### PR DESCRIPTION
## Summary
- clamp the computed screen-space area to a positive minimum before coverage calculations so zero-sized drawables no longer zero out residency coverage

## Testing
- not run (Metal runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_e_690b2873486c832d92dfebd36c1dd253