### PR TITLE
Add environment hit residency strategy placeholder

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1387,6 +1387,8 @@ std::string Renderer::residencyStrategyName(ResidencyStrategy strategy) const {
     return "Screen-space footprint";
   case ResidencyStrategy::Probabilistic:
     return "Probabilistic";
+  case ResidencyStrategy::EnvironmentHit:
+    return "Environment hit";
   case ResidencyStrategy::AlwaysResident:
     return "Always resident";
   case ResidencyStrategy::DistanceLOD:
@@ -2209,6 +2211,9 @@ void Renderer::updateVisibleScene() {
     break;
   case ResidencyStrategy::ScreenSpaceFootprint:
     strategyName = "Screen-space footprint";
+    break;
+  case ResidencyStrategy::EnvironmentHit:
+    strategyName = "Environment hit";
     break;
   case ResidencyStrategy::AlwaysResident:
     strategyName = "Always resident";
@@ -6627,6 +6632,9 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   case ResidencyStrategy::ScreenSpaceFootprint:
     changed = updateScreenSpaceFootprint(forceAllToggles);
     break;
+  case ResidencyStrategy::EnvironmentHit:
+    changed = updateEnvironmentHit(forceAllToggles);
+    break;
   case ResidencyStrategy::AlwaysResident:
     changed = updateAlwaysResident(forceAllToggles);
     break;
@@ -8697,6 +8705,13 @@ bool Renderer::updateScreenSpaceFootprint(bool forceAllToggles) {
   return changed;
 }
 
+bool Renderer::updateEnvironmentHit(bool forceAllToggles) {
+  // Placeholder until the environment-hit strategy is implemented.
+  // Fall back to distance-based heuristics so the renderer continues to
+  // activate content when the strategy is selected.
+  return updateLODByDistance(forceAllToggles);
+}
+
 // Propagate any pending primitive/object toggles to GPU memory.  The method
 // skips expensive repacks if nothing changed, otherwise it forwards to
 // rebuildResidentResources to patch only the dirty ranges (or rebuild
@@ -8987,7 +9002,8 @@ void Renderer::processRayHitCounters() {
               : ResidencyStrategy::DistanceLOD;
   bool strategyUsesHits =
       strategy == ResidencyStrategy::RayHitBudget ||
-      strategy == ResidencyStrategy::Probabilistic;
+      strategy == ResidencyStrategy::Probabilistic ||
+      strategy == ResidencyStrategy::EnvironmentHit;
   if (!strategyUsesHits) {
     std::memset(hitPtr, 0, bufferLength);
     _primitiveHitScores.clear();

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -155,6 +155,7 @@ private:
   bool updateProbabilisticResidency(bool forceAllToggles);
   void resetProbabilisticResidencyState();
   bool updateScreenSpaceFootprint(bool forceAllToggles);
+  bool updateEnvironmentHit(bool forceAllToggles);
   bool updateAlwaysResident(bool forceAllToggles);
   void flushResidencyChanges(bool forceFullRebuild);
   void beginFrameMetrics();

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -19,6 +19,7 @@ enum class ResidencyStrategy {
   ScreenSpaceFootprint = 3,
   Probabilistic = 4,
   AlwaysResident = 5,
+  EnvironmentHit = 6,
 };
 
 struct SceneObject {

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -628,6 +628,10 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         } else if (value == "alwaysresident" || value == "always_resident" ||
                    value == "always" || value == "none" || value == "off") {
             scene->setResidencyStrategy(ResidencyStrategy::AlwaysResident);
+        } else if (value == "environment" || value == "environmenthit" ||
+                   value == "environment_hit" || value == "envhit" ||
+                   value == "env_hit" || value == "env") {
+            scene->setResidencyStrategy(ResidencyStrategy::EnvironmentHit);
         } else {
             printf("Unknown residency strategy '%s', defaulting to distance LOD.\n",
                    residencyAttr);


### PR DESCRIPTION
## Summary
- add a new `ResidencyStrategy::EnvironmentHit` enumerant and extend the XML loader to recognize "environment"/"envhit" style aliases
- update renderer logging/residency switches so the new strategy name propagates to logs/benchmarks and dispatches through a placeholder `updateEnvironmentHit` path
- treat the new strategy as hit-driven so the hit counter buffers remain valid until the actual environment-hit heuristic lands

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d9b206b88832d82f616077c647a88)