### PR TITLE
Add environment-hit residency tuning controls

### DIFF
--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -20,6 +20,32 @@ Benchmark exports now include stochastic residency metrics alongside the existin
 
 These columns complement the existing residency memory statistics in `*_memory_mb` and allow the plotting tools to chart probability-driven residency behavior when comparing runs.
 
+## Environment-hit scene attributes
+
+Scenes that opt into the `environment` residency strategy can now tune how aggressively the renderer combats environment-map leaks. The `<Scene>` root accepts the following optional attributes:
+
+- `envTargetFraction` – fraction of total primitives that should remain active, even when the escape rate is low. Acts as a soft floor before the escape threshold kicks in. Defaults to `0.0` to preserve the previous "escape only" behavior.
+- `envEscapeThreshold` – maximum allowed average escape probability across the active set. Lower values keep more geometry resident to occlude environment rays.
+- `envMinActive` – minimum number of primitives that stay active regardless of the fraction/escape targets. Aliased to the older `environmentMinActive` attribute.
+- `envToggleBudget` – maximum number of primitives the environment strategy can flip per frame (`environmentToggleBudget` is still accepted).
+- `envDepthRadii` / `envDepthWeights` – comma-separated lists that bias which objects are prioritized. Each radius entry (world-space distance from the camera) pairs with a weight multiplier at the same index. Objects whose bounding-sphere centers fall within a radius use the corresponding weight when ranking environment leaks. When omitted, objects are ranked purely by their measured hit probability.
+
+All legacy `environment*` attribute names continue to work, and any `env*` overrides take precedence when both are present. Example configuration:
+
+```xml
+<Scene residencyStrategy="environment"
+       envTargetFraction="0.25"
+       envEscapeThreshold="0.35"
+       envMinActive="48"
+       envToggleBudget="96"
+       envDepthRadii="15,30,45"
+       envDepthWeights="1.5,1.0,0.5">
+    ...
+</Scene>
+```
+
+This snippet keeps at least 25% of the scene active, clamps the escape rate to 35%, and prioritizes geometry within 15 units of the camera 1.5× higher than distant occluders.
+
 ## Comparing EXR captures
 
 Use `compare_exr_ssim.cpp` to quantify the visual difference between two EXR frames with the Structural Similarity Index (SSIM). Build the tool with a C++17 compiler:

--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1294,8 +1294,9 @@ void Renderer::writeBenchmarkHeader() {
          "lod_enter_distance,lod_exit_distance,lod_enter_view_margin,"
          "lod_exit_view_margin,energy_target_fraction,"
          "energy_min_active,energy_visibility_boost,screen_target_fraction,"
-         "screen_min_pixels,screen_min_active,environment_target_escape,"
-         "environment_min_active,environment_toggle_budget";
+         "screen_min_pixels,screen_min_active,environment_target_fraction,"
+         "environment_escape_threshold,environment_min_active,environment_toggle_budget,"
+         "environment_depth_weights,environment_depth_radii";
   _benchmarkStream << '\n';
   _benchmarkHeaderWritten = true;
 }
@@ -1303,6 +1304,20 @@ void Renderer::writeBenchmarkHeader() {
 static std::string formatFixed(double value, int precision) {
   std::ostringstream ss;
   ss << std::fixed << std::setprecision(precision) << value;
+  return ss.str();
+}
+
+static std::string formatFloatList(const std::vector<float> &values,
+                                   int precision = 3) {
+  if (values.empty())
+    return "";
+
+  std::ostringstream ss;
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i > 0)
+      ss << '|';
+    ss << formatFixed(values[i], precision);
+  }
   return ss.str();
 }
 
@@ -1373,9 +1388,13 @@ void Renderer::writeBenchmarkRow(const BenchmarkSample &sample) {
       << formatFixed(_residencyConfig.screenFootprintTargetFraction, 3) << ','
       << formatFixed(_residencyConfig.screenFootprintMinPixelCoverage, 3) << ','
       << _residencyConfig.screenFootprintMinActivePrimitives << ','
-      << formatFixed(_residencyConfig.environmentTargetEscapeFraction, 3) << ','
+      << formatFixed(sample.environmentTargetActiveFraction, 3) << ','
+      << formatFixed(sample.environmentEscapeThreshold, 3) << ','
       << _residencyConfig.environmentMinActivePrimitives << ','
-      << _residencyConfig.environmentMaxTogglesPerFrame;
+      << _residencyConfig.environmentMaxTogglesPerFrame << ',';
+  appendCsvEscaped(row, sample.environmentDepthWeights);
+  row << ',';
+  appendCsvEscaped(row, sample.environmentDepthRadii);
 
   _benchmarkStream << row.str() << '\n';
   _benchmarkStream.flush();
@@ -8727,6 +8746,34 @@ bool Renderer::updateEnvironmentHitResidency(bool forceAllToggles) {
     std::fill(_objectImportance.begin(), _objectImportance.end(), 0.0f);
 
   std::vector<uint8_t> desiredObjectState(objectCount, 0);
+  std::vector<float> weightedImportance(objectCount, 0.0f);
+
+  auto computeDepthWeight = [&](size_t objectIndex) -> float {
+    const auto &weights = _residencyConfig.environmentDepthWeights;
+    if (weights.empty())
+      return 1.0f;
+    float fallbackWeight = weights.back();
+    const auto &radii = _residencyConfig.environmentDepthRadii;
+    if (radii.empty())
+      return fallbackWeight;
+    if (objectIndex >= _objectBounds.size())
+      return fallbackWeight;
+
+    simd::float3 toCenter = _objectBounds[objectIndex].center - Camera::position;
+    float distance = simd::length(toCenter);
+    if (!(distance > 0.0f))
+      return weights.front();
+
+    size_t pairCount = std::min(weights.size(), radii.size());
+    for (size_t i = 0; i < pairCount; ++i) {
+      float radius = radii[i];
+      if (!(radius > 0.0f))
+        continue;
+      if (distance <= radius)
+        return weights[i];
+    }
+    return fallbackWeight;
+  };
 
   for (size_t objectIndex = 0; objectIndex < objectCount; ++objectIndex) {
     float hitProbability =
@@ -8742,26 +8789,49 @@ bool Renderer::updateEnvironmentHitResidency(bool forceAllToggles) {
     if (!hasEvidence && !currentlyActive)
       hitProbability = 0.0f;
     _objectImportance[objectIndex] = hitProbability;
+
+    float depthWeight = computeDepthWeight(objectIndex);
+    float weighted = hitProbability * std::max(depthWeight, 0.0f);
+    weightedImportance[objectIndex] = std::isfinite(weighted) ? weighted : 0.0f;
   }
 
   auto &sortedIndices = _objectProbabilitySortedIndices;
   std::sort(sortedIndices.begin(), sortedIndices.end(),
             [&](size_t a, size_t b) {
-              float importanceA =
-                  (a < _objectImportance.size()) ? _objectImportance[a] : 0.0f;
-              float importanceB =
-                  (b < _objectImportance.size()) ? _objectImportance[b] : 0.0f;
-              if (importanceA == importanceB)
-                return a < b;
-              return importanceA > importanceB;
+              float scoreA =
+                  (a < weightedImportance.size()) ? weightedImportance[a] : 0.0f;
+              float scoreB =
+                  (b < weightedImportance.size()) ? weightedImportance[b] : 0.0f;
+              if (scoreA == scoreB) {
+                float importanceA =
+                    (a < _objectImportance.size()) ? _objectImportance[a] : 0.0f;
+                float importanceB =
+                    (b < _objectImportance.size()) ? _objectImportance[b] : 0.0f;
+                if (importanceA == importanceB)
+                  return a < b;
+                return importanceA > importanceB;
+              }
+              return scoreA > scoreB;
             });
 
-  float targetEscape =
-      std::clamp(_residencyConfig.environmentTargetEscapeFraction, 0.0f, 1.0f);
+  float escapeThreshold =
+      std::clamp(_residencyConfig.environmentEscapeThreshold, 0.0f, 1.0f);
   size_t minActivePrimitives =
       std::min(primitiveCount, _residencyConfig.environmentMinActivePrimitives);
   if (minActivePrimitives == 0 && primitiveCount > 0)
     minActivePrimitives = 1;
+
+  float targetFraction =
+      std::clamp(_residencyConfig.environmentTargetActiveFraction, 0.0f, 1.0f);
+  size_t targetPrimitiveCount = 0;
+  if (targetFraction > 0.0f && primitiveCount > 0) {
+    targetPrimitiveCount = static_cast<size_t>(std::ceil(
+        targetFraction * static_cast<float>(primitiveCount)));
+    targetPrimitiveCount = std::min(targetPrimitiveCount, primitiveCount);
+  }
+  size_t activationFloor = std::max(minActivePrimitives, targetPrimitiveCount);
+  if (activationFloor == 0 && primitiveCount > 0)
+    activationFloor = 1;
 
   size_t desiredPrimitiveCount = 0;
   float weightedEscape = 0.0f;
@@ -8778,9 +8848,9 @@ bool Renderer::updateEnvironmentHitResidency(bool forceAllToggles) {
     if (object.primitiveCount == 0)
       continue;
 
-    bool needMorePrimitives = desiredPrimitiveCount < minActivePrimitives;
+    bool needMorePrimitives = desiredPrimitiveCount < activationFloor;
     bool needsEscapeReduction =
-        averageEscape(desiredPrimitiveCount, weightedEscape) > targetEscape;
+        averageEscape(desiredPrimitiveCount, weightedEscape) > escapeThreshold;
     if (!needMorePrimitives && !needsEscapeReduction)
       break;
 
@@ -9665,6 +9735,14 @@ void Renderer::beginFrameMetrics() {
     sample.avgHitProbability = 0.0;
     sample.p95HitProbability = 0.0;
     sample.probabilityThreshold = _residencyConfig.probabilityThreshold;
+    sample.environmentTargetActiveFraction =
+        _residencyConfig.environmentTargetActiveFraction;
+    sample.environmentEscapeThreshold =
+        _residencyConfig.environmentEscapeThreshold;
+    sample.environmentDepthWeights =
+        formatFloatList(_residencyConfig.environmentDepthWeights);
+    sample.environmentDepthRadii =
+        formatFloatList(_residencyConfig.environmentDepthRadii);
     if (!_primitiveHitProbability.empty()) {
       size_t primitiveCount =
           std::min(_primitiveHitProbability.size(), _allPrimitives.size());

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -375,6 +375,10 @@ private:
     std::string primitiveProbabilities;
     std::string objectProbabilities;
     size_t probabilisticToggles = 0;
+    double environmentTargetActiveFraction = 0.0;
+    double environmentEscapeThreshold = 0.0;
+    std::string environmentDepthWeights;
+    std::string environmentDepthRadii;
     ResidencyStrategy strategy = ResidencyStrategy::DistanceLOD;
     std::string strategyName;
     uint32_t minSamplesPerPixel = 1;

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -65,9 +65,12 @@ struct ResidencyParameters {
   size_t screenFootprintMinActivePrimitives = 16;
   size_t screenFootprintMaxTogglesPerFrame = 10;
 
-  float environmentTargetEscapeFraction = 0.4f;
+  float environmentTargetActiveFraction = 0.0f;
+  float environmentEscapeThreshold = 0.4f;
   size_t environmentMinActivePrimitives = 16;
   size_t environmentMaxTogglesPerFrame = 16;
+  std::vector<float> environmentDepthWeights;
+  std::vector<float> environmentDepthRadii;
 
   // Allows resident buffers to shrink when most primitives remain inactive.
   bool enableBufferShrink = true;

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -16,6 +16,7 @@
 #include <vector>
 #include <limits>
 #include <cmath>
+#include <cstdlib>
 #include "tiny_obj_loader.h"
 #include "TextureLoader.h"
 
@@ -29,6 +30,26 @@ static simd::float3 parseVec3(const char* str) {
     float x = 0, y = 0, z = 0;
     sscanf(str, "%f,%f,%f", &x, &y, &z);
     return simd::make_float3(x, y, z);
+}
+
+static std::vector<float> parseFloatList(const char *attr) {
+    std::vector<float> values;
+    if (!attr) {
+        return values;
+    }
+
+    std::stringstream stream(attr);
+    std::string token;
+    while (std::getline(stream, token, ',')) {
+        const char *start = token.c_str();
+        char *end = nullptr;
+        float parsed = std::strtof(start, &end);
+        if (end != start) {
+            values.push_back(parsed);
+        }
+    }
+
+    return values;
 }
 
 // Rotates a vector by Euler angles applied in X->Y->Z order.
@@ -695,14 +716,40 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
     params.screenFootprintMaxTogglesPerFrame = static_cast<size_t>(root->Unsigned64Attribute(
         "screenToggleBudget",
         static_cast<uint64_t>(params.screenFootprintMaxTogglesPerFrame)));
-    params.environmentTargetEscapeFraction = root->FloatAttribute(
-        "environmentTargetEscapeFraction", params.environmentTargetEscapeFraction);
-    params.environmentMinActivePrimitives = static_cast<size_t>(root->Unsigned64Attribute(
+    params.environmentTargetActiveFraction = root->FloatAttribute(
+        "environmentTargetActiveFraction", params.environmentTargetActiveFraction);
+    params.environmentTargetActiveFraction = root->FloatAttribute(
+        "envTargetFraction", params.environmentTargetActiveFraction);
+
+    params.environmentEscapeThreshold = root->FloatAttribute(
+        "environmentTargetEscapeFraction", params.environmentEscapeThreshold);
+    params.environmentEscapeThreshold = root->FloatAttribute(
+        "envEscapeThreshold", params.environmentEscapeThreshold);
+
+    uint64_t minEnvActive = root->Unsigned64Attribute(
         "environmentMinActive",
-        static_cast<uint64_t>(params.environmentMinActivePrimitives)));
-    params.environmentMaxTogglesPerFrame = static_cast<size_t>(root->Unsigned64Attribute(
+        static_cast<uint64_t>(params.environmentMinActivePrimitives));
+    minEnvActive = root->Unsigned64Attribute("envMinActive", minEnvActive);
+    params.environmentMinActivePrimitives = static_cast<size_t>(minEnvActive);
+
+    uint64_t envToggleBudget = root->Unsigned64Attribute(
         "environmentToggleBudget",
-        static_cast<uint64_t>(params.environmentMaxTogglesPerFrame)));
+        static_cast<uint64_t>(params.environmentMaxTogglesPerFrame));
+    envToggleBudget = root->Unsigned64Attribute("envToggleBudget", envToggleBudget);
+    params.environmentMaxTogglesPerFrame = static_cast<size_t>(envToggleBudget);
+
+    if (const char *depthWeightsAttr = root->Attribute("environmentDepthWeights")) {
+        params.environmentDepthWeights = parseFloatList(depthWeightsAttr);
+    }
+    if (const char *depthWeightsAttr = root->Attribute("envDepthWeights")) {
+        params.environmentDepthWeights = parseFloatList(depthWeightsAttr);
+    }
+    if (const char *depthRadiiAttr = root->Attribute("environmentDepthRadii")) {
+        params.environmentDepthRadii = parseFloatList(depthRadiiAttr);
+    }
+    if (const char *depthRadiiAttr = root->Attribute("envDepthRadii")) {
+        params.environmentDepthRadii = parseFloatList(depthRadiiAttr);
+    }
     params.enableBufferShrink = root->BoolAttribute(
         "enableBufferShrink", params.enableBufferShrink);
     params.bufferShrinkActiveRatio = root->FloatAttribute(


### PR DESCRIPTION
## Summary
- extend the scene residency parameters to include environment-hit specific controls such as target active fraction, escape threshold, and optional depth-based weighting
- plumb the new settings through the renderer so the environment-hit strategy, benchmark samples, and CSV logs reflect the configured values
- document the new `env*` scene attributes so authors know how to tune the environment-hit strategy alongside other residency knobs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d9fed1e00832d99f0da5e6964f644)