### PR TITLE
Remove residency flush cooldown batching

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -10440,14 +10440,6 @@ void Renderer::flushResidencyChanges(bool forceFullRebuild) {
                           !_recentlyDeactivated.empty() ||
                           !_dirtyResidentObjects.empty();
 
-  bool hasPendingToggles = !_recentlyActivated.empty() ||
-                           !_recentlyDeactivated.empty();
-  bool cameraAdvanced = _cameraVersion != _lastResidentFlushCameraVersion;
-  bool bypassCooldown = cameraAdvanced && hasPendingToggles;
-
-  if (cameraAdvanced && hasRecentChanges)
-    _residentFlushCooldown = 0;
-
   if (!forceFullRebuild && !hasRecentChanges) {
     for (size_t objectIndex = 0;
          objectIndex < _residentObjectGpuResources.size(); ++objectIndex) {
@@ -10462,22 +10454,6 @@ void Renderer::flushResidencyChanges(bool forceFullRebuild) {
       }
     }
     return;
-  }
-
-  size_t pendingToggleCount = _recentlyActivated.size() +
-                              _recentlyDeactivated.size() +
-                              _dirtyResidentObjects.size();
-
-  if (!forceFullRebuild && hasRecentChanges && !bypassCooldown) {
-    if (pendingToggleCount < _residentFlushToggleThreshold &&
-        _residentFlushCooldown == 0)
-      _residentFlushCooldown = _residentFlushCooldownFrames;
-
-    if (_residentFlushCooldown > 0 &&
-        pendingToggleCount < _residentFlushToggleThreshold) {
-      --_residentFlushCooldown;
-      return;
-    }
   }
 
   std::chrono::steady_clock::time_point frameWaitSnapshot;
@@ -10497,7 +10473,6 @@ void Renderer::flushResidencyChanges(bool forceFullRebuild) {
   }
 
   rebuildResidentResources(forceFullRebuild);
-  _residentFlushCooldown = _residentFlushCooldownFrames;
   _lastResidentFlushCameraVersion = _cameraVersion;
 }
 

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -505,11 +505,6 @@ private:
   std::vector<size_t> _dirtyResidentObjects;
   std::vector<bool> _objectResidentState;
 
-  // Defer resident rebuilds to batch small bursts of toggles.
-  uint32_t _residentFlushCooldownFrames = 1;
-  uint32_t _residentFlushCooldown = 0;
-  size_t _residentFlushToggleThreshold = 16;
-
   std::vector<ResidentObjectGpuResources> _residentObjectGpuResources;
 
   DeferredPurgeQueue<ResidentObjectGpuResources, MTL::CommandBuffer>


### PR DESCRIPTION
## Summary
- rebuild residency resources immediately when changes are pending instead of waiting on cooldown batching
- remove unused residency flush cooldown configuration members

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935f88d3e78832d96a39f775c40ccc6)