### PR TITLE
Handle visibility when regressing exploration probabilities

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -8276,8 +8276,8 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
       bool visible = computeVisibility(idx);
       float evidence = computeEvidenceFactor(mass, visible);
       bool lowEvidence = evidence <= kMinimalEvidenceThreshold;
-      float effectiveProbability =
-          computeRegressedProbability(probability, mass);
+      float effectiveProbability = computeRegressedProbabilityFromEvidence(
+          probability, evidence);
       bool visibilityBootstrap = (idx < primitiveBecameVisible.size()) &&
                                  primitiveBecameVisible[idx] != 0 &&
                                  mass <= kMinimalEvidenceThreshold;


### PR DESCRIPTION
## Summary
- include primitive visibility when regressing exploration probabilities during primitive exploration
- align gated probability calculations with visibility-aware evidence handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692457a12470832db96670090e21ae49)