### PR TITLE
Add standalone residency dump visualiser

### DIFF
--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -20,6 +20,17 @@ Benchmark exports now include stochastic residency metrics alongside the existin
 
 These columns complement the existing residency memory statistics in `*_memory_mb` and allow the plotting tools to chart probability-driven residency behavior when comparing runs.
 
+## Acceleration-structure dumps and residency debugging
+
+Setting `MPT_RUNS_PATH` before launching the renderer creates a run directory containing CSV logs and an `as/` folder with frame-by-frame acceleration-structure dumps. Each JSON file mirrors the renderer's TLAS/BLAS hierarchy and includes a `primitives` array with the following keys:
+
+- `index` – primitive identifier within the flattened BLAS list.
+- `active` – whether the primitive was resident during the frame.
+- `hitProbability` – the stochastic hit probability tracked for the primitive (range 0–1).
+- `object` – optional owning object index, present when the primitive can be mapped back to a scene object.
+
+Run `analyze_residency_dump.py` against the capture directory to transform the dumps into Matplotlib artifacts that mirror the CSV tooling (`compare_runs.py`). The script emits `hit_probability_heatmap.png` for a per-primitive probability heatmap plus `object_hit_probability.png`/`.csv` for per-object trends. Capture a short run (for example, `MPT_MAX_FRAMES=300`) to produce a manageable series of dumps, then inspect the heatmap for stubbornly hot primitives or use the per-object plot to find residency oscillations.
+
 ## Comparing EXR captures
 
 Use `compare_exr_ssim.cpp` to quantify the visual difference between two EXR frames with the Structural Similarity Index (SSIM). Build the tool with a C++17 compiler:

--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -8053,6 +8053,9 @@ bool Renderer::setPrimitiveActive(size_t index, bool active) {
   return true;
 }
 
+// The dump serialises TLAS, BLAS, and per-primitive state as JSON. Primitive
+// records now include an estimated hitProbability (and optional object index)
+// so tooling can correlate residency decisions with the stochastic tracker.
 void Renderer::dumpAccelerationStructure(const std::string &path) {
   std::filesystem::create_directories(
       std::filesystem::path(path).parent_path());
@@ -8113,9 +8116,17 @@ void Renderer::dumpAccelerationStructure(const std::string &path) {
   out << "  \"primitives\": [\n";
   size_t primCount = std::min(_allPrimitives.size(), _activePrimitive.size());
   for (size_t i = 0; i < primCount; ++i) {
+    float hitProbability =
+        (i < _primitiveHitProbability.size()) ? _primitiveHitProbability[i] : 0.0f;
     out << "    {\"index\":" << i
         << ",\"active\":" << (_activePrimitive[i] ? "true" : "false")
-        << "}";
+        << ",\"hitProbability\":" << hitProbability;
+    if (i < _primitiveToObject.size()) {
+      size_t objectIndex = _primitiveToObject[i];
+      if (objectIndex != std::numeric_limits<size_t>::max())
+        out << ",\"object\":" << objectIndex;
+    }
+    out << "}";
     if (i + 1 < primCount)
       out << ",\n";
     else

--- a/analyze_residency_dump.py
+++ b/analyze_residency_dump.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Visualise per-primitive hit probabilities from acceleration-structure dumps.
+
+This tool complements ``compare_runs.py`` by focusing on the stochastic
+residency tracker data that the renderer emits inside ``as/frame_XXXX.json``
+files.  Point the script at a benchmark run directory (or directly at the
+``as`` folder) and it will generate:
+
+* ``hit_probability_heatmap.png`` – a frame-by-frame heatmap of each
+  primitive's ``hitProbability`` value.  Bright regions correspond to
+  primitives that stay hot or repeatedly receive hits, while dark regions show
+  primitives that are cooling successfully.
+* ``object_hit_probability.png`` – line plots of the average
+  ``hitProbability`` per object, highlighting the objects with the highest
+  observed probabilities so that residency anomalies are easy to spot.
+* ``object_hit_probability.csv`` – the numeric data behind the per-object plot
+  (one column per object index) for downstream tooling.
+
+Capture guidance
+================
+1. Export ``MPT_RUNS_PATH=/path/to/runs`` before launching the renderer.
+2. Optionally bound the capture with ``MPT_MAX_FRAMES=300`` (or similar) to
+   keep the dump series manageable.
+3. After the run, you should have ``runs/<timestamp>/as/frame_XXXX.json``
+   alongside CSV metrics.  Run this script against the directory to produce the
+   heatmap and per-object summaries that help debug residency behaviour.
+
+Example::
+
+    python analyze_residency_dump.py runs/2024-10-31_15-00-00 --output-dir plots
+
+When multiple benchmark runs are stored inside ``runs/``, point to the specific
+run directory (the script will automatically look for an ``as`` subdirectory).
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+@dataclass
+class PrimitiveRecord:
+    """Normalised primitive data extracted from a frame dump."""
+
+    index: int
+    hit_probability: float
+    object_index: Optional[int]
+    active: bool
+
+
+@dataclass
+class FrameRecord:
+    """Container for per-frame primitive information."""
+
+    frame: int
+    primitives: List[PrimitiveRecord]
+
+
+def _coerce_int(value: object) -> Optional[int]:
+    try:
+        if value is None:
+            return None
+        if isinstance(value, bool):  # bool is a subclass of int
+            return int(value)
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _infer_frame_index(data: Mapping[str, object], path: Path, fallback: int) -> int:
+    candidate = data.get("frame")
+    frame_index = _coerce_int(candidate)
+    if frame_index is not None:
+        return frame_index
+    match = re.search(r"(\d+)", path.stem)
+    if match:
+        try:
+            return int(match.group(1))
+        except ValueError:
+            pass
+    return fallback
+
+
+def _normalise_primitives(raw: Iterable[Mapping[str, object]]) -> List[PrimitiveRecord]:
+    primitives: List[PrimitiveRecord] = []
+    for entry in raw:
+        if not isinstance(entry, Mapping):
+            continue
+        index = _coerce_int(entry.get("index"))
+        if index is None or index < 0:
+            continue
+        hit_probability_raw = entry.get("hitProbability", 0.0)
+        try:
+            hit_probability = float(hit_probability_raw)
+        except (TypeError, ValueError):
+            hit_probability = 0.0
+        object_index = _coerce_int(entry.get("object"))
+        active = bool(entry.get("active", True))
+        primitives.append(
+            PrimitiveRecord(
+                index=index,
+                hit_probability=max(0.0, min(1.0, hit_probability)),
+                object_index=object_index,
+                active=active,
+            )
+        )
+    primitives.sort(key=lambda prim: prim.index)
+    return primitives
+
+
+def _load_frame_file(path: Path, fallback_frame_index: int) -> List[FrameRecord]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if isinstance(data, Mapping):
+        primitives_raw = data.get("primitives")
+        if not isinstance(primitives_raw, list):
+            raise ValueError(f"Dump file {path} is missing a 'primitives' array")
+        frame_index = _infer_frame_index(data, path, fallback_frame_index)
+        primitives = _normalise_primitives(primitives_raw)
+        return [FrameRecord(frame=frame_index, primitives=primitives)]
+    if isinstance(data, list):
+        frames: List[FrameRecord] = []
+        for idx, entry in enumerate(data):
+            if not isinstance(entry, Mapping):
+                continue
+            primitives_raw = entry.get("primitives")
+            if not isinstance(primitives_raw, list):
+                continue
+            frame_index = _coerce_int(entry.get("frame"))
+            if frame_index is None:
+                frame_index = fallback_frame_index + idx
+            frames.append(
+                FrameRecord(
+                    frame=frame_index,
+                    primitives=_normalise_primitives(primitives_raw),
+                )
+            )
+        if not frames:
+            raise ValueError(f"Dump file {path} does not contain valid frame entries")
+        return frames
+    raise ValueError(f"Unsupported JSON structure in dump file {path}")
+
+
+def load_frames(source: Path) -> List[FrameRecord]:
+    """Return sorted frame records from ``source`` (file or directory)."""
+
+    if source.is_file():
+        return _load_frame_file(source, 0)
+
+    if not source.exists():
+        raise FileNotFoundError(source)
+
+    json_paths = sorted(p for p in source.glob("*.json") if p.is_file())
+    if not json_paths:
+        raise FileNotFoundError(f"No JSON dumps found in {source}")
+
+    frames: List[FrameRecord] = []
+    for idx, path in enumerate(json_paths):
+        frames.extend(_load_frame_file(path, idx))
+
+    frames.sort(key=lambda frame: frame.frame)
+    return frames
+
+
+def probability_matrix(frames: Sequence[FrameRecord]) -> np.ndarray:
+    """Build a ``frame_count x primitive_count`` array of hit probabilities."""
+
+    if not frames:
+        raise ValueError("No frames available")
+
+    max_index = max((prim.index for frame in frames for prim in frame.primitives), default=-1)
+    if max_index < 0:
+        raise ValueError("Frames do not contain primitives")
+
+    matrix = np.full((len(frames), max_index + 1), np.nan, dtype=float)
+    for row, frame in enumerate(frames):
+        for prim in frame.primitives:
+            matrix[row, prim.index] = prim.hit_probability
+    return matrix
+
+
+def aggregate_by_object(frames: Sequence[FrameRecord]) -> Dict[int, List[float]]:
+    """Return average hit probability per object for each frame."""
+
+    object_series: Dict[int, List[float]] = {}
+    for frame_idx, frame in enumerate(frames):
+        for series in object_series.values():
+            series.append(math.nan)
+
+        per_object: MutableMapping[int, List[float]] = defaultdict(list)
+        for prim in frame.primitives:
+            if prim.object_index is None:
+                continue
+            per_object[prim.object_index].append(prim.hit_probability)
+
+        for object_index, values in per_object.items():
+            mean_value = float(np.mean(values)) if values else math.nan
+            if object_index not in object_series:
+                object_series[object_index] = [math.nan] * frame_idx + [mean_value]
+            else:
+                object_series[object_index][-1] = mean_value
+    return object_series
+
+
+def plot_heatmap(matrix: np.ndarray, frames: Sequence[FrameRecord], output_dir: Path) -> Path:
+    frame_numbers = [frame.frame for frame in frames]
+    extent = [0, matrix.shape[1], frame_numbers[0], frame_numbers[-1] + 1]
+
+    plt.figure(figsize=(12, 6))
+    img = plt.imshow(
+        matrix,
+        origin="lower",
+        aspect="auto",
+        interpolation="nearest",
+        vmin=0.0,
+        vmax=1.0,
+        extent=extent,
+        cmap="viridis",
+    )
+    plt.colorbar(img, label="hitProbability")
+    plt.xlabel("Primitive index")
+    plt.ylabel("Frame")
+    plt.title("Per-primitive hitProbability heatmap")
+    plt.tight_layout()
+
+    output_path = output_dir / "hit_probability_heatmap.png"
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+    return output_path
+
+
+def plot_object_series(
+    object_series: Mapping[int, Sequence[float]],
+    frames: Sequence[FrameRecord],
+    output_dir: Path,
+    top_n: int,
+) -> Optional[Path]:
+    if not object_series:
+        return None
+
+    frame_numbers = [frame.frame for frame in frames]
+    candidates = []
+    for object_index, series in object_series.items():
+        finite_values = [value for value in series if not math.isnan(value)]
+        if not finite_values:
+            continue
+        candidates.append((object_index, max(finite_values)))
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda item: item[1], reverse=True)
+    selected = [object_index for object_index, _ in candidates[:top_n]]
+
+    plt.figure(figsize=(12, 6))
+    for object_index in selected:
+        series = object_series[object_index]
+        plt.plot(frame_numbers, series, marker="o", label=f"object {object_index}")
+
+    plt.xlabel("Frame")
+    plt.ylabel("Average hitProbability")
+    plt.title("Top object hitProbability trends")
+    plt.grid(True, linestyle="--", alpha=0.4)
+    plt.legend(loc="upper right")
+    plt.tight_layout()
+
+    output_path = output_dir / "object_hit_probability.png"
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+    return output_path
+
+
+def export_object_csv(
+    object_series: Mapping[int, Sequence[float]], frames: Sequence[FrameRecord], output_dir: Path
+) -> Optional[Path]:
+    if not object_series:
+        return None
+
+    frame_numbers = [frame.frame for frame in frames]
+    object_indices = sorted(object_series)
+
+    output_path = output_dir / "object_hit_probability.csv"
+    with output_path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.writer(fh)
+        header = ["frame"] + [f"object_{idx}" for idx in object_indices]
+        writer.writerow(header)
+        for row_idx, frame_number in enumerate(frame_numbers):
+            row = [frame_number]
+            for object_index in object_indices:
+                series = object_series[object_index]
+                value = series[row_idx] if row_idx < len(series) else math.nan
+                row.append("" if math.isnan(value) else f"{value:.6f}")
+            writer.writerow(row)
+    return output_path
+
+
+def resolve_source_path(path: Path) -> Path:
+    if path.is_dir():
+        as_dir = path / "as"
+        return as_dir if as_dir.exists() else path
+    return path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path, help="Run directory or JSON dump path")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory where plots and CSV data will be written (defaults to the run directory)",
+    )
+    parser.add_argument(
+        "--top-objects",
+        type=int,
+        default=8,
+        help="Number of objects to include in the trend plot (default: 8)",
+    )
+
+    args = parser.parse_args()
+
+    source = resolve_source_path(args.path.resolve())
+    frames = load_frames(source)
+
+    output_dir = args.output_dir.resolve() if args.output_dir else source.parent
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    matrix = probability_matrix(frames)
+    heatmap_path = plot_heatmap(matrix, frames, output_dir)
+
+    object_series = aggregate_by_object(frames)
+    object_plot_path = plot_object_series(object_series, frames, output_dir, args.top_objects)
+    csv_path = export_object_csv(object_series, frames, output_dir)
+
+    print(f"Saved heatmap: {heatmap_path}")
+    if object_plot_path:
+        print(f"Saved object plot: {object_plot_path}")
+    else:
+        print("No object indices present in the dumps; skipping object trend plot.")
+    if csv_path:
+        print(f"Saved object data: {csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/visualize_metrics.py
+++ b/visualize_metrics.py
@@ -2,8 +2,8 @@
 """Generate all research plots from a single renderer run.
 
 The renderer can log performance counters (``perf.csv``), GPU memory usage
-(``gpu_mem.csv``), and per-frame acceleration-structure dumps.  Previously a
-collection of small scripts were required to visualise these outputs.  This
+(``gpu_mem.csv``), and per-frame acceleration-structure dumps. Previously a
+collection of small scripts were required to visualise these outputs. This
 utility consolidates those workflows: run it once and it will emit dedicated
 Plotly HTML dashboards for every available data source.
 
@@ -12,8 +12,14 @@ Example::
     python visualize_metrics.py runs --output-dir figures
 
 The script will look for ``perf.csv`` and ``gpu_mem.csv`` inside ``runs`` and
-an ``as`` directory containing frame dumps.  Each output is optional; missing
+an ``as`` directory containing frame dumps. Each output is optional; missing
 inputs are reported but do not abort the run.
+
+Set ``MPT_RUNS_PATH`` before launching the renderer to capture ``as/frame_XXXX.json``
+files alongside the CSV logs. Each primitive entry exposes ``active``,
+``hitProbability``, and (when available) ``object`` metadata. The probability
+values feed the new heatmap and per-object trend plots, which highlight how
+the stochastic residency tracker cools primitives over time.
 """
 from __future__ import annotations
 
@@ -183,25 +189,99 @@ def _node_series_from_frames(frames: List[Dict[str, Any]]) -> Dict[str, List[int
     }
 
 
-def _build_intersection_arrays(frames: List[Dict[str, Any]]) -> tuple[List[List[int]], List[List[int]]]:
-    """Return 2-D arrays for intersection counts and residency."""
+def _build_intersection_arrays(
+    frames: List[Dict[str, Any]]
+) -> tuple[List[List[int]], List[List[int]], List[List[Optional[float]]]]:
+    """Return 2-D arrays for intersection counts, residency, and hit probability."""
 
     if not frames:
-        return [], []
+        return [], [], []
 
     frame_count = len(frames)
     max_prims = max(len(f.get("primitives", [])) for f in frames)
 
     counts = [[0 for _ in range(frame_count)] for _ in range(max_prims)]
     active = [[0 for _ in range(frame_count)] for _ in range(max_prims)]
+    probabilities: List[List[Optional[float]]] = [
+        [None for _ in range(frame_count)] for _ in range(max_prims)
+    ]
 
     for f_idx, frame in enumerate(frames):
         prims = frame.get("primitives", [])
         for p_idx, prim in enumerate(prims):
             counts[p_idx][f_idx] = int(prim.get("lastIntersection", 0))
             active[p_idx][f_idx] = 1 if prim.get("active", True) else 0
+            prob_value = prim.get("hitProbability")
+            if prob_value is not None:
+                try:
+                    probabilities[p_idx][f_idx] = float(prob_value)
+                except (TypeError, ValueError):  # pragma: no cover - defensive parsing
+                    probabilities[p_idx][f_idx] = None
 
-    return counts, active
+    return counts, active, probabilities
+
+
+def _has_probability_data(probabilities: List[List[Optional[float]]]) -> bool:
+    """Return True if any probability samples are present."""
+
+    return any(any(value is not None for value in row) for row in probabilities)
+
+
+def _aggregate_object_probabilities(
+    frames: List[Dict[str, Any]]
+) -> Dict[int, List[Optional[float]]]:
+    """Return average hit probability per object for each frame."""
+
+    if not frames:
+        return {}
+
+    frame_count = len(frames)
+    object_ids = set()
+    for frame in frames:
+        for prim in frame.get("primitives", []):
+            obj = prim.get("object")
+            prob = prim.get("hitProbability")
+            if obj is None or prob is None:
+                continue
+            try:
+                object_ids.add(int(obj))
+            except (TypeError, ValueError):  # pragma: no cover - defensive parsing
+                continue
+
+    series: Dict[int, List[Optional[float]]] = {
+        obj: [None for _ in range(frame_count)] for obj in sorted(object_ids)
+    }
+
+    if not series:
+        return series
+
+    for f_idx, frame in enumerate(frames):
+        totals: Dict[int, float] = {}
+        counts: Dict[int, int] = {}
+        for prim in frame.get("primitives", []):
+            obj = prim.get("object")
+            prob = prim.get("hitProbability")
+            if obj is None or prob is None:
+                continue
+            try:
+                obj_idx = int(obj)
+                prob_value = float(prob)
+            except (TypeError, ValueError):  # pragma: no cover - defensive parsing
+                continue
+            totals[obj_idx] = totals.get(obj_idx, 0.0) + prob_value
+            counts[obj_idx] = counts.get(obj_idx, 0) + 1
+        for obj_idx, total in totals.items():
+            count = counts.get(obj_idx, 0)
+            if count:
+                series[obj_idx][f_idx] = total / count
+
+    return series
+
+
+def _has_object_probability_series(series: Mapping[int, List[Optional[float]]]) -> bool:
+    """Return True if any object-level probability samples are present."""
+
+    return any(any(value is not None for value in values) for values in series.values())
 
 
 # ---------------------------------------------------------------------------
@@ -281,9 +361,14 @@ def _intersection_figure(counts: List[List[int]], active: List[List[int]]) -> go
     )
 
     if counts:
+        frame_count = len(counts[0]) if counts[0] else 0
+        prim_indices = list(range(len(counts)))
+        frame_indices = list(range(frame_count))
         fig.add_trace(
             go.Heatmap(
                 z=counts,
+                x=frame_indices,
+                y=prim_indices,
                 colorscale="Viridis",
                 colorbar=dict(title="Hits"),
             ),
@@ -292,9 +377,14 @@ def _intersection_figure(counts: List[List[int]], active: List[List[int]]) -> go
         )
 
     if active:
+        frame_count = len(active[0]) if active[0] else 0
+        prim_indices = list(range(len(active)))
+        frame_indices = list(range(frame_count))
         fig.add_trace(
             go.Heatmap(
                 z=active,
+                x=frame_indices,
+                y=prim_indices,
                 colorscale=[[0, "#f44336"], [1, "#4caf50"]],
                 colorbar=dict(title="Active"),
             ),
@@ -307,6 +397,58 @@ def _intersection_figure(counts: List[List[int]], active: List[List[int]]) -> go
     fig.update_xaxes(title_text="Frame", row=2, col=1)
     fig.update_yaxes(title_text="Primitive", row=1, col=1)
     fig.update_yaxes(title_text="Primitive", row=2, col=1)
+    return fig
+
+
+
+def _probability_figure(probabilities: List[List[Optional[float]]]) -> go.Figure:
+    fig = go.Figure()
+    if probabilities:
+        frame_count = len(probabilities[0]) if probabilities[0] else 0
+        frame_indices = list(range(frame_count))
+        prim_indices = list(range(len(probabilities)))
+        fig.add_trace(
+            go.Heatmap(
+                z=probabilities,
+                x=frame_indices,
+                y=prim_indices,
+                colorscale="Inferno",
+                colorbar=dict(title="P(hit)"),
+                zmin=0.0,
+                zmax=1.0,
+            )
+        )
+    fig.update_layout(
+        title="Per-primitive hit probability",
+        xaxis_title="Frame",
+        yaxis_title="Primitive",
+        height=500,
+    )
+    return fig
+
+
+def _object_probability_figure(
+    frames: Iterable[int], series: Mapping[int, List[Optional[float]]]
+) -> go.Figure:
+    fig = go.Figure()
+    frame_list = list(frames)
+    for obj_idx, values in series.items():
+        if not any(value is not None for value in values):
+            continue
+        fig.add_trace(
+            go.Scatter(
+                x=frame_list,
+                y=values,
+                mode="lines+markers",
+                name=f"Object {obj_idx}",
+            )
+        )
+    fig.update_layout(
+        title="Average hit probability per object",
+        xaxis_title="Frame",
+        yaxis_title="Probability",
+    )
+    fig.update_yaxes(range=[0.0, 1.0])
     return fig
 
 
@@ -372,12 +514,27 @@ def main() -> None:
         _write_html(node_fig, node_output, args.auto_open)
         outputs["active_nodes"] = node_output
 
-        counts, active = _build_intersection_arrays(frames_for_nodes)
+        counts, active, probabilities = _build_intersection_arrays(frames_for_nodes)
         if counts or active:
             intersection_fig = _intersection_figure(counts, active)
             intersection_output = args.output_dir / "intersections.html"
             _write_html(intersection_fig, intersection_output, args.auto_open)
             outputs["intersections"] = intersection_output
+
+        if _has_probability_data(probabilities):
+            probability_fig = _probability_figure(probabilities)
+            probability_output = args.output_dir / "hit_probability.html"
+            _write_html(probability_fig, probability_output, args.auto_open)
+            outputs["hit_probability"] = probability_output
+
+        object_series = _aggregate_object_probabilities(frames_for_nodes)
+        if _has_object_probability_series(object_series):
+            object_fig = _object_probability_figure(
+                range(len(frames_for_nodes)), object_series
+            )
+            object_output = args.output_dir / "object_hit_probability.html"
+            _write_html(object_fig, object_output, args.auto_open)
+            outputs["object_hit_probability"] = object_output
 
     if not outputs:
         raise SystemExit("No plots were generated; ensure the runs directory contains logs")


### PR DESCRIPTION
## Summary
- add analyze_residency_dump.py to turn acceleration-structure dumps into hit-probability heatmaps and per-object trend plots
- document the new workflow in the benchmarks README so users relying on compare_runs.py know how to inspect residency data

## Testing
- python -m compileall analyze_residency_dump.py compare_runs.py visualize_metrics.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69133b87ca1c832db89e4f7d8184b2cc)