### PR TITLE
Fix pending command ownership and close namespace

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -11247,3 +11247,5 @@ size_t Renderer::totalNodeCount() const { return _totalNodeCount; }
 bool Renderer::isAlwaysResidentStrategy() const {
   return _frameStrategy == ResidencyStrategy::AlwaysResident;
 }
+
+} // namespace MetalCppPathTracer

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -76,11 +76,47 @@ struct ResidentObjectGpuResources {
   bool geometryValid = false;
   ResidencyState state = ResidencyState::Cold;
   std::chrono::steady_clock::time_point lastStateChange{};
-  struct PendingCommand {
-    MTL::CommandBuffer *command = nullptr;
-    std::atomic<bool> completed{false};
-    std::atomic<bool> error{false};
-  };
+    struct PendingCommand {
+      MTL::CommandBuffer *command = nullptr;
+      std::atomic<bool> completed{false};
+      std::atomic<bool> error{false};
+
+      PendingCommand() = default;
+      PendingCommand(const PendingCommand &) = delete;
+      PendingCommand &operator=(const PendingCommand &) = delete;
+
+      PendingCommand(PendingCommand &&other) noexcept
+          : command(other.command),
+            completed(other.completed.load(std::memory_order_relaxed)),
+            error(other.error.load(std::memory_order_relaxed)) {
+        other.command = nullptr;
+        other.completed.store(false, std::memory_order_relaxed);
+        other.error.store(false, std::memory_order_relaxed);
+      }
+
+      PendingCommand &operator=(PendingCommand &&other) noexcept {
+        if (this != &other) {
+          if (command)
+            command->release();
+
+          command = other.command;
+          completed.store(other.completed.load(std::memory_order_relaxed),
+                         std::memory_order_relaxed);
+          error.store(other.error.load(std::memory_order_relaxed),
+                     std::memory_order_relaxed);
+
+          other.command = nullptr;
+          other.completed.store(false, std::memory_order_relaxed);
+          other.error.store(false, std::memory_order_relaxed);
+        }
+        return *this;
+      }
+
+      ~PendingCommand() {
+        if (command)
+          command->release();
+      }
+    };
 
   std::vector<PendingCommand> pendingCommands;
   std::mutex pendingCommandsMutex;


### PR DESCRIPTION
## Summary
- add move-only support and destructor for ResidentObjectGpuResources::PendingCommand so vectors can store pending commands safely
- close the MetalCppPathTracer namespace in Renderer.cpp to balance braces

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934c31ac0b8832da488c912c70aadcb)