### PR TITLE
Adjust probabilistic residency selection logic

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -7512,6 +7512,8 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
   for (size_t idx : _probabilitySortedIndices) {
     if (idx >= primCount)
       continue;
+    if (idx < _activePrimitive.size() && _activePrimitive[idx])
+      continue;
     if (desired[idx])
       continue;
     float probability =
@@ -7640,6 +7642,8 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
       ++toggles;
       ++_frameProbabilisticToggles;
       changed = true;
+      if (!shouldBeActive && i < _primitiveExplorationScore.size())
+        _primitiveExplorationScore[i] = 0.0f;
     }
   }
 


### PR DESCRIPTION
## Summary
- skip primitives that remain active when gathering exploration candidates so churn can occur once probabilities drop
- reset exploration score when a primitive is toggled inactive to keep it from immediately re-promoting

## Testing
- ⚠️ Not run (requires macOS/Metal environment for probabilistic crossfire scene)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913297ab390832d89648110d7b2a8a4)