### PR TITLE
Fix benchmark header GPU column order

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1251,7 +1251,7 @@ void Renderer::writeBenchmarkHeader() {
          "primitive_activations,primitive_deactivations,object_activations,"
          "object_deactivations,active_primitives,resident_primitives,total_primitives,"
          "active_triangles,resident_triangles,total_triangles,active_nodes,"
-         "resident_nodes,total_nodes,active_objects,resident_objects,gpu_memory_mb,"
+         "resident_nodes,total_nodes,active_objects,resident_objects,"
          "avg_hit_probability,p95_hit_probability,probability_threshold,"
          "probabilistic_toggles,gpu_memory_mb,scratch_memory_mb,"
          "residency_memory_mb,texture_memory_cap_mb,"


### PR DESCRIPTION
## Summary
- update Renderer::writeBenchmarkHeader to remove the duplicated gpu_memory_mb column and align the header with row output

## Testing
- python - <<'PY'
import csv
import io
header = "frame,wall_seconds,cpu_ms,gpu_ms,rays_per_second,rays_cast,strategy,strategy_id,delta_time_seconds,min_samples_per_pixel,max_samples_per_pixel,primitive_activations,primitive_deactivations,object_activations,object_deactivations,active_primitives,resident_primitives,total_primitives,active_triangles,resident_triangles,total_triangles,active_nodes,resident_nodes,total_nodes,active_objects,resident_objects,avg_hit_probability,p95_hit_probability,probability_threshold,probabilistic_toggles,gpu_memory_mb,scratch_memory_mb,residency_memory_mb,texture_memory_cap_mb,over_memory_cap,residency_compacted,accumulation_reset,ray_hit_decay,state_cooldown_frames,lod_toggle_budget,energy_toggle_budget,screen_toggle_budget,rayhit_toggle_budget,rayhit_target_fraction,rayhit_min_active,rayhit_rebuild_cooldown,lod_enter_distance,lod_exit_distance,lod_enter_view_margin,lod_exit_view_margin,energy_target_fraction,energy_min_active,energy_visibility_boost,screen_target_fraction,screen_min_pixels,screen_min_active"
fields = header.split(',')
values = [str(i) for i in range(len(fields))]
row = ','.join(values)
reader = csv.DictReader(io.StringIO(header + '\n' + row + '\n'))
record = next(reader)
assert record['avg_hit_probability'] == '26'
assert record['gpu_memory_mb'] == '30'
assert len(record) == 56
PY

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69127268863c832db072af4c3e039875)