### PR TITLE
Use probabilistic decay for hit probability tracking

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -8117,7 +8117,7 @@ void Renderer::processRayHitCounters() {
               size_t(0));
   }
 
-  float decay = _residencyConfig.rayHitDecay;
+  float decay = _residencyConfig.probabilityDecay;
 
   parallelChunkedAsync(0, count, [&](size_t chunkStart, size_t chunkEnd) {
     for (size_t i = chunkStart; i < chunkEnd; ++i) {


### PR DESCRIPTION
## Summary
- switch the probabilistic residency update loop to use probabilityDecay instead of rayHitDecay

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913140979f8832db14e06442937edf6)