### PR TITLE
Respect probabilistic toggle budget in fallback activation

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -8979,15 +8979,16 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
 
     size_t toggled = setObjectActive(objectIndex, shouldBeActive);
     if (toggled > 0) {
+      size_t applied = toggled;
       if (!forceAllToggles) {
         size_t remainingBudget =
             (maxPrimitiveToggles > toggledPrimitiveCount)
                 ? (maxPrimitiveToggles - toggledPrimitiveCount)
                 : size_t(0);
-        size_t applied = std::min(toggled, remainingBudget);
+        applied = std::min(toggled, remainingBudget);
         toggledPrimitiveCount += applied;
       }
-      _frameProbabilisticToggles += toggled;
+      _frameProbabilisticToggles += applied;
       changed = true;
       if (!shouldBeActive && objectIndex < _objectExplorationScore.size())
         _objectExplorationScore[objectIndex] = 0.0f;
@@ -9007,13 +9008,15 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
         (maxPrimitiveToggles > toggledPrimitiveCount)
             ? (maxPrimitiveToggles - toggledPrimitiveCount)
             : size_t(0);
-    size_t toggled = setObjectActive(fallback, true);
+    bool canToggleFallback = forceAllToggles || remainingBudget > 0;
+    size_t toggled = canToggleFallback ? setObjectActive(fallback, true) : 0;
     if (toggled > 0) {
+      size_t applied = toggled;
       if (!forceAllToggles) {
-        size_t applied = std::min(toggled, remainingBudget);
+        applied = std::min(toggled, remainingBudget);
         toggledPrimitiveCount += applied;
       }
-      _frameProbabilisticToggles += toggled;
+      _frameProbabilisticToggles += applied;
       changed = true;
     }
     if (fallback < _desiredObjectState.size()) {


### PR DESCRIPTION
## Summary
- cap probabilistic toggle accounting to the applied budget
- skip fallback activation when no toggle budget remains
- keep fallback toggle accounting aligned with the configured per-frame limit


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924583781e4832d9ad9dc17f85f2b6f)