### PR TITLE
Accelerate idle probability cooling

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -10818,7 +10818,8 @@ void Renderer::processRayHitCounters() {
   const uint32_t idleCooldownFrames =
       _residencyConfig.probabilityIdleCooldownFrames;
   const float idleGraceDecay =
-      std::clamp(_residencyConfig.probabilityIdleDecay, 0.0f, 1.0f);
+      std::min(probabilityDecay,
+               std::clamp(_residencyConfig.probabilityIdleDecay, 0.0f, 1.0f));
   auto renormalizePosterior = [&](float &alpha, float &beta) {
     float sum = alpha + beta;
     if (!(sum > 0.0f)) {

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -73,8 +73,8 @@ struct ResidencyParameters {
   float probabilityEvidenceWindow = 64.0f;
   float probabilityDesiredHysteresis = 0.02f;
   uint32_t probabilityRecentPromotionFrames = 4;
-  uint32_t probabilityIdleCooldownFrames = 3;
-  float probabilityIdleDecay = 0.98f;
+  uint32_t probabilityIdleCooldownFrames = 0;
+  float probabilityIdleDecay = 0.9f;
   float probabilityVisibleFloor = 0.0f;
   uint32_t probabilityVisibleDemotionDwellFrames = 0;
 


### PR DESCRIPTION
## Summary
- reduce idle grace defaults so probability cooling begins immediately
- clamp idle grace decay to the base probability decay to prevent prolonged residency

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935798894c8832d876db9379d0e9904)