### PR TITLE
Fix idle residency hysteresis and add regression test

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -7767,6 +7767,7 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
   const size_t objectCount = _allSceneObjects.size();
 
   constexpr float kPosteriorFloor = 1.0e-3f;
+  constexpr float kMinimalEvidenceThreshold = 1.0e-3f;
   const float configuredWindow = _residencyConfig.probabilityEvidenceWindow;
   const bool finiteEvidenceWindow =
       configuredWindow > 0.0f && std::isfinite(configuredWindow);
@@ -8145,15 +8146,20 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
     float mass = (i < _objectPosteriorMass.size())
                      ? _objectPosteriorMass[i]
                      : 0.0f;
-    float effectiveProbability =
-        computeRegressedProbability(probability, mass);
+    float sanitizedProbability = sanitizePosteriorProbability(probability);
+    float evidence = computeEvidenceFactor(mass);
+    float effectiveProbability = sanitizedProbability * evidence +
+                                 0.5f * (1.0f - evidence);
     bool previousDesired = desiredObjects[i] != 0;
     bool desired = previousDesired;
     bool cooldownExpired =
         (i >= _objectCooldown.size()) || _objectCooldown[i] == 0;
-    if (effectiveProbability >= enterThreshold)
+    bool lowEvidence = evidence <= kMinimalEvidenceThreshold;
+    if (lowEvidence && cooldownExpired)
+      desired = false;
+    else if (sanitizedProbability >= enterThreshold)
       desired = true;
-    else if (effectiveProbability <= exitThreshold)
+    else if (sanitizedProbability <= exitThreshold)
       desired = false;
     else if (cooldownExpired)
       desired = effectiveProbability >= threshold;

--- a/tests/ProbabilisticResidencyTests.cpp
+++ b/tests/ProbabilisticResidencyTests.cpp
@@ -371,6 +371,71 @@ void testObjectFallbackOverridesToggleBudget() {
   assert(harness.toggledPrimitiveCount() == 0);
 }
 
+void testIdleResidencyCooldownClearsDesiredState() {
+  constexpr uint32_t kStateCooldownFrames = 3;
+  constexpr uint32_t kIdleCooldownFrames = 2;
+  constexpr float kThreshold = 0.55f;
+  constexpr float kHysteresis = 0.05f;
+  const float enterThreshold = std::clamp(kThreshold + kHysteresis, 0.0f, 1.0f);
+  const float exitThreshold = std::clamp(kThreshold - kHysteresis, 0.0f, 1.0f);
+  constexpr float kEvidenceWindow = 64.0f;
+  constexpr float kMinimalEvidenceThreshold = 1.0e-3f;
+
+  auto sanitizeProbability = [](float probability) {
+    if (!std::isfinite(probability))
+      return 0.5f;
+    return std::clamp(probability, 0.0f, 1.0f);
+  };
+
+  auto computeEvidenceFactor = [=](float mass) {
+    if (!(mass > 0.0f) || !std::isfinite(mass))
+      return 0.0f;
+    float window = std::max(kEvidenceWindow, 1.0e-3f);
+    float normalized = mass / window;
+    return std::clamp(normalized, 0.0f, 1.0f);
+  };
+
+  auto evaluateDesiredState = [&](float probability, float mass,
+                                  bool previousDesired,
+                                  uint32_t cooldown) {
+    float sanitizedProbability = sanitizeProbability(probability);
+    float evidence = computeEvidenceFactor(mass);
+    float regressedProbability = sanitizedProbability * evidence +
+                                 0.5f * (1.0f - evidence);
+    bool desired = previousDesired;
+    bool cooldownExpired = cooldown == 0;
+    if (evidence <= kMinimalEvidenceThreshold && cooldownExpired)
+      desired = false;
+    else if (sanitizedProbability >= enterThreshold)
+      desired = true;
+    else if (sanitizedProbability <= exitThreshold)
+      desired = false;
+    else if (cooldownExpired)
+      desired = regressedProbability >= kThreshold;
+    return desired;
+  };
+
+  bool desired = true;
+  uint32_t cooldown = kStateCooldownFrames;
+  const uint32_t totalIdleFrames = kStateCooldownFrames + kIdleCooldownFrames;
+  float probability = kThreshold;
+  float mass = kEvidenceWindow;
+
+  for (uint32_t frame = 0; frame < totalIdleFrames; ++frame) {
+    float frameMass = mass;
+    if (frame + 1 == totalIdleFrames)
+      frameMass = 1.0e-6f;
+    bool next = evaluateDesiredState(probability, frameMass, desired, cooldown);
+    if (frame + 1 < totalIdleFrames)
+      assert(next);
+    desired = next;
+    if (cooldown > 0)
+      --cooldown;
+  }
+
+  assert(!desired);
+}
+
 } // namespace
 
 void RunProbabilisticResidencyTests() {
@@ -378,4 +443,5 @@ void RunProbabilisticResidencyTests() {
   testAlternatingHitsRespectDecayAndFallback();
   testZeroActiveFallbackEnsuresOnePrimitive();
   testObjectFallbackOverridesToggleBudget();
+  testIdleResidencyCooldownClearsDesiredState();
 }


### PR DESCRIPTION
## Summary
- adjust the probabilistic residency state machine to compare hysteresis against the sanitized posterior probability, and treat objects with exhausted evidence as below the exit threshold once cooldown has expired
- add a regression test that simulates a long-idle object and verifies it eventually leaves the desired set when idle plus cooldown frames have elapsed

## Testing
- `cmake -S tests -B tests/build`
- `cmake --build tests/build`
- `tests/build/ResidencyTests`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691db2efd5d0832da30f0f51cb8bda55)