### PR TITLE
Add probabilistic residency strategy configuration

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1354,6 +1354,8 @@ std::string Renderer::residencyStrategyName(ResidencyStrategy strategy) const {
     return "Ray-hit budget";
   case ResidencyStrategy::ScreenSpaceFootprint:
     return "Screen-space footprint";
+  case ResidencyStrategy::Probabilistic:
+    return "Probabilistic";
   case ResidencyStrategy::AlwaysResident:
     return "Always resident";
   case ResidencyStrategy::DistanceLOD:
@@ -8455,6 +8457,7 @@ void Renderer::processRayHitCounters() {
   float rayHitDecay = _residencyConfig.rayHitDecay;
   float probabilityDecay = _residencyConfig.probabilityDecay;
   float probabilityThreshold = _residencyConfig.probabilityThreshold;
+  constexpr float kMinPosteriorMass = 1.0e-3f;
 
   parallelChunkedAsync(0, count, [&](size_t chunkStart, size_t chunkEnd) {
     for (size_t i = chunkStart; i < chunkEnd; ++i) {
@@ -8486,7 +8489,6 @@ void Renderer::processRayHitCounters() {
         // pseudo-count mass so the distribution never fully collapses.
         float cooledProbability =
             std::clamp(probability * probabilityDecay, 0.0f, 1.0f);
-        constexpr float kMinPosteriorMass = 1.0e-3f;
         float cooledMass = std::max(sum, kMinPosteriorMass);
         alpha = cooledProbability * cooledMass;
         beta = std::max(cooledMass - alpha, 0.0f);
@@ -8512,6 +8514,41 @@ void Renderer::processRayHitCounters() {
       hitPtr[base + 1] = 0;
     }
   });
+
+  if (count < totalPrimitiveCount) {
+    parallelChunkedAsync(count, totalPrimitiveCount,
+                         [&](size_t chunkStart, size_t chunkEnd) {
+                           for (size_t i = chunkStart; i < chunkEnd; ++i) {
+                             _primitiveHitScores[i] *= rayHitDecay;
+                             _primitiveRayContributions[i] *= rayHitDecay;
+                             _primitiveHitLastFrame[i] = 0;
+                             _primitiveRaysTestedLastFrame[i] = 0;
+
+                             float alpha = _primitiveHitAlpha[i] * probabilityDecay;
+                             float beta = _primitiveHitBeta[i] * probabilityDecay;
+                             float sum = alpha + beta;
+                             float probability =
+                                 (sum > 0.0f) ? (alpha / sum) : 0.5f;
+                             float cooledProbability =
+                                 std::clamp(probability * probabilityDecay, 0.0f, 1.0f);
+                             float cooledMass = std::max(sum, kMinPosteriorMass);
+                             alpha = cooledProbability * cooledMass;
+                             beta = std::max(cooledMass - alpha, 0.0f);
+                             float updatedSum = alpha + beta;
+                             float updatedProbability =
+                                 (updatedSum > 0.0f) ? (alpha / updatedSum) : 0.5f;
+                             _primitiveHitAlpha[i] = alpha;
+                             _primitiveHitBeta[i] = beta;
+                             _primitiveHitProbability[i] =
+                                 std::clamp(updatedProbability, 0.0f, 1.0f);
+
+                             float exploration =
+                                 _primitiveExplorationScore[i] * probabilityDecay;
+                             exploration *= rayHitDecay;
+                             _primitiveExplorationScore[i] = exploration;
+                           }
+                         });
+  }
 }
 
 void Renderer::trackFrameCommandBuffer(MTL::CommandBuffer *commandBuffer) {

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -17,7 +17,8 @@ enum class ResidencyStrategy {
   EnergyImportance = 1,
   RayHitBudget = 2,
   ScreenSpaceFootprint = 3,
-  AlwaysResident = 4,
+  Probabilistic = 4,
+  AlwaysResident = 5,
 };
 
 struct SceneObject {
@@ -50,6 +51,11 @@ struct ResidencyParameters {
   size_t rayHitMinActivePrimitives = 16;
   size_t rayHitMaxTogglesPerFrame = 12;
   uint32_t rayHitRebuildCooldownFrames = 6;
+
+  float probabilityDecay = 0.9f;
+  float probabilityThreshold = 0.5f;
+  size_t probabilityMinActivePrimitives = 16;
+  size_t probabilityMaxTogglesPerFrame = 16;
 
   float screenFootprintTargetFraction = 0.65f;
   float screenFootprintMinPixelCoverage = 32.0f;

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -621,6 +621,10 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
                    value == "screen_space_footprint" || value == "footprint" ||
                    value == "screenspace") {
             scene->setResidencyStrategy(ResidencyStrategy::ScreenSpaceFootprint);
+        } else if (value == "probabilistic" || value == "probability" ||
+                   value == "probabilistic_residency" ||
+                   value == "probability_residency") {
+            scene->setResidencyStrategy(ResidencyStrategy::Probabilistic);
         } else if (value == "alwaysresident" || value == "always_resident" ||
                    value == "always" || value == "none" || value == "off") {
             scene->setResidencyStrategy(ResidencyStrategy::AlwaysResident);
@@ -661,6 +665,17 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         "rayHitToggleBudget", static_cast<uint64_t>(params.rayHitMaxTogglesPerFrame)));
     params.rayHitRebuildCooldownFrames = root->UnsignedAttribute(
         "rayHitCooldown", params.rayHitRebuildCooldownFrames);
+
+    params.probabilityDecay =
+        root->FloatAttribute("probabilityDecay", params.probabilityDecay);
+    params.probabilityThreshold = root->FloatAttribute(
+        "probabilityThreshold", params.probabilityThreshold);
+    params.probabilityMinActivePrimitives = static_cast<size_t>(root->Unsigned64Attribute(
+        "probabilityMinActive",
+        static_cast<uint64_t>(params.probabilityMinActivePrimitives)));
+    params.probabilityMaxTogglesPerFrame = static_cast<size_t>(root->Unsigned64Attribute(
+        "probabilityToggleBudget",
+        static_cast<uint64_t>(params.probabilityMaxTogglesPerFrame)));
 
     params.screenFootprintTargetFraction = root->FloatAttribute(
         "screenTargetFraction", params.screenFootprintTargetFraction);


### PR DESCRIPTION
## Summary
- add a probabilistic residency strategy option and defaults to the scene configuration
- parse probabilistic streaming parameters from scene XML and expose the new strategy name in renderer diagnostics
- continue decaying hit probabilities for primitives that are currently offloaded so they can be reconsidered for residency

## Testing
- not run (Metal toolchain unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691367826ce4832d9377ca10f36ad8cb)