### PR TITLE
Add distance LOD env prior toggle

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -7291,10 +7291,22 @@ bool Renderer::updateLODByDistance(bool forceAllToggles) {
                               objectViewExit[objectIndex])
                            : (objectIndex < objectViewEnter.size() &&
                               objectViewEnter[objectIndex]);
+    float enterThreshold = _residencyConfig.lodEnterDistance;
+    float exitThreshold = _residencyConfig.lodExitDistance;
+    if (_residencyConfig.enableDistanceEnvPrior) {
+      float hitProbability =
+          (objectIndex < _objectHitProbability.size())
+              ? std::clamp(_objectHitProbability[objectIndex], 0.0f, 1.0f)
+              : 0.0f;
+      float escapeScore = 1.0f - hitProbability;
+      float priorWeight = 1.0f + (escapeScore - 0.5f) * 0.25f;
+      priorWeight = std::clamp(priorWeight, 0.25f, 4.0f);
+      enterThreshold *= priorWeight;
+      exitThreshold *= priorWeight;
+    }
     bool shouldBeActive = viewAllowed && !behind &&
-                          (currentlyActive
-                               ? (dist <= _residencyConfig.lodExitDistance)
-                               : (dist < _residencyConfig.lodEnterDistance));
+                          (currentlyActive ? (dist <= exitThreshold)
+                                           : (dist < enterThreshold));
     bool canToggle =
         forceAllToggles || objectIndex >= _objectCooldown.size() ||
         _objectCooldown[objectIndex] == 0;

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -89,6 +89,7 @@ struct ResidencyParameters {
   size_t environmentMaxTogglesPerFrame = 16;
   std::vector<float> environmentDepthWeights;
   std::vector<float> environmentDepthRadii;
+  bool enableDistanceEnvPrior = false;
 
   // Allows resident buffers to shrink when most primitives remain inactive.
   bool enableBufferShrink = true;

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -785,6 +785,8 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
     if (const char *depthRadiiAttr = root->Attribute("envDepthRadii")) {
         params.environmentDepthRadii = parseFloatList(depthRadiiAttr);
     }
+    params.enableDistanceEnvPrior = root->BoolAttribute(
+        "enableDistanceEnvPrior", params.enableDistanceEnvPrior);
     params.enableBufferShrink = root->BoolAttribute(
         "enableBufferShrink", params.enableBufferShrink);
     params.bufferShrinkActiveRatio = root->FloatAttribute(


### PR DESCRIPTION
## Summary
- add a residency parameter toggle to gate environment-hit priors in distance LOD
- parse the new flag from scene XML so experiments can enable it
- adjust distance-based activation thresholds when the prior is enabled using per-object environment probabilities

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934e95656d0832da8a7a1991a6b18fd)