### PR TITLE
Add visible demotion dwell control

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -8535,6 +8535,10 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
     _desiredObjectDemotionFrame.resize(objectCount, 0);
   else if (_desiredObjectDemotionFrame.size() > objectCount)
     _desiredObjectDemotionFrame.resize(objectCount);
+  if (_objectDemotionDwell.size() < objectCount)
+    _objectDemotionDwell.resize(objectCount, 0);
+  else if (_objectDemotionDwell.size() > objectCount)
+    _objectDemotionDwell.resize(objectCount);
 
   std::vector<uint8_t> desiredObjects = _desiredObjectState;
   auto &pendingDesiredObjects = _pendingDesiredObjects;
@@ -8582,6 +8586,8 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
       std::clamp(_residencyConfig.probabilityDesiredHysteresis, 0.0f, 0.5f);
   float enterThreshold = std::clamp(threshold + hysteresis, 0.0f, 1.0f);
   float exitThreshold = std::clamp(threshold - hysteresis, 0.0f, 1.0f);
+  uint32_t demotionDwellFrames =
+      _residencyConfig.probabilityVisibleDemotionDwellFrames;
 
   size_t desiredPrimitiveCount = 0;
   for (size_t i = 0; i < objectCount; ++i) {
@@ -8615,6 +8621,10 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
     float evaluationProbability = lowEvidence ? effectiveProbability
                                               : enterScore;
 
+    bool dwellApplies = visible && demotionDwellFrames > 0;
+    if (!dwellApplies || demotionProbability > exitThreshold)
+      _objectDemotionDwell[i] = 0;
+
     if (visible) {
       demotionProbability =
           std::max(demotionProbability, probabilityVisibleFloor);
@@ -8622,12 +8632,27 @@ bool Renderer::updateProbabilisticResidency(bool forceAllToggles) {
           std::max(evaluationProbability, probabilityVisibleFloor);
     }
 
-    if (promotionProbability >= enterThreshold)
+    if (promotionProbability >= enterThreshold) {
       desired = true;
-    else if (demotionProbability <= exitThreshold)
-      desired = false;
-    else if (cooldownExpired && !previousDesired)
+      _objectDemotionDwell[i] = 0;
+    } else if (demotionProbability <= exitThreshold) {
+      if (dwellApplies && previousDesired) {
+        uint32_t &dwellCount = _objectDemotionDwell[i];
+        if (dwellCount < demotionDwellFrames)
+          ++dwellCount;
+        if (dwellCount >= demotionDwellFrames)
+          desired = false;
+        else
+          desired = true;
+      } else {
+        desired = false;
+        _objectDemotionDwell[i] = 0;
+      }
+    } else if (cooldownExpired && !previousDesired) {
       desired = evaluationProbability >= threshold;
+      if (desired)
+        _objectDemotionDwell[i] = 0;
+    }
 
     if (desired && !previousDesired && i < _desiredObjectPromotionFrame.size())
       _desiredObjectPromotionFrame[i] = _renderedFrameCount;

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -434,6 +434,7 @@ private:
   std::vector<uint8_t> _pendingDesiredObjects;
   std::vector<uint64_t> _desiredObjectPromotionFrame;
   std::vector<uint64_t> _desiredObjectDemotionFrame;
+  std::vector<uint32_t> _objectDemotionDwell;
   std::vector<float> _primitiveImportance;
   std::vector<float> _objectImportance;
   std::vector<float> _objectImportanceHistory;

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -72,6 +72,7 @@ struct ResidencyParameters {
   uint32_t probabilityIdleCooldownFrames = 3;
   float probabilityIdleDecay = 0.98f;
   float probabilityVisibleFloor = 0.0f;
+  uint32_t probabilityVisibleDemotionDwellFrames = 0;
 
   float screenFootprintTargetFraction = 0.65f;
   float screenFootprintMinPixelCoverage = 32.0f;

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -727,6 +727,9 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         "probabilityVisibleFloor", params.probabilityVisibleFloor);
     params.probabilityRecentPromotionFrames = root->UnsignedAttribute(
         "probabilityRecentPromotionFrames", params.probabilityRecentPromotionFrames);
+    params.probabilityVisibleDemotionDwellFrames = root->UnsignedAttribute(
+        "probabilityVisibleDemotionDwellFrames",
+        params.probabilityVisibleDemotionDwellFrames);
     params.probabilityIdleCooldownFrames = root->UnsignedAttribute(
         "probabilityIdleCooldownFrames", params.probabilityIdleCooldownFrames);
     params.probabilityIdleCooldownFrames = root->UnsignedAttribute(


### PR DESCRIPTION
## Summary
- add a configurable demotion dwell frame count to residency parameters and loading
- track per-object demotion dwell counters in probabilistic residency evaluation
- delay demotion for visible objects until dwell duration is reached while resetting counters appropriately

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69246b3bce20832dbecf34d407a8a0a4)