### PR TITLE
Ensure residency threshold is inclusive

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -7820,7 +7820,7 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
                        ? _primitivePosteriorMass[i]
                        : 0.0f;
       float effectiveProbability = computeRegressedProbability(probability, mass);
-      if (effectiveProbability > threshold)
+      if (effectiveProbability >= threshold)
         desired[i] = true;
     }
 
@@ -8121,7 +8121,7 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
                      : 0.0f;
     float effectiveProbability =
         computeRegressedProbability(probability, mass);
-    if (effectiveProbability > threshold) {
+    if (effectiveProbability >= threshold) {
       desiredObjects[i] = true;
       size_t contribution =
           (i < _objectPrimitiveCounts.size()) ? _objectPrimitiveCounts[i] : 0;


### PR DESCRIPTION
## Summary
- make the primitive and object residency loops treat the configured probability threshold as inclusive so entities at the cutoff remain resident

## Testing
- `cmake -S tests -B tests/build`
- `cmake --build tests/build`
- `tests/build/ResidencyTests`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691daac84568832dbb51451ed0535324)