### PR TITLE
Update benchmarking environment variable handling

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1191,14 +1191,14 @@ void Renderer::setFrameCaptureInterval(size_t interval) {
 }
 
 void Renderer::initializeBenchmarking() {
-  const char *primaryEnv = std::getenv("METALPT_BENCH");
-  const char *legacyEnv = std::getenv("METALAPT_BENCH");
+  const char *primaryEnv = std::getenv("METALAPT_BENCH");
+  const char *legacyEnv = std::getenv("METALPT_BENCH");
   const char *env = primaryEnv ? primaryEnv : legacyEnv;
   if (!env)
     return;
 
   if (!primaryEnv && legacyEnv) {
-    printf("METALAPT_BENCH detected; please update to METALPT_BENCH for future runs.\n");
+    printf("METALPT_BENCH detected; please update to METALAPT_BENCH for future runs.\n");
   }
 
   std::string value(env);


### PR DESCRIPTION
## Summary
- switch benchmarking initialization to use METALAPT_BENCH as the primary environment variable
- keep METALPT_BENCH as a legacy fallback and update the warning message to reference the deprecated name

## Testing
- g++ -std=c++17 'MetalCpp Path Tracer/Renderer/Renderer.cpp' -I'MetalCpp Path Tracer' -c *(fails: Metal/Metal.hpp is unavailable in this Linux container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69134615fb0c832dbc8fdb6a762e8b33)