### PR TITLE
Handle residency rebuilds after camera movement

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -10429,12 +10429,17 @@ void Renderer::flushResidencyChanges(bool forceFullRebuild) {
                               _recentlyDeactivated.size() +
                               _dirtyResidentObjects.size();
 
+  bool cameraAdvanced = _residentFlushCameraVersion != _cameraVersion;
+
   if (!forceFullRebuild && hasRecentChanges) {
     if (pendingToggleCount < _residentFlushToggleThreshold &&
         _residentFlushCooldown == 0)
       _residentFlushCooldown = _residentFlushCooldownFrames;
 
-    if (_residentFlushCooldown > 0 &&
+    if (cameraAdvanced && pendingToggleCount > 0)
+      _residentFlushCooldown = 0;
+
+    if (!cameraAdvanced && _residentFlushCooldown > 0 &&
         pendingToggleCount < _residentFlushToggleThreshold) {
       --_residentFlushCooldown;
       return;
@@ -10459,6 +10464,7 @@ void Renderer::flushResidencyChanges(bool forceFullRebuild) {
 
   rebuildResidentResources(forceFullRebuild);
   _residentFlushCooldown = _residentFlushCooldownFrames;
+  _residentFlushCameraVersion = _cameraVersion;
 }
 
 void Renderer::drawableSizeWillChange(MTK::View *pView, CGSize size) {

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -508,6 +508,7 @@ private:
   uint32_t _residentFlushCooldownFrames = 2;
   uint32_t _residentFlushCooldown = 0;
   size_t _residentFlushToggleThreshold = 64;
+  uint64_t _residentFlushCameraVersion = 0;
 
   std::vector<ResidentObjectGpuResources> _residentObjectGpuResources;
 


### PR DESCRIPTION
## Summary
- track the camera version used for residency flushes
- bypass residency batching cooldown when the camera advances with pending toggles so rebuilds occur immediately

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693572eded84832d876f3ead0656d77a)