### PR TITLE
Add probabilistic residency logging and visualization

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1253,7 +1253,8 @@ void Renderer::writeBenchmarkHeader() {
          "active_triangles,resident_triangles,total_triangles,active_nodes,"
          "resident_nodes,total_nodes,active_objects,resident_objects,"
          "avg_hit_probability,p95_hit_probability,probability_threshold,"
-         "probabilistic_toggles,gpu_memory_mb,scratch_memory_mb,"
+         "primitive_probabilities,object_probabilities,probabilistic_toggles,"
+         "gpu_memory_mb,scratch_memory_mb,"
          "residency_memory_mb,texture_memory_cap_mb,"
          "over_memory_cap,residency_compacted,"
          "accumulation_reset,ray_hit_decay,state_cooldown_frames,lod_toggle_budget,"
@@ -1273,6 +1274,16 @@ static std::string formatFixed(double value, int precision) {
   return ss.str();
 }
 
+static void appendCsvEscaped(std::ostringstream &ss, const std::string &value) {
+  ss << '"';
+  for (char c : value) {
+    if (c == '"')
+      ss << '"';
+    ss << c;
+  }
+  ss << '"';
+}
+
 void Renderer::writeBenchmarkRow(const BenchmarkSample &sample) {
   if (!_benchmarkStream.is_open())
     return;
@@ -1283,8 +1294,9 @@ void Renderer::writeBenchmarkRow(const BenchmarkSample &sample) {
   row << sample.frameIndex << ',' << formatFixed(sample.wallSeconds, 6) << ','
       << formatFixed(sample.cpuTimeSeconds * 1000.0, 3) << ','
       << formatFixed(sample.gpuTimeSeconds * 1000.0, 3) << ','
-      << formatFixed(sample.raysPerSecond, 2) << ',' << sample.rayCount << ','
-      << '"' << sample.strategyName << "\"," << static_cast<int>(sample.strategy)
+      << formatFixed(sample.raysPerSecond, 2) << ',' << sample.rayCount << ',';
+  appendCsvEscaped(row, sample.strategyName);
+  row << ',' << static_cast<int>(sample.strategy)
       << ',' << formatFixed(sample.deltaTimeSeconds, 6) << ','
       << sample.minSamplesPerPixel << ',' << sample.maxSamplesPerPixel << ','
       << sample.primitiveActivations << ',' << sample.primitiveDeactivations << ','
@@ -1297,7 +1309,11 @@ void Renderer::writeBenchmarkRow(const BenchmarkSample &sample) {
       << sample.residentObjectCount << ','
       << formatFixed(sample.avgHitProbability, 6) << ','
       << formatFixed(sample.p95HitProbability, 6) << ','
-      << formatFixed(sample.probabilityThreshold, 3) << ','
+      << formatFixed(sample.probabilityThreshold, 3) << ',';
+  appendCsvEscaped(row, sample.primitiveProbabilities);
+  row << ',';
+  appendCsvEscaped(row, sample.objectProbabilities);
+  row << ','
       << sample.probabilisticToggles << ','
       << formatFixed(sample.gpuMemoryMB, 3) << ','
       << formatFixed(sample.scratchMemoryMB, 3) << ','
@@ -8484,15 +8500,67 @@ void Renderer::beginFrameMetrics() {
     sample.p95HitProbability = 0.0;
     sample.probabilityThreshold = _residencyConfig.probabilityThreshold;
     if (!_primitiveHitProbability.empty()) {
+      size_t primitiveCount =
+          std::min(_primitiveHitProbability.size(), _allPrimitives.size());
       std::vector<float> validProbabilities;
-      validProbabilities.reserve(_primitiveHitProbability.size());
+      validProbabilities.reserve(primitiveCount);
       double probabilitySum = 0.0;
-      for (float probability : _primitiveHitProbability) {
-        if (!std::isfinite(probability))
-          continue;
-        probabilitySum += probability;
-        validProbabilities.push_back(probability);
+      std::ostringstream primitiveStream;
+      bool firstPrimitive = true;
+
+      std::vector<double> objectProbabilitySums(_allSceneObjects.size(), 0.0);
+      std::vector<size_t> objectProbabilityCounts(_allSceneObjects.size(), 0);
+
+      for (size_t index = 0; index < primitiveCount; ++index) {
+        float probability = _primitiveHitProbability[index];
+        bool probabilityFinite = std::isfinite(probability);
+        float sanitized = probabilityFinite
+                               ? std::clamp(probability, 0.0f, 1.0f)
+                               : 0.0f;
+
+        if (!firstPrimitive)
+          primitiveStream << ';';
+        primitiveStream << index << ':'
+                        << formatFixed(static_cast<double>(sanitized), 6);
+        firstPrimitive = false;
+
+        if (probabilityFinite) {
+          probabilitySum += sanitized;
+          validProbabilities.push_back(sanitized);
+        }
+
+        if (index < _primitiveToObject.size()) {
+          size_t objectIndex = _primitiveToObject[index];
+          if (objectIndex < objectProbabilitySums.size()) {
+            objectProbabilitySums[objectIndex] += static_cast<double>(sanitized);
+            objectProbabilityCounts[objectIndex] += 1;
+          }
+        }
       }
+
+      sample.primitiveProbabilities = primitiveStream.str();
+
+      if (!_allSceneObjects.empty()) {
+        std::ostringstream objectStream;
+        bool firstObject = true;
+        for (size_t objectIndex = 0; objectIndex < _allSceneObjects.size();
+             ++objectIndex) {
+          double avgProbability = 0.0;
+          if (objectIndex < objectProbabilitySums.size() &&
+              objectProbabilityCounts[objectIndex] > 0) {
+            avgProbability = objectProbabilitySums[objectIndex] /
+                              static_cast<double>(
+                                  objectProbabilityCounts[objectIndex]);
+          }
+          if (!firstObject)
+            objectStream << ';';
+          objectStream << objectIndex << ':'
+                       << formatFixed(avgProbability, 6);
+          firstObject = false;
+        }
+        sample.objectProbabilities = objectStream.str();
+      }
+
       if (!validProbabilities.empty()) {
         sample.avgHitProbability =
             probabilitySum / static_cast<double>(validProbabilities.size());
@@ -8505,6 +8573,17 @@ void Renderer::beginFrameMetrics() {
                          validProbabilities.end());
         sample.p95HitProbability = validProbabilities[percentileIndex];
       }
+    } else if (!_allSceneObjects.empty()) {
+      std::ostringstream objectStream;
+      bool firstObject = true;
+      for (size_t objectIndex = 0; objectIndex < _allSceneObjects.size();
+           ++objectIndex) {
+        if (!firstObject)
+          objectStream << ';';
+        objectStream << objectIndex << ':' << formatFixed(0.0, 6);
+        firstObject = false;
+      }
+      sample.objectProbabilities = objectStream.str();
     }
     sample.probabilisticToggles = _frameProbabilisticToggles;
     sample.deltaTimeSeconds = _deltaTimeSeconds;

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -368,6 +368,8 @@ private:
     double avgHitProbability = 0.0;
     double p95HitProbability = 0.0;
     double probabilityThreshold = 0.0;
+    std::string primitiveProbabilities;
+    std::string objectProbabilities;
     size_t probabilisticToggles = 0;
     ResidencyStrategy strategy = ResidencyStrategy::DistanceLOD;
     std::string strategyName;

--- a/visualize_probabilities.py
+++ b/visualize_probabilities.py
@@ -1,0 +1,255 @@
+"""Visualize probabilistic residency metrics recorded in benchmark CSV files."""
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import matplotlib.pyplot as plt
+
+FrameProbabilities = Dict[int, float]
+ProbabilityFrames = List[FrameProbabilities]
+Totals = Dict[int, float]
+Counts = Dict[int, int]
+
+
+def _parse_probability_column(value: Optional[str]) -> FrameProbabilities:
+    """Parse a probability column into ``index -> probability`` mappings."""
+
+    if not value:
+        return {}
+
+    result: FrameProbabilities = {}
+    entries = value.split(";")
+    for entry in entries:
+        entry = entry.strip()
+        if not entry or ":" not in entry:
+            continue
+        index_part, probability_part = entry.split(":", 1)
+        try:
+            index = int(index_part.strip())
+            probability = float(probability_part.strip())
+        except ValueError:
+            continue
+        result[index] = probability
+    return result
+
+
+def _load_probability_data(
+    path: Path,
+) -> Tuple[
+    List[int],
+    ProbabilityFrames,
+    ProbabilityFrames,
+    str,
+    Totals,
+    Counts,
+    Totals,
+    Counts,
+]:
+    frames: List[int] = []
+    primitive_frames: ProbabilityFrames = []
+    object_frames: ProbabilityFrames = []
+    strategy = ""
+
+    primitive_totals: Totals = {}
+    primitive_counts: Counts = {}
+    object_totals: Totals = {}
+    object_counts: Counts = {}
+
+    with path.open("r", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            raise ValueError(f"CSV file has no header: {path}")
+
+        for row in reader:
+            frame_value = row.get("frame")
+            if frame_value is None or frame_value == "":
+                raise ValueError(f"Missing 'frame' value in {path}")
+            frames.append(int(float(frame_value)))
+
+            if not strategy:
+                strategy = row.get("strategy", "") or ""
+
+            primitive_probs = _parse_probability_column(
+                row.get("primitive_probabilities")
+            )
+            object_probs = _parse_probability_column(row.get("object_probabilities"))
+
+            primitive_frames.append(primitive_probs)
+            object_frames.append(object_probs)
+
+            for index, probability in primitive_probs.items():
+                primitive_totals[index] = primitive_totals.get(index, 0.0) + probability
+                primitive_counts[index] = primitive_counts.get(index, 0) + 1
+
+            for index, probability in object_probs.items():
+                object_totals[index] = object_totals.get(index, 0.0) + probability
+                object_counts[index] = object_counts.get(index, 0) + 1
+
+    return (
+        frames,
+        primitive_frames,
+        object_frames,
+        strategy,
+        primitive_totals,
+        primitive_counts,
+        object_totals,
+        object_counts,
+    )
+
+
+def _average_probabilities(totals: Totals, counts: Counts) -> Dict[int, float]:
+    return {
+        index: totals[index] / counts[index]
+        for index in totals
+        if counts.get(index, 0) > 0
+    }
+
+
+def _select_indices(
+    explicit: Optional[Sequence[int]],
+    top_count: Optional[int],
+    totals: Totals,
+    counts: Counts,
+    default_top: int,
+) -> List[int]:
+    if explicit:
+        unique = sorted({int(value) for value in explicit})
+        return unique
+
+    averages = _average_probabilities(totals, counts)
+    if not averages:
+        return []
+
+    if top_count is None:
+        top_count = default_top
+    top_count = max(int(top_count), 0)
+    if top_count == 0:
+        return []
+
+    sorted_indices = sorted(averages.items(), key=lambda item: item[1], reverse=True)
+    return [index for index, _ in sorted_indices[:top_count]]
+
+
+def _build_series(
+    frames: ProbabilityFrames, indices: Iterable[int]
+) -> Dict[int, List[float]]:
+    series: Dict[int, List[float]] = {index: [] for index in indices}
+    for frame_data in frames:
+        for index in series:
+            series[index].append(frame_data.get(index, math.nan))
+    return series
+
+
+def _safe_name(name: str) -> str:
+    return "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in name)
+
+
+def _plot_series(
+    frames: List[int],
+    series: Dict[int, List[float]],
+    output_dir: Path,
+    prefix: str,
+    strategy: str,
+) -> None:
+    if not series:
+        return
+
+    for index, values in series.items():
+        plt.figure(figsize=(10, 6))
+        plt.plot(frames, values, marker="o")
+        plt.xlabel("Frame")
+        plt.ylabel("Probability")
+        plt.ylim(0.0, 1.0)
+        title = f"{prefix.title()} {index} probability"
+        if strategy:
+            title += f" ({strategy})"
+        plt.title(title)
+        plt.grid(True, linestyle="--", alpha=0.5)
+        plt.tight_layout()
+        filename = f"{_safe_name(prefix)}_{index}.png"
+        output_path = output_dir / filename
+        plt.savefig(output_path, dpi=150)
+        plt.close()
+        print(f"Saved {prefix} {index} plot to {output_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("csv", type=Path, help="Metrics CSV file produced by the renderer")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory for the generated plots (defaults to the CSV directory)",
+    )
+    parser.add_argument(
+        "--primitives",
+        type=int,
+        nargs="*",
+        help="Specific primitive indices to plot (defaults to top entries by average probability)",
+    )
+    parser.add_argument(
+        "--top-primitives",
+        type=int,
+        default=None,
+        help="Number of primitives with the highest average probability to plot",
+    )
+    parser.add_argument(
+        "--objects",
+        type=int,
+        nargs="*",
+        help="Specific object indices to plot (defaults to top entries by average probability)",
+    )
+    parser.add_argument(
+        "--top-objects",
+        type=int,
+        default=None,
+        help="Number of objects with the highest average probability to plot",
+    )
+
+    args = parser.parse_args()
+
+    csv_path: Path = args.csv.resolve()
+    if not csv_path.is_file():
+        raise FileNotFoundError(f"CSV path is not a file: {csv_path}")
+
+    (
+        frames,
+        primitive_frames,
+        object_frames,
+        strategy,
+        primitive_totals,
+        primitive_counts,
+        object_totals,
+        object_counts,
+    ) = _load_probability_data(csv_path)
+
+    output_dir = args.output_dir.resolve() if args.output_dir else csv_path.parent
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    primitive_indices = _select_indices(
+        args.primitives, args.top_primitives, primitive_totals, primitive_counts, default_top=5
+    )
+    object_indices = _select_indices(
+        args.objects, args.top_objects, object_totals, object_counts, default_top=5
+    )
+
+    if primitive_indices:
+        primitive_series = _build_series(primitive_frames, primitive_indices)
+        _plot_series(frames, primitive_series, output_dir, "primitive", strategy)
+    else:
+        print("No primitive probability data available to plot.")
+
+    if object_indices:
+        object_series = _build_series(object_frames, object_indices)
+        _plot_series(frames, object_series, output_dir, "object", strategy)
+    else:
+        print("No object probability data available to plot.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- capture per-primitive and per-object probability snapshots in benchmark CSV output when METALAPT_BENCH is enabled
- escape CSV text fields and aggregate object probability data for logging
- add a matplotlib-based visualize_probabilities.py helper to plot logged probabilities

## Testing
- python -m compileall visualize_probabilities.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69135164af18832db80cef20f6f8d67b)