### PR TITLE
Allow residency rebuild after frame wait

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -10461,17 +10461,6 @@ void Renderer::flushResidencyChanges(bool forceFullRebuild) {
                                    &frameWaitSnapshot))
     return;
 
-  {
-    std::unique_lock<std::mutex> lock(_frameCommandBufferMutex);
-    auto newerSubmission = std::find_if(
-        _frameCommandBuffers.begin(), _frameCommandBuffers.end(),
-        [frameWaitSnapshot](const FrameCommandBufferRecord &record) {
-          return record.trackedSince >= frameWaitSnapshot;
-        });
-    if (newerSubmission != _frameCommandBuffers.end())
-      return;
-  }
-
   rebuildResidentResources(forceFullRebuild);
   _lastResidentFlushCameraVersion = _cameraVersion;
 }


### PR DESCRIPTION
## Summary
- remove the post-wait early return that blocked residency rebuilds when newer frame command buffers were present
- keep the existing wait protection while allowing rebuildResidentResources to run each frame

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935fb3a8fd8832dad4545a229849cdb)