### PR TITLE
Update node counter recalculation to use GPU residency mask

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -4867,6 +4867,22 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   _needsAccumulationReset = true;
 }
 
+std::vector<bool> Renderer::buildResidentMaskFromGpuResources() const {
+  std::vector<bool> residentMask;
+  if (_residentObjectGpuResources.empty())
+    return residentMask;
+
+  size_t objectCount =
+      std::max(_residentObjectGpuResources.size(), _objectResidentState.size());
+  residentMask.assign(objectCount, false);
+  for (size_t objectIndex = 0; objectIndex < _residentObjectGpuResources.size();
+       ++objectIndex) {
+    residentMask[objectIndex] =
+        _residentObjectGpuResources[objectIndex].isResident();
+  }
+  return residentMask;
+}
+
 void Renderer::recalculateNodeCounters(
     const std::vector<bool> &residentMask) {
   bool hasBlasData =
@@ -9536,8 +9552,14 @@ void Renderer::completeFrameMetrics(MTL::CommandBuffer *pCmd) {
       (_blasNodeCount > 0 && _cachedBVHNodes.size() >= _blasNodeCount * 2) ||
       (_tlasNodeCount > 0 && _cachedTLASNodes.size() >= _tlasNodeCount * 2) ||
       (_residentCompacted && (_blasNodeCount > 0 || _tlasNodeCount > 0));
-  if (canRecalculateNodes)
-    recalculateNodeCounters(_objectResidentState);
+  if (canRecalculateNodes) {
+    if (_residentObjectGpuResources.empty()) {
+      recalculateNodeCounters(_objectResidentState);
+    } else {
+      auto gpuResidentMask = buildResidentMaskFromGpuResources();
+      recalculateNodeCounters(gpuResidentMask);
+    }
+  }
 
   size_t offloaded = _totalNodeCount > _residentNodeCount ?
                          _totalNodeCount - _residentNodeCount :

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -158,6 +158,7 @@ private:
   void flushResidencyChanges(bool forceFullRebuild);
   void beginFrameMetrics();
   void completeFrameMetrics(MTL::CommandBuffer *pCmd);
+  std::vector<bool> buildResidentMaskFromGpuResources() const;
   void trackFrameCommandBuffer(MTL::CommandBuffer *commandBuffer);
   bool waitForPendingFrameCommands(
       std::chrono::milliseconds timeout,


### PR DESCRIPTION
## Summary
- add a helper on `Renderer` to derive a resident mask straight from `_residentObjectGpuResources`
- use the helper in `completeFrameMetrics` to feed live GPU residency into `recalculateNodeCounters`, falling back to the CPU mask when no GPU data exists

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b0c187b98832db7de435840a07041)