### PR TITLE
Avoid blocking on TLAS rebuild without shared events

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -3939,21 +3939,19 @@ void Renderer::updateTopLevelAccelerationStructure(
           this->_tlasCompletedEventValue.store(signalValue,
                                                std::memory_order_release);
         });
+  } else {
+    commandBuffer->addCompletedHandler(
+        [this](MTL::CommandBuffer *cmd) {
+          bool success =
+              cmd->status() == MTL::CommandBufferStatusCompleted;
+          this->handleDeferredBlasEvictions(cmd, success);
+          this->finalizePendingTlasScratchResize(true);
+        });
   }
 
   _pendingBlasEvictions.assign(commandBuffer);
 
   commandBuffer->commit();
-
-  if (!_pTlasBuildEvent) {
-    commandBuffer->waitUntilCompleted();
-    bool success =
-        commandBuffer->status() == MTL::CommandBufferStatusCompleted;
-    handleDeferredBlasEvictions(commandBuffer, success);
-    _tlasCompletedEventValue.store(_tlasBuildEventValue,
-                                   std::memory_order_release);
-    finalizePendingTlasScratchResize(true);
-  }
 
   instanceDesc->release();
 


### PR DESCRIPTION
## Summary
- avoid CPU-side waits during TLAS rebuilds on devices without shared events by relying on completion handlers
- ensure deferred BLAS evictions and scratch buffer maintenance still run after the command buffer finishes

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693430a259b4832db3f02a670177805d)