### PR TITLE
Soften visibility evidence gating for offloaded objects

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -8113,7 +8113,6 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
 
   constexpr float kPosteriorFloor = 1.0e-3f;
   constexpr float kMinimalEvidenceThreshold = 1.0e-3f;
-  constexpr float kVisibleEvidenceFloor = 0.1f;
   constexpr float kVisibilityEvidenceDecay = 0.9f;
   const float configuredWindow = _residencyConfig.probabilityEvidenceWindow;
   const bool finiteEvidenceWindow =
@@ -8557,9 +8556,7 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
         (idx < _objectVisibilityEvidence.size()) ? _objectVisibilityEvidence[idx]
                                                  : 0.0f;
     float decayed = previous * kVisibilityEvidenceDecay;
-    float visibilityFloor = visible ? kVisibleEvidenceFloor : 0.0f;
-    float buffered =
-        std::max({std::clamp(rawEvidence, 0.0f, 1.0f), decayed, visibilityFloor});
+    float buffered = std::max(std::clamp(rawEvidence, 0.0f, 1.0f), decayed);
     if (idx < _objectVisibilityEvidence.size())
       _objectVisibilityEvidence[idx] = buffered;
     return buffered;
@@ -8594,7 +8591,9 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
     bool desired = previousDesired;
     bool cooldownExpired =
         (i >= _objectCooldown.size()) || _objectCooldown[i] == 0;
-    bool lowEvidence = bufferedEvidence <= kMinimalEvidenceThreshold;
+    float lowEvidenceMetric =
+        std::min(bufferedEvidence, std::clamp(rawEvidence, 0.0f, 1.0f));
+    bool lowEvidence = lowEvidenceMetric <= kMinimalEvidenceThreshold;
     float promotionProbability = enterScore;
     float demotionProbability = exitScore;
     float evaluationProbability = lowEvidence ? effectiveProbability
@@ -8736,7 +8735,9 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
     bool visibilityBootstrap = (idx < objectBecameVisible.size()) &&
                                objectBecameVisible[idx] != 0 &&
                                mass <= kMinimalEvidenceThreshold;
-    bool lowEvidence = bufferedEvidence <= kMinimalEvidenceThreshold;
+    float lowEvidenceMetric =
+        std::min(bufferedEvidence, std::clamp(rawEvidence, 0.0f, 1.0f));
+    bool lowEvidence = lowEvidenceMetric <= kMinimalEvidenceThreshold;
     float visibilityAdjustedProbability =
         (visible && lowEvidence) ? std::min(effectiveProbability, threshold)
                                  : effectiveProbability;


### PR DESCRIPTION
## Summary
- remove the visibility evidence floor to let buffered evidence decay naturally
- base low-evidence checks on raw evidence so visible objects with weak evidence can bypass strict thresholds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692455dc50e8832da838054d835404bc)