### PR TITLE
Add unified residency scoring strategy

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1420,6 +1420,8 @@ std::string Renderer::residencyStrategyName(ResidencyStrategy strategy) const {
     return "Screen-space footprint";
   case ResidencyStrategy::Probabilistic:
     return "Probabilistic";
+  case ResidencyStrategy::UnifiedScore:
+    return "Unified score";
   case ResidencyStrategy::EnvironmentHit:
     return "Environment hit";
   case ResidencyStrategy::AlwaysResident:
@@ -2244,6 +2246,9 @@ void Renderer::updateVisibleScene() {
     break;
   case ResidencyStrategy::ScreenSpaceFootprint:
     strategyName = "Screen-space footprint";
+    break;
+  case ResidencyStrategy::UnifiedScore:
+    strategyName = "Unified score";
     break;
   case ResidencyStrategy::EnvironmentHit:
     strategyName = "Environment hit";
@@ -6656,6 +6661,9 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   case ResidencyStrategy::EnergyImportance:
     changed = updateEnergyImportance(forceAllToggles);
     break;
+  case ResidencyStrategy::UnifiedScore:
+    changed = updateUnifiedResidency(forceAllToggles);
+    break;
   case ResidencyStrategy::RayHitBudget:
     changed = updateRayHitBudget(forceAllToggles);
     break;
@@ -6970,6 +6978,135 @@ size_t Renderer::setObjectActive(size_t objectIndex, bool active) {
     _dirtyResidentObjects.push_back(objectIndex);
 
   return toggled;
+}
+
+std::vector<float> Renderer::computeUnifiedImportance(float &outTotalScore) {
+  const size_t primCount = _activePrimitive.size();
+  std::vector<float> unifiedScores(primCount, 0.0f);
+  outTotalScore = 0.0f;
+  if (primCount == 0)
+    return unifiedScores;
+
+  if (_primitiveScreenCoverage.size() != primCount)
+    _primitiveScreenCoverage.assign(primCount, 0.0f);
+
+  float screenArea = Camera::screenSize.x * Camera::screenSize.y;
+  if (screenArea <= 0.0f)
+    screenArea = 1.0f;
+  float halfFov = Camera::verticalFov * static_cast<float>(M_PI) / 180.0f * 0.5f;
+  float tanHalfFov = std::tan(halfFov);
+  if (tanHalfFov <= 0.0f)
+    tanHalfFov = 1e-3f;
+
+  simd::float3 forward = simd::normalize(Camera::forward);
+  simd::float3 up = simd::normalize(Camera::up);
+  simd::float3 right = simd::cross(forward, up);
+  float rightLenSq = simd::length_squared(right);
+  if (rightLenSq < 1e-6f)
+    right = {1.0f, 0.0f, 0.0f};
+  else
+    right /= std::sqrt(rightLenSq);
+
+  float aspect = Camera::screenSize.y > 0.0f
+                     ? Camera::screenSize.x / Camera::screenSize.y
+                     : 1.0f;
+  float horizontalHalfFov = std::atan(tanHalfFov * aspect);
+
+  parallelChunkedAsync(0, primCount, [this, screenArea, forward, right,
+                                      horizontalHalfFov, tanHalfFov](
+                                         size_t chunkBegin, size_t chunkEnd) {
+    for (size_t i = chunkBegin; i < chunkEnd; ++i) {
+      float coverage = 0.0f;
+      if (i < _primitiveBounds.size() && isInView(_primitiveBounds[i])) {
+        const BoundingSphere &b = _primitiveBounds[i];
+        simd::float3 toCenter = b.center - Camera::position;
+        float depth = simd::dot(toCenter, forward);
+        if (depth > 1e-3f) {
+          float dist = simd::length(toCenter);
+          float cosAngle = depth / std::max(dist, 1e-3f);
+          float horiz = simd::dot(toCenter, right);
+          float horizAngle = std::atan2(std::fabs(horiz), depth);
+          if (horizAngle <= horizontalHalfFov + 0.1f) {
+            float radiusPixels = (b.radius / depth) / tanHalfFov *
+                                 (Camera::screenSize.y * 0.5f);
+            radiusPixels = std::max(radiusPixels, 0.0f);
+            float area = static_cast<float>(M_PI) * radiusPixels * radiusPixels;
+            float angleFactor = std::max(cosAngle, 0.0f);
+            coverage = std::min(area * angleFactor, screenArea);
+          }
+        }
+      }
+      _primitiveScreenCoverage[i] = coverage;
+    }
+  });
+
+  if (_primitiveHitScoresSnapshot.size() < primCount)
+    _primitiveHitScoresSnapshot.resize(primCount, 0.0f);
+  size_t copyCount = std::min(_primitiveHitScores.size(), primCount);
+  std::copy_n(_primitiveHitScores.begin(), copyCount,
+              _primitiveHitScoresSnapshot.begin());
+  if (copyCount < primCount) {
+    std::fill(_primitiveHitScoresSnapshot.begin() + copyCount,
+              _primitiveHitScoresSnapshot.begin() + primCount, 0.0f);
+  }
+
+  auto distanceFalloff = [&](size_t primIndex) -> float {
+    BoundingSphere sphere{};
+    bool haveSphere = false;
+    if (primIndex < _primitiveBounds.size()) {
+      sphere = _primitiveBounds[primIndex];
+      haveSphere = true;
+    } else {
+      size_t objectIndex =
+          primIndex < _primitiveToObject.size() ? _primitiveToObject[primIndex]
+                                                : std::numeric_limits<size_t>::max();
+      if (objectIndex < _objectBounds.size()) {
+        sphere = _objectBounds[objectIndex];
+        haveSphere = true;
+      }
+    }
+    if (!haveSphere || !isInView(sphere))
+      return 0.0f;
+
+    simd::float3 toCenter = sphere.center - Camera::position;
+    float depth = simd::dot(toCenter, forward);
+    if (depth <= 1e-3f)
+      return 0.0f;
+
+    float dist = simd::length(toCenter);
+    float cosAngle = depth / std::max(dist, 1e-3f);
+    float horiz = simd::dot(toCenter, right);
+    float horizAngle = std::atan2(std::fabs(horiz), depth);
+    if (horizAngle > horizontalHalfFov + 0.1f)
+      return 0.0f;
+
+    float angleFactor = std::max(cosAngle, 0.0f);
+    return angleFactor / (1.0f + depth);
+  };
+
+  const float alpha = _residencyConfig.unifiedEnergyWeight;
+  const float beta = _residencyConfig.unifiedHitWeight;
+  const float gamma = _residencyConfig.unifiedCoverageWeight;
+  const float delta = _residencyConfig.unifiedDistanceWeight;
+
+  for (size_t i = 0; i < primCount; ++i) {
+    float energy = (i < _primitiveImportance.size()) ? _primitiveImportance[i]
+                                                     : 0.0f;
+    float hit = (i < _primitiveHitScoresSnapshot.size())
+                    ? _primitiveHitScoresSnapshot[i]
+                    : 0.0f;
+    float coverage = (i < _primitiveScreenCoverage.size())
+                         ? _primitiveScreenCoverage[i]
+                         : 0.0f;
+    float distanceScore = distanceFalloff(i);
+
+    float score = alpha * energy + beta * hit + gamma * coverage +
+                  delta * distanceScore;
+    unifiedScores[i] = score;
+    outTotalScore += std::max(score, 0.0f);
+  }
+
+  return unifiedScores;
 }
 
 bool Renderer::updateEnergyImportance(bool forceAllToggles) {
@@ -7629,6 +7766,28 @@ bool Renderer::updateEnergyImportance(bool forceAllToggles) {
     }
   }
 
+  return changed;
+}
+
+bool Renderer::updateUnifiedResidency(bool forceAllToggles) {
+  float totalUnifiedScore = 0.0f;
+  std::vector<float> unifiedScores = computeUnifiedImportance(totalUnifiedScore);
+  if (unifiedScores.empty())
+    return false;
+
+  std::vector<float> originalImportance = _primitiveImportance;
+  float originalTotalImportance = _totalPrimitiveImportance;
+  float originalVisibilityBoost = _residencyConfig.energyVisibilityBoost;
+
+  _primitiveImportance = std::move(unifiedScores);
+  _totalPrimitiveImportance = totalUnifiedScore;
+  _residencyConfig.energyVisibilityBoost = 1.0f;
+
+  bool changed = updateEnergyImportance(forceAllToggles);
+
+  _primitiveImportance = std::move(originalImportance);
+  _totalPrimitiveImportance = originalTotalImportance;
+  _residencyConfig.energyVisibilityBoost = originalVisibilityBoost;
   return changed;
 }
 
@@ -9428,7 +9587,8 @@ void Renderer::processRayHitCounters() {
   bool strategyUsesHits =
       strategy == ResidencyStrategy::RayHitBudget ||
       strategy == ResidencyStrategy::Probabilistic ||
-      strategy == ResidencyStrategy::EnvironmentHit;
+      strategy == ResidencyStrategy::EnvironmentHit ||
+      strategy == ResidencyStrategy::UnifiedScore;
   if (!strategyUsesHits) {
     std::memset(hitPtr, 0, bufferLength);
     _primitiveHitScores.clear();

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -151,6 +151,7 @@ private:
                        bool forceFullRebuild = false);
   bool updateLODByDistance(bool forceAllToggles);
   bool updateEnergyImportance(bool forceAllToggles);
+  bool updateUnifiedResidency(bool forceAllToggles);
   bool updateRayHitBudget(bool forceAllToggles);
   bool updateProbabilisticResidency(bool forceAllToggles);
   void resetProbabilisticResidencyState();
@@ -165,6 +166,7 @@ private:
   bool waitForPendingFrameCommands(
       std::chrono::milliseconds timeout,
       std::chrono::steady_clock::time_point *waitSnapshot = nullptr);
+  std::vector<float> computeUnifiedImportance(float &outTotalScore);
   bool flushRayHitCopy();
   bool rayHitCopyReady() const;
   void processRayHitCounters();

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -20,6 +20,7 @@ enum class ResidencyStrategy {
   Probabilistic = 4,
   AlwaysResident = 5,
   EnvironmentHit = 6,
+  UnifiedScore = 7,
 };
 
 struct SceneObject {
@@ -46,6 +47,11 @@ struct ResidencyParameters {
   size_t energyMinActivePrimitives = 16;
   size_t energyMaxTogglesPerFrame = 32;
   float energyVisibilityBoost = 1.75f;
+
+  float unifiedEnergyWeight = 1.0f;
+  float unifiedHitWeight = 1.0f;
+  float unifiedCoverageWeight = 1.0f;
+  float unifiedDistanceWeight = 1.0f;
 
   float rayHitDecay = 0.85f;
   float rayHitTargetFraction = 0.6f;

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -631,6 +631,9 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         if (value == "energy" || value == "importance" || value == "energyimportance" ||
             value == "energy_importance") {
             scene->setResidencyStrategy(ResidencyStrategy::EnergyImportance);
+        } else if (value == "unified" || value == "hybrid" ||
+                   value == "unifiedscore" || value == "unified_score") {
+            scene->setResidencyStrategy(ResidencyStrategy::UnifiedScore);
         } else if (value == "distance" || value == "lod" || value == "distance_lod" ||
                    value == "distancelod" || value == "distancebased") {
             scene->setResidencyStrategy(ResidencyStrategy::DistanceLOD);
@@ -680,6 +683,15 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         "energyToggleBudget", static_cast<uint64_t>(params.energyMaxTogglesPerFrame)));
     params.energyVisibilityBoost =
         root->FloatAttribute("energyVisibilityBoost", params.energyVisibilityBoost);
+
+    params.unifiedEnergyWeight =
+        root->FloatAttribute("unifiedEnergyWeight", params.unifiedEnergyWeight);
+    params.unifiedHitWeight =
+        root->FloatAttribute("unifiedHitWeight", params.unifiedHitWeight);
+    params.unifiedCoverageWeight = root->FloatAttribute(
+        "unifiedCoverageWeight", params.unifiedCoverageWeight);
+    params.unifiedDistanceWeight = root->FloatAttribute(
+        "unifiedDistanceWeight", params.unifiedDistanceWeight);
 
     params.rayHitDecay = root->FloatAttribute("rayHitDecay", params.rayHitDecay);
     params.rayHitTargetFraction =


### PR DESCRIPTION
## Summary
- add unified residency strategy configuration and XML parsing, including weights for energy, hit, coverage, and distance terms
- implement unified score computation in the renderer and route residency switching through the new strategy name aliases
- reuse the energy-importance residency pipeline with combined per-primitive scores that blend energy, hits, coverage, and distance falloff

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69203632e4ac832d88939ab2765d8f9f)