### PR TITLE
Add configurable unified decay parameters

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -7454,7 +7454,8 @@ std::vector<float> Renderer::computeUnifiedImportance(float &outTotalScore) {
     // When the camera changes, decay cached hit information so the unified
     // score does not overly favor primitives that were visible from a previous
     // viewpoint.
-    const float cameraHitDecay = 0.25f;
+    const float cameraHitDecay =
+        std::clamp(_residencyConfig.cameraHitDecay, 0.0f, 1.0f);
     for (float &hit : _primitiveHitScores)
       hit *= cameraHitDecay;
   }
@@ -7588,7 +7589,8 @@ std::vector<float> Renderer::computeUnifiedImportance(float &outTotalScore) {
   const float beta = _residencyConfig.unifiedHitWeight;
   const float gamma = _residencyConfig.unifiedCoverageWeight;
   const float delta = _residencyConfig.unifiedDistanceWeight;
-  const float offscreenDecay = 0.1f;
+  const float offscreenDecay =
+      std::clamp(_residencyConfig.unifiedOffscreenDecay, 0.0f, 1.0f);
 
   std::vector<size_t> candidateIndices;
   candidateIndices.reserve(primCount);

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -53,6 +53,8 @@ struct ResidencyParameters {
   float unifiedHitWeight = 1.0f;
   float unifiedCoverageWeight = 1.0f;
   float unifiedDistanceWeight = 1.0f;
+  float cameraHitDecay = 0.25f;
+  float unifiedOffscreenDecay = 0.1f;
 
   float rayHitDecay = 0.85f;
   float rayHitTargetFraction = 0.6f;

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -694,6 +694,10 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         "unifiedCoverageWeight", params.unifiedCoverageWeight);
     params.unifiedDistanceWeight = root->FloatAttribute(
         "unifiedDistanceWeight", params.unifiedDistanceWeight);
+    params.cameraHitDecay =
+        root->FloatAttribute("cameraHitDecay", params.cameraHitDecay);
+    params.unifiedOffscreenDecay = root->FloatAttribute(
+        "unifiedOffscreenDecay", params.unifiedOffscreenDecay);
 
     params.rayHitDecay = root->FloatAttribute("rayHitDecay", params.rayHitDecay);
     params.rayHitTargetFraction =


### PR DESCRIPTION
## Summary
- add camera hit decay and offscreen decay controls to residency parameters and XML parsing
- apply configurable decay values inside unified importance calculation

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934ca28d744832dbcc72165216148f8)