### PR TITLE
Add probabilistic residency strategy support

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1334,6 +1334,8 @@ std::string Renderer::residencyStrategyName(ResidencyStrategy strategy) const {
     return "Screen-space footprint";
   case ResidencyStrategy::AlwaysResident:
     return "Always resident";
+  case ResidencyStrategy::Probabilistic:
+    return "Probabilistic residency";
   case ResidencyStrategy::DistanceLOD:
   default:
     return "Distance-based LOD";
@@ -2156,6 +2158,9 @@ void Renderer::updateVisibleScene() {
     break;
   case ResidencyStrategy::AlwaysResident:
     strategyName = "Always resident";
+    break;
+  case ResidencyStrategy::Probabilistic:
+    strategyName = "Probabilistic residency";
     break;
   case ResidencyStrategy::DistanceLOD:
   default:

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -18,6 +18,7 @@ enum class ResidencyStrategy {
   RayHitBudget = 2,
   ScreenSpaceFootprint = 3,
   AlwaysResident = 4,
+  Probabilistic = 5,
 };
 
 struct SceneObject {
@@ -55,6 +56,11 @@ struct ResidencyParameters {
   float screenFootprintMinPixelCoverage = 32.0f;
   size_t screenFootprintMinActivePrimitives = 16;
   size_t screenFootprintMaxTogglesPerFrame = 10;
+
+  float probabilityDecay = 0.9f;
+  float probabilityThreshold = 0.5f;
+  size_t probabilityMinActivePrimitives = 16;
+  size_t probabilityMaxTogglesPerFrame = 16;
 
   // Allows resident buffers to shrink when most primitives remain inactive.
   bool enableBufferShrink = true;

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -624,6 +624,10 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         } else if (value == "alwaysresident" || value == "always_resident" ||
                    value == "always" || value == "none" || value == "off") {
             scene->setResidencyStrategy(ResidencyStrategy::AlwaysResident);
+        } else if (value == "probabilistic" || value == "probability" ||
+                   value == "stochastic" || value == "probability_based" ||
+                   value == "probabilitybased") {
+            scene->setResidencyStrategy(ResidencyStrategy::Probabilistic);
         } else {
             printf("Unknown residency strategy '%s', defaulting to distance LOD.\n",
                    residencyAttr);
@@ -672,6 +676,17 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
     params.screenFootprintMaxTogglesPerFrame = static_cast<size_t>(root->Unsigned64Attribute(
         "screenToggleBudget",
         static_cast<uint64_t>(params.screenFootprintMaxTogglesPerFrame)));
+
+    params.probabilityDecay =
+        root->FloatAttribute("probabilityDecay", params.probabilityDecay);
+    params.probabilityThreshold =
+        root->FloatAttribute("probabilityThreshold", params.probabilityThreshold);
+    params.probabilityMinActivePrimitives = static_cast<size_t>(root->Unsigned64Attribute(
+        "probabilityMinActive",
+        static_cast<uint64_t>(params.probabilityMinActivePrimitives)));
+    params.probabilityMaxTogglesPerFrame = static_cast<size_t>(root->Unsigned64Attribute(
+        "probabilityToggleBudget",
+        static_cast<uint64_t>(params.probabilityMaxTogglesPerFrame)));
     params.enableBufferShrink = root->BoolAttribute(
         "enableBufferShrink", params.enableBufferShrink);
     params.bufferShrinkActiveRatio = root->FloatAttribute(


### PR DESCRIPTION
## Summary
- add a probabilistic residency enum value and defaults to the scene parameters
- teach the XML scene loader to parse probabilistic strategy aliases and attributes
- surface a human readable probabilistic strategy name in the renderer output

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911d61c7ca8832d9da331805d6cb31a)