### PR TITLE
Apply probability decay when no rays hit primitives

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -8295,7 +8295,15 @@ void Renderer::processRayHitCounters() {
       float clampedProbability = std::clamp(probability, 0.0f, 1.0f);
       // Numerical safeguards ensure the Beta-derived probability stays within
       // the true [0, 1] interval regardless of tuning.
-      _primitiveHitProbability[i] = clampedProbability;
+      float adjustedProbability = clampedProbability;
+      if (raysTested == 0) {
+        // When no rays were fired at a primitive this frame, apply a decay so
+        // dormant primitives slowly cool off instead of preserving stale
+        // residency values indefinitely.
+        adjustedProbability =
+            std::clamp(clampedProbability * probabilityDecay, 0.0f, 1.0f);
+      }
+      _primitiveHitProbability[i] = adjustedProbability;
 
       float exploration = _primitiveExplorationScore[i] * probabilityDecay;
       if (raysTested > 0) {


### PR DESCRIPTION
## Summary
- decay primitive hit probability when no rays were tested to prevent stale residency
- keep probabilities clamped to the valid range while preserving existing beta updates

## Testing
- Not run (Metal renderer requires macOS environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69132e08585c832d99884327fcb44706)