### PR TITLE
Add missing <memory> include to ParallelFor header

### DIFF
--- a/MetalCpp Path Tracer/Renderer/ParallelFor.h
+++ b/MetalCpp Path Tracer/Renderer/ParallelFor.h
@@ -5,6 +5,7 @@
 #include <condition_variable>
 #include <deque>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <utility>


### PR DESCRIPTION
## Summary
- add the <memory> include to ParallelFor.h so std::shared_ptr utilities are available to consumers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934bf50f470832dbea12ab85a3f471e)