### PR TITLE
Align residency hysteresis with regressed probabilities

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -8492,6 +8492,8 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
     float probability = (i < _objectHitProbability.size())
                             ? _objectHitProbability[i]
                             : 0.5f;
+    float variance = (i < _objectHitVariance.size()) ? _objectHitVariance[i]
+                                                     : 0.0f;
     float mass = (i < _objectPosteriorMass.size())
                      ? _objectPosteriorMass[i]
                      : 0.0f;
@@ -8499,15 +8501,18 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
     float evidence = computeEvidenceFactor(mass);
     float effectiveProbability = sanitizedProbability * evidence +
                                  0.5f * (1.0f - evidence);
+    float boostedProbability = computePosteriorScore(probability, variance, mass);
+    float enterScore = std::max(effectiveProbability, boostedProbability);
+    float exitScore = effectiveProbability;
     bool previousDesired = desiredObjects[i] != 0;
     bool desired = previousDesired;
     bool cooldownExpired =
         (i >= _objectCooldown.size()) || _objectCooldown[i] == 0;
     bool lowEvidence = evidence <= kMinimalEvidenceThreshold;
-    float promotionProbability = sanitizedProbability;
-    float demotionProbability = effectiveProbability;
+    float promotionProbability = enterScore;
+    float demotionProbability = exitScore;
     float evaluationProbability = lowEvidence ? effectiveProbability
-                                              : sanitizedProbability;
+                                              : enterScore;
 
     if (promotionProbability >= enterThreshold)
       desired = true;

--- a/tests/ProbabilisticResidencyTests.cpp
+++ b/tests/ProbabilisticResidencyTests.cpp
@@ -393,21 +393,25 @@ void testLowEvidenceHysteresisDemotion() {
     return std::clamp(normalized, 0.0f, 1.0f);
   };
 
-  auto evaluateDesiredState = [&](float probability, float mass,
-                                  bool previousDesired,
-                                  uint32_t cooldown) {
+  auto evaluateDesiredState = [&](float probability, float mass, float variance,
+                                  bool previousDesired, uint32_t cooldown) {
     float sanitizedProbability = sanitizeProbability(probability);
     float evidence = computeEvidenceFactor(mass);
     float regressedProbability = sanitizedProbability * evidence +
                                  0.5f * (1.0f - evidence);
+    float sqrtVariance = std::sqrt(std::max(variance, 0.0f));
+    float boostedProbability = regressedProbability +
+                               kUncertaintyBoost * sqrtVariance;
+    float enterScore = std::max(regressedProbability, boostedProbability);
+    float exitScore = regressedProbability;
     bool desired = previousDesired;
     bool cooldownExpired = cooldown == 0;
     bool lowEvidence = evidence <= kMinimalEvidenceThreshold;
     float evaluationProbability =
-        lowEvidence ? regressedProbability : sanitizedProbability;
-    if (sanitizedProbability >= enterThreshold)
+        lowEvidence ? regressedProbability : enterScore;
+    if (enterScore >= enterThreshold)
       desired = true;
-    else if (regressedProbability <= exitThreshold)
+    else if (exitScore <= exitThreshold)
       desired = false;
     else if (cooldownExpired && !previousDesired)
       desired = evaluationProbability >= kThreshold;
@@ -418,16 +422,82 @@ void testLowEvidenceHysteresisDemotion() {
   uint32_t cooldown = 0;
   constexpr float kLowEvidenceMass = kMinimalEvidenceThreshold * 0.5f;
 
-  desired = evaluateDesiredState(0.65f, kLowEvidenceMass, desired, cooldown);
+  desired = evaluateDesiredState(0.65f, kLowEvidenceMass, 0.0f, desired,
+                                 cooldown);
   assert(desired);
 
-  desired = evaluateDesiredState(0.4f, kLowEvidenceMass, desired, cooldown);
+  desired = evaluateDesiredState(0.4f, 0.0f, 0.0f, desired, cooldown);
   assert(!desired);
 
-  desired = evaluateDesiredState(0.75f, kLowEvidenceMass, desired, cooldown);
+  desired = evaluateDesiredState(0.75f, kLowEvidenceMass, 0.0f, desired,
+                                 cooldown);
   assert(desired);
 
-  desired = evaluateDesiredState(0.62f, kLowEvidenceMass, desired, cooldown);
+  desired = evaluateDesiredState(0.62f, kLowEvidenceMass, 0.0f, desired,
+                                 cooldown);
+  assert(desired);
+}
+
+void testLowEvidenceStabilityWithRegressedProbability() {
+  constexpr float kThreshold = 0.55f;
+  constexpr float kHysteresis = 0.05f;
+  const float enterThreshold = std::clamp(kThreshold + kHysteresis, 0.0f, 1.0f);
+  const float exitThreshold = std::clamp(kThreshold - kHysteresis, 0.0f, 1.0f);
+  constexpr float kEvidenceWindow = 4.0f;
+  constexpr float kMinimalEvidenceThreshold = 1.0e-3f;
+  constexpr float kUncertaintyBoost = 0.25f;
+
+  auto sanitizeProbability = [](float probability) {
+    if (!std::isfinite(probability))
+      return 0.5f;
+    return std::clamp(probability, 0.0f, 1.0f);
+  };
+
+  auto computeEvidenceFactor = [=](float mass) {
+    if (!(mass > 0.0f) || !std::isfinite(mass))
+      return 0.0f;
+    float window = std::max(kEvidenceWindow, 1.0e-3f);
+    float normalized = mass / window;
+    return std::clamp(normalized, 0.0f, 1.0f);
+  };
+
+  auto evaluateDesiredState = [&](float probability, float mass, float variance,
+                                  bool previousDesired) {
+    float sanitizedProbability = sanitizeProbability(probability);
+    float evidence = computeEvidenceFactor(mass);
+    float regressedProbability = sanitizedProbability * evidence +
+                                 0.5f * (1.0f - evidence);
+    float sqrtVariance = std::sqrt(std::max(variance, 0.0f));
+    float boostedProbability = regressedProbability +
+                               kUncertaintyBoost * sqrtVariance;
+    float enterScore = std::max(regressedProbability, boostedProbability);
+    float exitScore = regressedProbability;
+    bool desired = previousDesired;
+    bool lowEvidence = evidence <= kMinimalEvidenceThreshold;
+    float evaluationProbability =
+        lowEvidence ? regressedProbability : enterScore;
+    if (enterScore >= enterThreshold)
+      desired = true;
+    else if (exitScore <= exitThreshold)
+      desired = false;
+    else if (!previousDesired)
+      desired = evaluationProbability >= kThreshold;
+    return desired;
+  };
+
+  bool desired = false;
+  constexpr float kVariance = 0.04f;
+
+  desired =
+      evaluateDesiredState(0.85f, 1.5f, kVariance, desired /*previousDesired*/);
+  assert(desired);
+
+  desired =
+      evaluateDesiredState(0.68f, 1.5f, kVariance, desired /*previousDesired*/);
+  assert(desired);
+
+  desired =
+      evaluateDesiredState(0.64f, 1.6f, kVariance, desired /*previousDesired*/);
   assert(desired);
 }
 
@@ -455,21 +525,25 @@ void testIdleResidencyCooldownClearsDesiredState() {
     return std::clamp(normalized, 0.0f, 1.0f);
   };
 
-  auto evaluateDesiredState = [&](float probability, float mass,
-                                  bool previousDesired,
-                                  uint32_t cooldown) {
+  auto evaluateDesiredState = [&](float probability, float mass, float variance,
+                                  bool previousDesired, uint32_t cooldown) {
     float sanitizedProbability = sanitizeProbability(probability);
     float evidence = computeEvidenceFactor(mass);
     float regressedProbability = sanitizedProbability * evidence +
                                  0.5f * (1.0f - evidence);
+    float sqrtVariance = std::sqrt(std::max(variance, 0.0f));
+    float boostedProbability = regressedProbability +
+                               kUncertaintyBoost * sqrtVariance;
+    float enterScore = std::max(regressedProbability, boostedProbability);
+    float exitScore = regressedProbability;
     bool desired = previousDesired;
     bool cooldownExpired = cooldown == 0;
     bool lowEvidence = evidence <= kMinimalEvidenceThreshold;
     float evaluationProbability =
-        lowEvidence ? regressedProbability : sanitizedProbability;
-    if (sanitizedProbability >= enterThreshold)
+        lowEvidence ? regressedProbability : enterScore;
+    if (enterScore >= enterThreshold)
       desired = true;
-    else if (regressedProbability <= exitThreshold)
+    else if (exitScore <= exitThreshold)
       desired = false;
     else if (cooldownExpired && !previousDesired)
       desired = evaluationProbability >= kThreshold;
@@ -486,7 +560,8 @@ void testIdleResidencyCooldownClearsDesiredState() {
     float frameMass = mass;
     if (frame + 1 == totalIdleFrames)
       frameMass = 1.0e-6f;
-    bool next = evaluateDesiredState(probability, frameMass, desired, cooldown);
+    bool next = evaluateDesiredState(probability, frameMass, 0.0f, desired,
+                                     cooldown);
     if (frame + 1 < totalIdleFrames)
       assert(next);
     desired = next;
@@ -505,5 +580,6 @@ void RunProbabilisticResidencyTests() {
   testZeroActiveFallbackEnsuresOnePrimitive();
   testObjectFallbackOverridesToggleBudget();
   testLowEvidenceHysteresisDemotion();
+  testLowEvidenceStabilityWithRegressedProbability();
   testIdleResidencyCooldownClearsDesiredState();
 }


### PR DESCRIPTION
## Summary
- evaluate probabilistic residency hysteresis using evidence-weighted and uncertainty-boosted probabilities
- keep cooldown path while preventing low-evidence flapping by basing promotion and demotion on regressed probabilities
- add coverage for stable residency decisions when evidence is sparse but regressed probabilities stay above threshold

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69243cfa8214832d98858115ed4be480)