### PR TITLE
Eager residency rebuild on camera motion

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -10409,6 +10409,14 @@ void Renderer::flushResidencyChanges(bool forceFullRebuild) {
                           !_recentlyDeactivated.empty() ||
                           !_dirtyResidentObjects.empty();
 
+  bool hasPendingToggles = !_recentlyActivated.empty() ||
+                           !_recentlyDeactivated.empty();
+  bool cameraAdvanced = _cameraVersion != _lastResidentFlushCameraVersion;
+  bool bypassCooldown = cameraAdvanced && hasPendingToggles;
+
+  if (cameraAdvanced && hasRecentChanges)
+    _residentFlushCooldown = 0;
+
   if (!forceFullRebuild && !hasRecentChanges) {
     for (size_t objectIndex = 0;
          objectIndex < _residentObjectGpuResources.size(); ++objectIndex) {
@@ -10429,7 +10437,7 @@ void Renderer::flushResidencyChanges(bool forceFullRebuild) {
                               _recentlyDeactivated.size() +
                               _dirtyResidentObjects.size();
 
-  if (!forceFullRebuild && hasRecentChanges) {
+  if (!forceFullRebuild && hasRecentChanges && !bypassCooldown) {
     if (pendingToggleCount < _residentFlushToggleThreshold &&
         _residentFlushCooldown == 0)
       _residentFlushCooldown = _residentFlushCooldownFrames;
@@ -10459,6 +10467,7 @@ void Renderer::flushResidencyChanges(bool forceFullRebuild) {
 
   rebuildResidentResources(forceFullRebuild);
   _residentFlushCooldown = _residentFlushCooldownFrames;
+  _lastResidentFlushCameraVersion = _cameraVersion;
 }
 
 void Renderer::drawableSizeWillChange(MTK::View *pView, CGSize size) {

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -491,6 +491,7 @@ private:
   std::vector<uint64_t> _objectBoundsVersion;
   uint64_t _boundsVersionCounter = 1;
   uint64_t _cameraVersion = 1;
+  uint64_t _lastResidentFlushCameraVersion = 0;
   uint64_t _coverageCameraVersion = 0;
   std::vector<size_t> _screenCoverageSortedIndices;
   float _totalPrimitiveImportance = 0.0f;


### PR DESCRIPTION
## Summary
- reset residency flush cooldown when camera advances with pending toggles to avoid delayed rebuilds
- track last camera version so camera changes bypass residency batching when necessary

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69357616046c832d86345ee48c2bc0ae)