### PR TITLE
Normalize environment depth residency settings

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -2333,6 +2333,7 @@ void Renderer::updateVisibleScene() {
          _pScene->getTriangleCount(), _pScene->getRectangleCount());
 
   _residencyConfig = _pScene->getResidencyParameters();
+  _residencyConfig.normalizeEnvironmentDepthSettings();
   bool requiresCachedBlas =
       _pScene->getResidencyStrategy() != ResidencyStrategy::AlwaysResident;
   if (_residencyConfig.buildCachedBlas != requiresCachedBlas) {
@@ -9890,10 +9891,11 @@ bool Renderer::updateEnvironmentHitResidency(bool forceAllToggles) {
     const auto &weights = _residencyConfig.environmentDepthWeights;
     if (weights.empty())
       return 1.0f;
-    float fallbackWeight = weights.back();
     const auto &radii = _residencyConfig.environmentDepthRadii;
-    if (radii.empty())
-      return fallbackWeight;
+    size_t pairCount = std::min(weights.size(), radii.size());
+    if (pairCount == 0)
+      return weights.back();
+    float fallbackWeight = weights[pairCount - 1];
     if (objectIndex >= _objectBounds.size())
       return fallbackWeight;
 
@@ -9902,14 +9904,10 @@ bool Renderer::updateEnvironmentHitResidency(bool forceAllToggles) {
     if (!(distance > 0.0f))
       return weights.front();
 
-    size_t pairCount = std::min(weights.size(), radii.size());
-    for (size_t i = 0; i < pairCount; ++i) {
-      float radius = radii[i];
-      if (!(radius > 0.0f))
-        continue;
-      if (distance <= radius)
-        return weights[i];
-    }
+    auto end = radii.begin() + pairCount;
+    auto lowerBound = std::lower_bound(radii.begin(), end, distance);
+    if (lowerBound != end)
+      return weights[std::distance(radii.begin(), lowerBound)];
     return fallbackWeight;
   };
 

--- a/MetalCpp Path Tracer/Scene/Scene.cpp
+++ b/MetalCpp Path Tracer/Scene/Scene.cpp
@@ -11,6 +11,32 @@
 
 namespace MetalCppPathTracer {
 
+void ResidencyParameters::normalizeEnvironmentDepthSettings() {
+  size_t pairCount =
+      std::min(environmentDepthRadii.size(), environmentDepthWeights.size());
+  if (pairCount == 0) {
+    environmentDepthRadii.clear();
+    environmentDepthWeights.clear();
+    return;
+  }
+
+  std::vector<std::pair<float, float>> paired;
+  paired.reserve(pairCount);
+  for (size_t i = 0; i < pairCount; ++i) {
+    paired.emplace_back(environmentDepthRadii[i], environmentDepthWeights[i]);
+  }
+
+  std::sort(paired.begin(), paired.end(),
+            [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
+
+  environmentDepthRadii.resize(pairCount);
+  environmentDepthWeights.resize(pairCount);
+  for (size_t i = 0; i < pairCount; ++i) {
+    environmentDepthRadii[i] = paired[i].first;
+    environmentDepthWeights[i] = paired[i].second;
+  }
+}
+
 Scene::Scene() { clear(); }
 
 void Scene::markTriangleCacheDirty() { triangleCacheDirty = true; }
@@ -224,6 +250,7 @@ const ResidencyParameters &Scene::getResidencyParameters() const {
 
 void Scene::setResidencyParameters(const ResidencyParameters &params) {
   residencyParams = params;
+  residencyParams.normalizeEnvironmentDepthSettings();
 }
 
 bool Scene::getStartCompacted() const { return startCompacted; }

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -94,6 +94,8 @@ struct ResidencyParameters {
   // construction. Disabling this reduces build time at the cost of on-demand
   // rebuilds when residency streaming requires the data.
   bool buildCachedBlas = true;
+
+  void normalizeEnvironmentDepthSettings();
 };
 
 struct TLASNode {


### PR DESCRIPTION
## Summary
- normalize environment depth residency radii/weight pairs when loading parameters
- ensure renderer uses sanitized environment depth configuration
- compute depth weights assuming sorted radii for consistent behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69343784d824832db8e222b736fe451f)