### PR TITLE
Clamp fairness tolerance for mesh residency

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -7096,6 +7096,12 @@ bool Renderer::updateEnergyImportance(bool forceAllToggles) {
     allowedRatio = std::max(allowedRatio, kRelativeFallback);
 
     float allowedDelta = meshLastPrimaryAverage * allowedRatio;
+    const float kMaxAllowedFraction = 0.25f;
+    if (std::isfinite(allowedDelta) && meshLastPrimaryAverage > 0.0f) {
+      float maxAllowedDelta = meshLastPrimaryAverage * kMaxAllowedFraction;
+      if (std::isfinite(maxAllowedDelta))
+        allowedDelta = std::min(allowedDelta, maxAllowedDelta);
+    }
 
     if (allowedDelta > 0.0f) {
       float epsilon = std::max(1e-5f, meshLastPrimaryAverage * 1e-3f);


### PR DESCRIPTION
## Summary
- clamp the fairness tolerance by limiting the allowed delta to a fraction of the last primary average
- use the clamped tolerance when reactivating mesh groups so low-importance groups remain inactive

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_690b290095cc832da87d63bb1b25b16e