### PR TITLE
Bind primitive stats buffers for acceleration layout

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -6131,6 +6131,8 @@ void Renderer::draw(MTK::View *pView) {
         pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 8);
         pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 9);
         pCompute->setBuffer(_pInstanceBuffer, 0, 10);
+        pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
+        pCompute->setBuffer(_pInstanceBuffer, 0, 13);
       } else {
         pCompute->setBuffer(_pBVHBuffer, 0, 0);
         pCompute->setBuffer(_pSphereBuffer, 0, 1);


### PR DESCRIPTION
## Summary
- bind the primitive ray stats and instance buffers when using the acceleration-structure resource layout so they remain available to the path tracer

## Testing
- not run (requires macOS/Metal tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913602464f8832d9e2abe647ab46f2f)