### PR TITLE
Prioritize probabilistic residency toggles by object priority

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -8965,7 +8965,37 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
   size_t toggledPrimitiveCount = 0;
   size_t maxPrimitiveToggles = _residencyConfig.probabilityMaxTogglesPerFrame;
 
-  for (size_t objectIndex = 0; objectIndex < objectCount; ++objectIndex) {
+  std::vector<size_t> toggleOrder;
+  toggleOrder.reserve(objectCount);
+  std::vector<uint8_t> added(objectCount, 0);
+
+  auto appendList = [&](const std::vector<size_t> &candidates) {
+    for (size_t idx : candidates) {
+      if (idx >= objectCount)
+        continue;
+      if (added[idx])
+        continue;
+      toggleOrder.push_back(idx);
+      added[idx] = 1;
+    }
+  };
+
+  std::vector<size_t> desiredByPriority;
+  desiredByPriority.reserve(objectCount);
+  for (size_t idx : _objectProbabilitySortedIndices) {
+    if (idx >= objectCount)
+      continue;
+    if (desiredObjects[idx] == 0)
+      continue;
+    desiredByPriority.push_back(idx);
+  }
+
+  appendList(desiredByPriority);
+  appendList(visibleExplore);
+  appendList(hiddenExplore);
+  appendList(_objectProbabilitySortedIndices);
+
+  for (size_t objectIndex : toggleOrder) {
     if (!forceAllToggles) {
       if (maxPrimitiveToggles == 0 || toggledPrimitiveCount >= maxPrimitiveToggles)
         break;


### PR DESCRIPTION
## Summary
- build a priority-ordered toggle list that fronts desired and exploration candidates before the remaining probability-ranked objects
- keep existing cooldown and budget gating while applying toggles through the prioritized list

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69245b284c00832d9888345e241a7209)