### PR TITLE
Handle large CSV probability fields

### DIFF
--- a/visualize_probabilities.py
+++ b/visualize_probabilities.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import csv
 import math
+import sys
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
@@ -60,6 +61,7 @@ def _load_probability_data(
     object_counts: Counts = {}
 
     with path.open("r", encoding="utf-8") as handle:
+        csv.field_size_limit(sys.maxsize)
         reader = csv.DictReader(handle)
         if reader.fieldnames is None:
             raise ValueError(f"CSV file has no header: {path}")


### PR DESCRIPTION
## Summary
- import sys in visualize_probabilities to configure CSV limits
- raise the CSV field size limit before parsing so large probability columns are accepted

## Testing
- python visualize_probabilities.py large_metrics.csv *(fails: missing matplotlib dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69135bc9bf3c832d86d4c193b9cb319f)