### PR TITLE
Tune unified residency weights for offload demo

### DIFF
--- a/MetalCpp Path Tracer/scene_unified_offload_demo.xml
+++ b/MetalCpp Path Tracer/scene_unified_offload_demo.xml
@@ -1,10 +1,10 @@
 <Scene width="960" height="540" maxRayDepth="6" startCompacted="true"
        residencyStrategy="unified"
        textureResidencyMemoryCapMB="512"
-       unifiedEnergyWeight="0.75"
-       unifiedHitWeight="1.55"
-       unifiedCoverageWeight="1.2"
-       unifiedDistanceWeight="0.35">
+       unifiedEnergyWeight="0.85"
+       unifiedHitWeight="1.95"
+       unifiedCoverageWeight="1.55"
+       unifiedDistanceWeight="0.55">
     <CameraPath>
         <!-- Lateral sweep across offset occluders; meshes fade in/out as the unified scorer reprioritizes residency -->
         <Keyframe frame="0"   position="-55,12,20" lookAt="0,8,-40" />


### PR DESCRIPTION
## Summary
- increase unified scoring weights to prioritize newly visible screen-dominant meshes
- keep distance weight non-zero while boosting hit, coverage, and energy emphasis

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924751f13ac832d8a85dbb038afa798)