### PR TITLE
Reduce probability hysteresis for residency

### DIFF
--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -71,7 +71,7 @@ struct ResidencyParameters {
   size_t probabilityMaxTogglesPerFrame = 16;
   float probabilityUncertaintyBoost = 0.25f;
   float probabilityEvidenceWindow = 64.0f;
-  float probabilityDesiredHysteresis = 0.05f;
+  float probabilityDesiredHysteresis = 0.02f;
   uint32_t probabilityRecentPromotionFrames = 4;
   uint32_t probabilityIdleCooldownFrames = 3;
   float probabilityIdleDecay = 0.98f;


### PR DESCRIPTION
## Summary
- reduce the default probabilistic residency hysteresis so enter and exit thresholds converge faster for low-probability objects

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935793328d4832d9f2d79b9072c0366)