### PR TITLE
Update residency analysis to read benchmark CSVs

### DIFF
--- a/analyze_residency_dump.py
+++ b/analyze_residency_dump.py
@@ -1,226 +1,158 @@
 #!/usr/bin/env python3
-"""Visualise per-primitive hit probabilities from acceleration-structure dumps.
+"""Visualise stochastic residency metrics logged to renderer benchmark CSVs.
 
-This tool complements ``compare_runs.py`` by focusing on the stochastic
-residency tracker data that the renderer emits inside ``as/frame_XXXX.json``
-files.  Point the script at a benchmark run directory (or directly at the
-``as`` folder) and it will generate:
+The renderer no longer emits ``as/frame_XXXX.json`` acceleration-structure
+dumps, which means residency analysis must rely entirely on the CSV exports
+produced in benchmark mode.  This script mirrors the CSV handling used by
+``compare_runs.py`` so that the same log files can now drive single-run
+diagnostics.  Point the tool at a benchmark CSV (or the directory containing
+it) and the following artefacts will be generated when the relevant columns are
+present:
 
-* ``hit_probability_heatmap.png`` – a frame-by-frame heatmap of each
-  primitive's ``hitProbability`` value.  Bright regions correspond to
-  primitives that stay hot or repeatedly receive hits, while dark regions show
-  primitives that are cooling successfully.
-* ``object_hit_probability.png`` – line plots of the average
-  ``hitProbability`` per object, highlighting the objects with the highest
-  observed probabilities so that residency anomalies are easy to spot.
-* ``object_hit_probability.csv`` – the numeric data behind the per-object plot
+* ``hit_probability_heatmap.png`` – a per-frame heatmap built from columns such
+  as ``primitive_0_hit_probability``.  The script automatically discovers
+  numbered primitive columns and paints them against the recorded frame index.
+* ``object_hit_probability.png`` – line plots for columns named like
+  ``object_12_hit_probability``.  The highest ``top-n`` object curves are drawn
+  to highlight residency outliers across the run.
+* ``object_hit_probability.csv`` – the numeric data backing the per-object plot
   (one column per object index) for downstream tooling.
-
-Capture guidance
-================
-1. Export ``METALAPT_BENCH=/path/to/runs`` before launching the renderer.
-2. Optionally bound the capture with ``MPT_MAX_FRAMES=300`` (or similar) to
-   keep the dump series manageable.
-3. After the run, you should have ``runs/<timestamp>/as/frame_XXXX.json``
-   alongside CSV metrics.  Run this script against the directory to produce the
-   heatmap and per-object summaries that help debug residency behaviour.
-4. Interpret the new plots as follows: bright bands in the heatmap flag
-   primitives whose ``hitProbability`` remains high (potential residency
-   pressure), while diagonal fades show cooling behaviour.  The per-object
-   trends highlight which scene instances accumulate probability so you can
-   focus on problematic assets frame-by-frame.
+* ``hit_probability_trends.png`` – aggregated metrics for
+  ``avg_hit_probability``, ``p95_hit_probability``, and
+  ``probability_threshold`` plotted against the frame index.
+* ``probabilistic_toggles.png`` – a helper plot for the
+  ``probabilistic_toggles`` column when it is present in the CSV.
 
 Example::
 
-    python analyze_residency_dump.py runs/2024-10-31_15-00-00 --output-dir plots
+    python analyze_residency_dump.py Benchmarks/metrics_20251016_101530.csv
 
-When multiple benchmark runs are stored inside ``runs/``, point to the specific
-run directory (the script will automatically look for an ``as`` subdirectory).
+If the provided path is a directory the script will search for a single CSV
+inside it, preferring files with ``metrics`` in the name.  Set
+``METALAPT_BENCH`` before launching the renderer to store benchmark logs in a
+known location; the script defaults to that directory when no explicit path is
+supplied.
 """
+
 from __future__ import annotations
 
 import argparse
 import csv
-import json
 import math
-import re
 import os
-from collections import defaultdict
+import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+from typing import Dict, List, Mapping, Optional, Sequence
 
 import matplotlib.pyplot as plt
 import numpy as np
 
 
+PrimitiveSeries = Dict[int, List[float]]
+ObjectSeries = Dict[int, List[float]]
+
+PRIMITIVE_COLUMN_RE = re.compile(
+    r"(?:(?:primitive|prim)[_\-]?)(\d+)(?:[_\-]hit[_\-]?probability|[_\-]?probability)?$",
+    re.IGNORECASE,
+)
+OBJECT_COLUMN_RE = re.compile(
+    r"object[_\-]?(\d+)(?:[_\-]hit[_\-]?probability|[_\-]?probability)?$",
+    re.IGNORECASE,
+)
+
+
 @dataclass
-class PrimitiveRecord:
-    """Normalised primitive data extracted from a frame dump."""
+class RunMetrics:
+    """Container for per-frame CSV metrics used by the residency analyser."""
 
-    index: int
-    hit_probability: float
-    object_index: Optional[int]
-    active: bool
+    frames: List[int]
+    metrics: Dict[str, List[float]]
 
 
-@dataclass
-class FrameRecord:
-    """Container for per-frame primitive information."""
+def _load_csv(path: Path) -> RunMetrics:
+    """Return frame numbers and numeric metric series from ``path``."""
 
-    frame: int
-    primitives: List[PrimitiveRecord]
+    frames: List[int] = []
+    metrics: Dict[str, List[float]] = {}
+
+    with path.open("r", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        if reader.fieldnames is None:
+            raise ValueError(f"CSV file has no header: {path}")
+
+        for row in reader:
+            frame_value = row.get("frame")
+            if frame_value in (None, ""):
+                raise ValueError(f"Missing 'frame' value in {path}")
+            frames.append(int(float(frame_value)))
+
+            for key, value in row.items():
+                if key == "frame" or value in (None, ""):
+                    continue
+                try:
+                    numeric_value = float(value)
+                except (TypeError, ValueError):
+                    continue
+                metrics.setdefault(key, []).append(numeric_value)
+
+    valid_frame_count = len(frames)
+    metrics = {
+        key: values
+        for key, values in metrics.items()
+        if len(values) == valid_frame_count
+    }
+    return RunMetrics(frames=frames, metrics=metrics)
 
 
-def _coerce_int(value: object) -> Optional[int]:
-    try:
-        if value is None:
-            return None
-        if isinstance(value, bool):  # bool is a subclass of int
-            return int(value)
-        return int(float(value))
-    except (TypeError, ValueError):
+def _partition_metrics(metrics: Mapping[str, Sequence[float]]) -> tuple[
+    PrimitiveSeries, ObjectSeries, Dict[str, List[float]]
+]:
+    """Split ``metrics`` into primitive, object, and remaining series."""
+
+    primitive_series: PrimitiveSeries = {}
+    object_series: ObjectSeries = {}
+    remaining: Dict[str, List[float]] = {}
+
+    for name, values in metrics.items():
+        primitive_match = PRIMITIVE_COLUMN_RE.search(name)
+        if primitive_match:
+            index = int(primitive_match.group(1))
+            primitive_series[index] = list(map(float, values))
+            continue
+
+        object_match = OBJECT_COLUMN_RE.search(name)
+        if object_match:
+            index = int(object_match.group(1))
+            object_series[index] = list(map(float, values))
+            continue
+
+        remaining[name] = list(map(float, values))
+
+    return primitive_series, object_series, remaining
+
+
+def _probability_matrix(
+    primitive_series: PrimitiveSeries, frame_count: int
+) -> Optional[np.ndarray]:
+    if not primitive_series:
         return None
 
-
-def _infer_frame_index(data: Mapping[str, object], path: Path, fallback: int) -> int:
-    candidate = data.get("frame")
-    frame_index = _coerce_int(candidate)
-    if frame_index is not None:
-        return frame_index
-    match = re.search(r"(\d+)", path.stem)
-    if match:
-        try:
-            return int(match.group(1))
-        except ValueError:
-            pass
-    return fallback
-
-
-def _normalise_primitives(raw: Iterable[Mapping[str, object]]) -> List[PrimitiveRecord]:
-    primitives: List[PrimitiveRecord] = []
-    for entry in raw:
-        if not isinstance(entry, Mapping):
+    max_index = max(primitive_series)
+    matrix = np.full((frame_count, max_index + 1), np.nan, dtype=float)
+    for index, series in primitive_series.items():
+        if len(series) != frame_count:
             continue
-        index = _coerce_int(entry.get("index"))
-        if index is None or index < 0:
-            continue
-        hit_probability_raw = entry.get("hitProbability", 0.0)
-        try:
-            hit_probability = float(hit_probability_raw)
-        except (TypeError, ValueError):
-            hit_probability = 0.0
-        object_index = _coerce_int(entry.get("object"))
-        active = bool(entry.get("active", True))
-        primitives.append(
-            PrimitiveRecord(
-                index=index,
-                hit_probability=max(0.0, min(1.0, hit_probability)),
-                object_index=object_index,
-                active=active,
-            )
-        )
-    primitives.sort(key=lambda prim: prim.index)
-    return primitives
-
-
-def _load_frame_file(path: Path, fallback_frame_index: int) -> List[FrameRecord]:
-    with path.open("r", encoding="utf-8") as fh:
-        data = json.load(fh)
-    if isinstance(data, Mapping):
-        primitives_raw = data.get("primitives")
-        if not isinstance(primitives_raw, list):
-            raise ValueError(f"Dump file {path} is missing a 'primitives' array")
-        frame_index = _infer_frame_index(data, path, fallback_frame_index)
-        primitives = _normalise_primitives(primitives_raw)
-        return [FrameRecord(frame=frame_index, primitives=primitives)]
-    if isinstance(data, list):
-        frames: List[FrameRecord] = []
-        for idx, entry in enumerate(data):
-            if not isinstance(entry, Mapping):
-                continue
-            primitives_raw = entry.get("primitives")
-            if not isinstance(primitives_raw, list):
-                continue
-            frame_index = _coerce_int(entry.get("frame"))
-            if frame_index is None:
-                frame_index = fallback_frame_index + idx
-            frames.append(
-                FrameRecord(
-                    frame=frame_index,
-                    primitives=_normalise_primitives(primitives_raw),
-                )
-            )
-        if not frames:
-            raise ValueError(f"Dump file {path} does not contain valid frame entries")
-        return frames
-    raise ValueError(f"Unsupported JSON structure in dump file {path}")
-
-
-def load_frames(source: Path) -> List[FrameRecord]:
-    """Return sorted frame records from ``source`` (file or directory)."""
-
-    if source.is_file():
-        return _load_frame_file(source, 0)
-
-    if not source.exists():
-        raise FileNotFoundError(source)
-
-    json_paths = sorted(p for p in source.glob("*.json") if p.is_file())
-    if not json_paths:
-        raise FileNotFoundError(f"No JSON dumps found in {source}")
-
-    frames: List[FrameRecord] = []
-    for idx, path in enumerate(json_paths):
-        frames.extend(_load_frame_file(path, idx))
-
-    frames.sort(key=lambda frame: frame.frame)
-    return frames
-
-
-def probability_matrix(frames: Sequence[FrameRecord]) -> np.ndarray:
-    """Build a ``frame_count x primitive_count`` array of hit probabilities."""
-
-    if not frames:
-        raise ValueError("No frames available")
-
-    max_index = max((prim.index for frame in frames for prim in frame.primitives), default=-1)
-    if max_index < 0:
-        raise ValueError("Frames do not contain primitives")
-
-    matrix = np.full((len(frames), max_index + 1), np.nan, dtype=float)
-    for row, frame in enumerate(frames):
-        for prim in frame.primitives:
-            matrix[row, prim.index] = prim.hit_probability
+        matrix[:, index] = series
+    if np.isnan(matrix).all():
+        return None
     return matrix
 
 
-def aggregate_by_object(frames: Sequence[FrameRecord]) -> Dict[int, List[float]]:
-    """Return average hit probability per object for each frame."""
-
-    object_series: Dict[int, List[float]] = {}
-    for frame_idx, frame in enumerate(frames):
-        for series in object_series.values():
-            series.append(math.nan)
-
-        per_object: MutableMapping[int, List[float]] = defaultdict(list)
-        for prim in frame.primitives:
-            if prim.object_index is None:
-                continue
-            per_object[prim.object_index].append(prim.hit_probability)
-
-        for object_index, values in per_object.items():
-            mean_value = float(np.mean(values)) if values else math.nan
-            if object_index not in object_series:
-                object_series[object_index] = [math.nan] * frame_idx + [mean_value]
-            else:
-                object_series[object_index][-1] = mean_value
-    return object_series
-
-
-def plot_heatmap(matrix: np.ndarray, frames: Sequence[FrameRecord], output_dir: Path) -> Path:
-    frame_numbers = [frame.frame for frame in frames]
-    extent = [0, matrix.shape[1], frame_numbers[0], frame_numbers[-1] + 1]
+def plot_heatmap(
+    matrix: np.ndarray, frames: Sequence[int], output_dir: Path
+) -> Path:
+    extent = [0, matrix.shape[1], frames[0], frames[-1] + 1]
 
     plt.figure(figsize=(12, 6))
     img = plt.imshow(
@@ -247,18 +179,18 @@ def plot_heatmap(matrix: np.ndarray, frames: Sequence[FrameRecord], output_dir: 
 
 def plot_object_series(
     object_series: Mapping[int, Sequence[float]],
-    frames: Sequence[FrameRecord],
+    frames: Sequence[int],
     output_dir: Path,
     top_n: int,
 ) -> Optional[Path]:
     if not object_series:
         return None
 
-    frame_numbers = [frame.frame for frame in frames]
+    frame_numbers = list(frames)
     candidates = []
     for object_index, series in object_series.items():
         finite_values = [value for value in series if not math.isnan(value)]
-        if not finite_values:
+        if not finite_values or len(series) != len(frame_numbers):
             continue
         candidates.append((object_index, max(finite_values)))
 
@@ -287,13 +219,17 @@ def plot_object_series(
 
 
 def export_object_csv(
-    object_series: Mapping[int, Sequence[float]], frames: Sequence[FrameRecord], output_dir: Path
+    object_series: Mapping[int, Sequence[float]],
+    frames: Sequence[int],
+    output_dir: Path,
 ) -> Optional[Path]:
     if not object_series:
         return None
 
-    frame_numbers = [frame.frame for frame in frames]
+    frame_numbers = list(frames)
     object_indices = sorted(object_series)
+    if not object_indices:
+        return None
 
     output_path = output_dir / "object_hit_probability.csv"
     with output_path.open("w", encoding="utf-8", newline="") as fh:
@@ -310,11 +246,91 @@ def export_object_csv(
     return output_path
 
 
-def resolve_source_path(path: Path) -> Path:
-    if path.is_dir():
-        as_dir = path / "as"
-        return as_dir if as_dir.exists() else path
-    return path
+def plot_probability_trends(
+    frames: Sequence[int],
+    metrics: Mapping[str, Sequence[float]],
+    output_dir: Path,
+) -> Optional[Path]:
+    keys = [
+        ("avg_hit_probability", "Average"),
+        ("p95_hit_probability", "95th percentile"),
+        ("probability_threshold", "Threshold"),
+    ]
+    available = [
+        (name, label)
+        for name, label in keys
+        if name in metrics and len(metrics[name]) == len(frames)
+    ]
+
+    if not available:
+        return None
+
+    plt.figure(figsize=(12, 6))
+    for name, label in available:
+        plt.plot(frames, metrics[name], marker="o", label=label)
+
+    plt.xlabel("Frame")
+    plt.ylabel("Probability")
+    plt.title("Hit probability trends")
+    plt.grid(True, linestyle="--", alpha=0.4)
+    plt.legend(loc="best")
+    plt.ylim(0.0, 1.05)
+    plt.tight_layout()
+
+    output_path = output_dir / "hit_probability_trends.png"
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+    return output_path
+
+
+def plot_probabilistic_toggles(
+    frames: Sequence[int],
+    metrics: Mapping[str, Sequence[float]],
+    output_dir: Path,
+) -> Optional[Path]:
+    key = "probabilistic_toggles"
+    if key not in metrics or len(metrics[key]) != len(frames):
+        return None
+
+    plt.figure(figsize=(12, 4))
+    plt.plot(frames, metrics[key], marker="s", color="tab:orange")
+    plt.xlabel("Frame")
+    plt.ylabel("Toggles")
+    plt.title("Probabilistic residency toggles per frame")
+    plt.grid(True, linestyle="--", alpha=0.4)
+    plt.tight_layout()
+
+    output_path = output_dir / "probabilistic_toggles.png"
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+    return output_path
+
+
+def _resolve_csv(path: Path) -> Path:
+    if path.is_file():
+        if path.suffix.lower() != ".csv":
+            raise ValueError(f"Expected a CSV file, got: {path}")
+        return path
+
+    if not path.exists():
+        raise FileNotFoundError(path)
+
+    candidates = sorted(p for p in path.glob("*.csv") if p.is_file())
+    if not candidates:
+        raise FileNotFoundError(f"No CSV files found in {path}")
+
+    preferred = [p for p in candidates if "metrics" in p.stem]
+    if len(preferred) == 1:
+        return preferred[0]
+    if len(preferred) > 1:
+        raise ValueError(
+            "Multiple metrics CSV files found; please specify the desired file explicitly"
+        )
+    if len(candidates) > 1:
+        raise ValueError(
+            "Multiple CSV files found; please specify the desired file explicitly"
+        )
+    return candidates[0]
 
 
 def main() -> None:
@@ -323,13 +339,13 @@ def main() -> None:
         "path",
         type=Path,
         nargs="?",
-        help="Run directory or JSON dump path (defaults to METALAPT_BENCH)",
+        help="Benchmark CSV or directory (defaults to METALAPT_BENCH)",
     )
     parser.add_argument(
         "--output-dir",
         type=Path,
         default=None,
-        help="Directory where plots and CSV data will be written (defaults to the run directory)",
+        help="Directory where plots and CSV data will be written (defaults to the CSV directory)",
     )
     parser.add_argument(
         "--top-objects",
@@ -343,34 +359,57 @@ def main() -> None:
     env_default = os.getenv("METALAPT_BENCH")
     if args.path is None:
         if not env_default:
-            parser.error(
-                "Provide a run directory/JSON path or set METALAPT_BENCH."
-            )
+            parser.error("Provide a CSV path or set METALAPT_BENCH.")
         base_path = Path(env_default).resolve()
     else:
         base_path = args.path.resolve()
 
-    source = resolve_source_path(base_path)
-    frames = load_frames(source)
+    csv_path = _resolve_csv(base_path)
+    run_metrics = _load_csv(csv_path)
+    primitive_series, object_series, remaining_metrics = _partition_metrics(run_metrics.metrics)
 
-    output_dir = args.output_dir.resolve() if args.output_dir else source.parent
+    output_dir = args.output_dir.resolve() if args.output_dir else csv_path.parent
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    matrix = probability_matrix(frames)
-    heatmap_path = plot_heatmap(matrix, frames, output_dir)
+    outputs: Dict[str, Path] = {}
 
-    object_series = aggregate_by_object(frames)
-    object_plot_path = plot_object_series(object_series, frames, output_dir, args.top_objects)
-    csv_path = export_object_csv(object_series, frames, output_dir)
+    matrix = _probability_matrix(primitive_series, len(run_metrics.frames))
+    if matrix is not None:
+        outputs["heatmap"] = plot_heatmap(matrix, run_metrics.frames, output_dir)
+        print(f"Saved heatmap: {outputs['heatmap']}")
+    else:
+        print("No per-primitive probability columns found; skipping heatmap.")
 
-    print(f"Saved heatmap: {heatmap_path}")
+    object_plot_path = plot_object_series(
+        object_series, run_metrics.frames, output_dir, args.top_objects
+    )
     if object_plot_path:
+        outputs["object_plot"] = object_plot_path
         print(f"Saved object plot: {object_plot_path}")
     else:
-        print("No object indices present in the dumps; skipping object trend plot.")
-    if csv_path:
-        print(f"Saved object data: {csv_path}")
+        print("No object probability columns found; skipping object trend plot.")
+
+    csv_output = export_object_csv(object_series, run_metrics.frames, output_dir)
+    if csv_output:
+        outputs["object_csv"] = csv_output
+        print(f"Saved object data: {csv_output}")
+
+    trend_path = plot_probability_trends(run_metrics.frames, remaining_metrics, output_dir)
+    if trend_path:
+        outputs["probability_trends"] = trend_path
+        print(f"Saved probability trends: {trend_path}")
+
+    toggles_path = plot_probabilistic_toggles(run_metrics.frames, remaining_metrics, output_dir)
+    if toggles_path:
+        outputs["probabilistic_toggles"] = toggles_path
+        print(f"Saved probabilistic toggles: {toggles_path}")
+
+    if not outputs:
+        raise SystemExit(
+            "No residency metrics were discovered in the CSV; ensure the log contains probability columns"
+        )
 
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- rewrite analyze_residency_dump.py to consume residency metrics from benchmark CSV logs instead of JSON frame dumps
- auto-detect primitive and object probability series to generate heatmaps, trend plots, and CSV exports when the relevant columns exist
- add aggregated probability and toggle plots derived from avg_hit_probability, p95_hit_probability, probability_threshold, and probabilistic_toggles metrics

## Testing
- python -m compileall analyze_residency_dump.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69134d899b90832d965e724117a448ca)