### PR TITLE
Add probabilistic residency metrics to benchmarks

### DIFF
--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -9,6 +9,17 @@ The path tracer can emit additional metrics and frame captures while running ben
 
 These variables can be exported in your shell or added to any run scripts you maintain for benchmarking sessions.
 
+## Benchmark CSV columns
+
+Benchmark exports now include stochastic residency metrics alongside the existing memory and activation counters:
+
+- `avg_hit_probability` – arithmetic mean of the per-primitive hit probabilities tracked during the frame.
+- `p95_hit_probability` – 95th percentile of the same per-primitive hit probabilities, highlighting upper-tail engagement.
+- `probability_threshold` – the active residency threshold applied by the probabilistic strategy for the frame.
+- `probabilistic_toggles` – number of primitives that flipped residency state due to the probabilistic strategy during the frame.
+
+These columns complement the existing residency memory statistics in `*_memory_mb` and allow the plotting tools to chart probability-driven residency behavior when comparing runs.
+
 ## Comparing EXR captures
 
 Use `compare_exr_ssim.cpp` to quantify the visual difference between two EXR frames with the Structural Similarity Index (SSIM). Build the tool with a C++17 compiler:

--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1252,7 +1252,9 @@ void Renderer::writeBenchmarkHeader() {
          "object_deactivations,active_primitives,resident_primitives,total_primitives,"
          "active_triangles,resident_triangles,total_triangles,active_nodes,"
          "resident_nodes,total_nodes,active_objects,resident_objects,gpu_memory_mb,"
-         "scratch_memory_mb,residency_memory_mb,texture_memory_cap_mb,"
+         "avg_hit_probability,p95_hit_probability,probability_threshold,"
+         "probabilistic_toggles,gpu_memory_mb,scratch_memory_mb,"
+         "residency_memory_mb,texture_memory_cap_mb,"
          "over_memory_cap,residency_compacted,"
          "accumulation_reset,ray_hit_decay,state_cooldown_frames,lod_toggle_budget,"
          "energy_toggle_budget,screen_toggle_budget,rayhit_toggle_budget,"
@@ -1293,6 +1295,10 @@ void Renderer::writeBenchmarkRow(const BenchmarkSample &sample) {
       << sample.activeNodeCount << ',' << sample.residentNodeCount << ','
       << sample.totalNodeCount << ',' << sample.activeObjectCount << ','
       << sample.residentObjectCount << ','
+      << formatFixed(sample.avgHitProbability, 6) << ','
+      << formatFixed(sample.p95HitProbability, 6) << ','
+      << formatFixed(sample.probabilityThreshold, 3) << ','
+      << sample.probabilisticToggles << ','
       << formatFixed(sample.gpuMemoryMB, 3) << ','
       << formatFixed(sample.scratchMemoryMB, 3) << ','
       << formatFixed(sample.residencyMemoryMB, 3) << ','
@@ -6309,6 +6315,7 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   _framePrimitiveDeactivations = 0;
   _frameObjectActivations = 0;
   _frameObjectDeactivations = 0;
+  _frameProbabilisticToggles = 0;
   ResidencyStrategy strategy = _pScene->getResidencyStrategy();
   if (strategy != _lastResidencyStrategy) {
     if (strategy == ResidencyStrategy::AlwaysResident)
@@ -7501,6 +7508,7 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
     }
     if (setPrimitiveActive(i, shouldBeActive)) {
       ++toggles;
+      ++_frameProbabilisticToggles;
       changed = true;
     }
   }
@@ -7516,8 +7524,10 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
                           : size_t(0);
     if (fallback >= primCount)
       fallback = primCount - 1;
-    if (setPrimitiveActive(fallback, true))
+    if (setPrimitiveActive(fallback, true)) {
+      ++_frameProbabilisticToggles;
       changed = true;
+    }
   }
 
   if (changed)
@@ -8282,6 +8292,33 @@ void Renderer::beginFrameMetrics() {
     sample.residencyMemoryMB =
         std::max(0.0, sample.gpuMemoryMB - sample.scratchMemoryMB);
     sample.textureMemoryCapMB = _textureResidencyMemoryCapMB;
+    sample.avgHitProbability = 0.0;
+    sample.p95HitProbability = 0.0;
+    sample.probabilityThreshold = _residencyConfig.probabilityThreshold;
+    if (!_primitiveHitProbability.empty()) {
+      std::vector<float> validProbabilities;
+      validProbabilities.reserve(_primitiveHitProbability.size());
+      double probabilitySum = 0.0;
+      for (float probability : _primitiveHitProbability) {
+        if (!std::isfinite(probability))
+          continue;
+        probabilitySum += probability;
+        validProbabilities.push_back(probability);
+      }
+      if (!validProbabilities.empty()) {
+        sample.avgHitProbability =
+            probabilitySum / static_cast<double>(validProbabilities.size());
+        size_t percentileIndex = static_cast<size_t>(std::floor(
+            0.95 * static_cast<double>(validProbabilities.size() - 1)));
+        percentileIndex = std::min(percentileIndex,
+                                    validProbabilities.size() - 1);
+        std::nth_element(validProbabilities.begin(),
+                         validProbabilities.begin() + percentileIndex,
+                         validProbabilities.end());
+        sample.p95HitProbability = validProbabilities[percentileIndex];
+      }
+    }
+    sample.probabilisticToggles = _frameProbabilisticToggles;
     sample.deltaTimeSeconds = _deltaTimeSeconds;
     sample.wallSeconds = std::chrono::duration<double>(
                             std::chrono::steady_clock::now() - _benchmarkStartTime)

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -365,6 +365,10 @@ private:
     double cpuTimeSeconds = 0.0;
     double gpuTimeSeconds = 0.0;
     double raysPerSecond = 0.0;
+    double avgHitProbability = 0.0;
+    double p95HitProbability = 0.0;
+    double probabilityThreshold = 0.0;
+    size_t probabilisticToggles = 0;
     ResidencyStrategy strategy = ResidencyStrategy::DistanceLOD;
     std::string strategyName;
     uint32_t minSamplesPerPixel = 1;
@@ -539,6 +543,7 @@ private:
   size_t _framePrimitiveDeactivations = 0;
   size_t _frameObjectActivations = 0;
   size_t _frameObjectDeactivations = 0;
+  size_t _frameProbabilisticToggles = 0;
   ResidencyStrategy _frameStrategy = ResidencyStrategy::DistanceLOD;
   ResidencyStrategy _lastResidencyStrategy = ResidencyStrategy::DistanceLOD;
   AlwaysResidentCache _alwaysResidentCache;

--- a/compare_runs.py
+++ b/compare_runs.py
@@ -6,7 +6,9 @@ numeric metric columns.  For every metric that exists in both files a
 ``frame vs metric`` plot is written next to the CSVs.  When present, a
 ``strategy`` column provides the legend label; otherwise the filename stem
 is used.  This is useful when benchmark runs are timestamped under
-``benchmarks/runs1``.
+``benchmarks/runs1``.  Newly exported metrics such as
+``avg_hit_probability`` and ``probabilistic_toggles`` are automatically
+included when both CSVs expose them.
 """
 from __future__ import annotations
 
@@ -19,6 +21,16 @@ import matplotlib.pyplot as plt
 
 Frames = List[int]
 Series = Dict[str, List[float]]
+
+PREFERRED_METRICS = [
+    "residency_memory_mb",
+    "gpu_memory_mb",
+    "avg_hit_probability",
+    "p95_hit_probability",
+    "probability_threshold",
+    "probabilistic_toggles",
+]
+_PREFERRED_INDEX = {name: index for index, name in enumerate(PREFERRED_METRICS)}
 
 
 def _load_csv(path: Path) -> Tuple[Frames, Series, str]:
@@ -70,10 +82,13 @@ def _load_csv(path: Path) -> Tuple[Frames, Series, str]:
 def _metric_names(metrics_a: Series, metrics_b: Series) -> Iterable[str]:
     """Return the metrics shared by both CSV files."""
 
-    shared = sorted(set(metrics_a) & set(metrics_b))
+    shared = set(metrics_a) & set(metrics_b)
     if not shared:
         raise ValueError("No shared numeric metrics between the provided CSVs")
-    return shared
+    return sorted(
+        shared,
+        key=lambda name: (_PREFERRED_INDEX.get(name, len(PREFERRED_METRICS)), name),
+    )
 
 
 def _safe_name(name: str) -> str:


### PR DESCRIPTION
## Summary
- capture probabilistic residency statistics in each benchmark sample and export them in the CSV output
- document the new CSV columns for benchmarking runs and note their availability in the plotting helper
- prefer plotting the new metrics when present so residency comparisons highlight probabilistic behavior

## Testing
- python3 -m compileall compare_runs.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911fc147318832da5fdd424cd78bcc7)