### PR TITLE
Add baseline exploration for visible offloaded candidates

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -8304,6 +8304,8 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
         effectiveExplore = std::max(effectiveExplore, kIdleVisibleExploreSeed);
       if (visible && (raysTested == 0 || lowEvidence))
         effectiveExplore = std::max(effectiveExplore, kIdleVisibleExploreSeed);
+      if (visible && raysTested > 0 && !lowEvidence)
+        effectiveExplore = std::max(effectiveExplore, kPosteriorFloor);
       if (idx < _primitiveExplorationScore.size())
         _primitiveExplorationScore[idx] = effectiveExplore;
       if (effectiveExplore <= 0.0f)
@@ -8757,6 +8759,8 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
       effectiveExplore = std::max(effectiveExplore, kIdleVisibleExploreSeed);
     if (visible && (raysTested == 0 || lowEvidence))
       effectiveExplore = std::max(effectiveExplore, kIdleVisibleExploreSeed);
+    if (visible && raysTested > 0 && !lowEvidence)
+      effectiveExplore = std::max(effectiveExplore, kPosteriorFloor);
     if (idx < _objectExplorationScore.size())
       _objectExplorationScore[idx] = effectiveExplore;
     if (effectiveExplore <= 0.0f)


### PR DESCRIPTION
## Summary
- add a small baseline exploration score for visible offloaded primitives even when evidence is above the minimal threshold
- apply the same baseline to offloaded objects so visible entries can re-enter exploration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692456723894832dafa248bb477a1edf)