### PR TITLE
Adjust probabilistic residency threshold handling

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -7464,7 +7464,7 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
     float probability = (i < _primitiveHitProbability.size())
                             ? _primitiveHitProbability[i]
                             : 0.0f;
-    if (probability >= threshold)
+    if (probability > threshold)
       desired[i] = true;
   }
 
@@ -7519,7 +7519,7 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
     float probability =
         (idx < _primitiveHitProbability.size()) ? _primitiveHitProbability[idx]
                                                 : 0.0f;
-    if (probability >= threshold)
+    if (probability > threshold)
       continue;
     uint32_t raysTested =
         (idx < _primitiveRaysTestedLastFrame.size())


### PR DESCRIPTION
## Summary
- treat primitives whose hit probability equals the configured threshold as candidates for eviction in the probabilistic residency update
- keep the probabilistic exploration queue focused on below-threshold primitives so low-probability assets can stream out

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69132b1cc6cc832d8039bc99c0a68b33)