### PR TITLE
Adjust distance prior bias handling

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -7298,9 +7298,11 @@ bool Renderer::updateLODByDistance(bool forceAllToggles) {
           (objectIndex < _objectHitProbability.size())
               ? std::clamp(_objectHitProbability[objectIndex], 0.0f, 1.0f)
               : 0.0f;
-      float escapeScore = 1.0f - hitProbability;
-      float priorWeight = 1.0f + (escapeScore - 0.5f) * 0.25f;
-      priorWeight = std::clamp(priorWeight, 0.25f, 4.0f);
+      float priorScale = std::max(_residencyConfig.distancePriorScale, 0.0f);
+      float bias = _residencyConfig.distancePriorFavorHighProbability ? -1.0f : 1.0f;
+      float priorWeight = 1.0f + (hitProbability - 0.5f) * priorScale * bias;
+      float maxPrior = _residencyConfig.distancePriorFavorHighProbability ? 4.0f : 1.0f;
+      priorWeight = std::clamp(priorWeight, 0.25f, maxPrior);
       enterThreshold *= priorWeight;
       exitThreshold *= priorWeight;
     }

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -90,6 +90,10 @@ struct ResidencyParameters {
   std::vector<float> environmentDepthWeights;
   std::vector<float> environmentDepthRadii;
   bool enableDistanceEnvPrior = false;
+  // Shrinks distance thresholds when recent hit probability is low. Set the
+  // bias flag to true to preserve the original high-hit shrink direction.
+  float distancePriorScale = 0.5f;
+  bool distancePriorFavorHighProbability = false;
 
   // Allows resident buffers to shrink when most primitives remain inactive.
   bool enableBufferShrink = true;

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -787,6 +787,11 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
     }
     params.enableDistanceEnvPrior = root->BoolAttribute(
         "enableDistanceEnvPrior", params.enableDistanceEnvPrior);
+    params.distancePriorScale =
+        root->FloatAttribute("distancePriorScale", params.distancePriorScale);
+    params.distancePriorFavorHighProbability = root->BoolAttribute(
+        "distancePriorFavorHighProbability",
+        params.distancePriorFavorHighProbability);
     params.enableBufferShrink = root->BoolAttribute(
         "enableBufferShrink", params.enableBufferShrink);
     params.bufferShrinkActiveRatio = root->FloatAttribute(

--- a/MetalCpp Path Tracer/scene_distance_lod_crossfire.xml
+++ b/MetalCpp Path Tracer/scene_distance_lod_crossfire.xml
@@ -1,5 +1,6 @@
 <Scene width="960" height="540" maxRayDepth="4" startCompacted="true" residencyStrategy="distance"
-       textureResidencyMemoryCapMB="512" enableDistanceEnvPrior="true"
+       textureResidencyMemoryCapMB="512" enableDistanceEnvPrior="true" distancePriorScale="0.5"
+       distancePriorFavorHighProbability="false"
        lodEnterDistance="28" lodExitDistance="36" residencyCooldown="2" lodToggleBudget="14000">
     <CameraPath>
         <!-- Strafe across staggered occluders so rear clusters cross the exit threshold once the camera moves past -->


### PR DESCRIPTION
## Summary
- invert the distance residency prior to shrink thresholds when hit probability is low
- add configurable scale and bias flag for the distance prior and load them from scenes
- update sample scene defaults to reflect the low-hit bias

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69357d54ec64832d911748f4a626beed)