### PR TITLE
Reduce residency flush batching

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -506,9 +506,9 @@ private:
   std::vector<bool> _objectResidentState;
 
   // Defer resident rebuilds to batch small bursts of toggles.
-  uint32_t _residentFlushCooldownFrames = 2;
+  uint32_t _residentFlushCooldownFrames = 1;
   uint32_t _residentFlushCooldown = 0;
-  size_t _residentFlushToggleThreshold = 64;
+  size_t _residentFlushToggleThreshold = 16;
 
   std::vector<ResidentObjectGpuResources> _residentObjectGpuResources;
 


### PR DESCRIPTION
## Summary
- lower the residency flush cooldown to trigger rebuilds after a single frame when toggles occur
- reduce the toggle threshold so residency updates happen after fewer object changes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693578afdd74832da0ff00f755ca4a0e)