### PR TITLE
Interpolate energy visibility boost

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -7272,8 +7272,10 @@ bool Renderer::updateEnergyImportance(bool forceAllToggles) {
       if (objectIndex < _objectBounds.size())
         sphereCoverage = coverageForSphere(_objectBounds[objectIndex]);
       float combinedCoverage = std::max(coverage, sphereCoverage);
-      float visibilityFactor = combinedCoverage > 0.0f ? 1.0f : 0.0f;
-      float multiplier = 1.0f + (visibilityBoost - 1.0f) * visibilityFactor;
+      float coverageFraction =
+          std::clamp(combinedCoverage / screenArea, 0.0f, 1.0f);
+      float multiplier =
+          1.0f + (visibilityBoost - 1.0f) * coverageFraction;
       _objectImportance[objectIndex] = totalImportance * multiplier;
     } else {
       _objectImportance[objectIndex] = totalImportance;


### PR DESCRIPTION
## Summary
- normalize coverage against screen area when computing energy importance boost
- interpolate the visibility boost between no change and the configured multiplier
- apply the fractional boost directly to object importance values

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692042b2cca4832db4172c50e007f940)