### PR TITLE
Add visible probability floor for residency decisions

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1285,7 +1285,8 @@ void Renderer::writeBenchmarkHeader() {
          "active_triangles,resident_triangles,total_triangles,active_nodes,"
          "resident_nodes,total_nodes,active_objects,resident_objects,"
          "avg_hit_probability,p95_hit_probability,probability_threshold,"
-         "probability_target_fraction,probability_target_primitives,"
+         "probability_target_fraction,probability_visible_floor,"
+         "probability_target_primitives,"
          "probability_initial_desired_primitives,"
          "probability_final_desired_primitives,probability_trimmed_primitives,"
          "probability_budget_hit,primitive_probabilities,object_probabilities,"
@@ -1363,6 +1364,7 @@ void Renderer::writeBenchmarkRow(const BenchmarkSample &sample) {
       << formatFixed(sample.p95HitProbability, 6) << ','
       << formatFixed(sample.probabilityThreshold, 3) << ','
       << formatFixed(sample.probabilityTargetFraction, 3) << ','
+      << formatFixed(sample.probabilityVisibleFloor, 3) << ','
       << sample.probabilityTargetPrimitives << ','
       << sample.probabilityInitialDesiredPrimitives << ','
       << sample.probabilityFinalDesiredPrimitives << ','
@@ -8121,6 +8123,8 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
   const float configuredWindow = _residencyConfig.probabilityEvidenceWindow;
   const bool finiteEvidenceWindow =
       configuredWindow > 0.0f && std::isfinite(configuredWindow);
+  float probabilityVisibleFloor =
+      std::clamp(_residencyConfig.probabilityVisibleFloor, 0.0f, 1.0f);
   float scoringWindow = finiteEvidenceWindow
                             ? std::max(configuredWindow, kPosteriorFloor)
                             : std::max(64.0f, kPosteriorFloor);
@@ -8610,6 +8614,13 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
     float demotionProbability = exitScore;
     float evaluationProbability = lowEvidence ? effectiveProbability
                                               : enterScore;
+
+    if (visible) {
+      demotionProbability =
+          std::max(demotionProbability, probabilityVisibleFloor);
+      evaluationProbability =
+          std::max(evaluationProbability, probabilityVisibleFloor);
+    }
 
     if (promotionProbability >= enterThreshold)
       desired = true;
@@ -10557,6 +10568,7 @@ void Renderer::beginFrameMetrics() {
     sample.p95HitProbability = 0.0;
     sample.probabilityThreshold = _residencyConfig.probabilityThreshold;
     sample.probabilityTargetFraction = _residencyConfig.probabilityTargetFraction;
+    sample.probabilityVisibleFloor = _residencyConfig.probabilityVisibleFloor;
     sample.environmentTargetActiveFraction =
         _residencyConfig.environmentTargetActiveFraction;
     sample.environmentEscapeThreshold =

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -375,6 +375,7 @@ private:
     double p95HitProbability = 0.0;
     double probabilityThreshold = 0.0;
     double probabilityTargetFraction = 0.0;
+    double probabilityVisibleFloor = 0.0;
     std::string primitiveProbabilities;
     std::string objectProbabilities;
     size_t probabilisticToggles = 0;

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -71,6 +71,7 @@ struct ResidencyParameters {
   uint32_t probabilityRecentPromotionFrames = 4;
   uint32_t probabilityIdleCooldownFrames = 3;
   float probabilityIdleDecay = 0.98f;
+  float probabilityVisibleFloor = 0.0f;
 
   float screenFootprintTargetFraction = 0.65f;
   float screenFootprintMinPixelCoverage = 32.0f;

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -723,6 +723,8 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         "probabilityEvidenceWindow", params.probabilityEvidenceWindow);
     params.probabilityDesiredHysteresis = root->FloatAttribute(
         "probabilityDesiredHysteresis", params.probabilityDesiredHysteresis);
+    params.probabilityVisibleFloor = root->FloatAttribute(
+        "probabilityVisibleFloor", params.probabilityVisibleFloor);
     params.probabilityRecentPromotionFrames = root->UnsignedAttribute(
         "probabilityRecentPromotionFrames", params.probabilityRecentPromotionFrames);
     params.probabilityIdleCooldownFrames = root->UnsignedAttribute(


### PR DESCRIPTION
## Summary
- add a probabilityVisibleFloor knob to residency parameters and parse it from scene XML
- clamp demotion and evaluation probabilities for visible objects in probabilistic residency updates
- include the new probability floor in benchmark/config logging

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692469c4705c832d9bede4d808e265b2)