### PR TITLE
Add unified visibility reentry boost handling

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -7297,6 +7297,8 @@ std::vector<float> Renderer::computeUnifiedImportance(float &outTotalScore) {
     _primitiveCoverageBoundsVersion.assign(primCount, 0);
   if (_primitiveCoverageVisibilityKey.size() != primCount)
     _primitiveCoverageVisibilityKey.assign(primCount, 0xFF);
+  if (_primitiveUnifiedPrevVisible.size() != primCount)
+    _primitiveUnifiedPrevVisible.assign(primCount, 0);
 
   float screenArea = Camera::screenSize.x * Camera::screenSize.y;
   if (screenArea <= 0.0f)
@@ -7466,15 +7468,30 @@ std::vector<float> Renderer::computeUnifiedImportance(float &outTotalScore) {
                     ? _primitiveHitScoresSnapshot[i]
                     : 0.0f;
 
+    bool wasVisible = (i < _primitiveUnifiedPrevVisible.size())
+                          ? (_primitiveUnifiedPrevVisible[i] != 0)
+                          : false;
+
     if (hit == 0.0f && energy == 0.0f && coverage == 0.0f &&
-        distanceScore == 0.0f && !visible)
+        distanceScore == 0.0f && !visible) {
+      _primitiveUnifiedPrevVisible[i] = visible ? 1 : 0;
       continue;
+    }
 
     bool offscreenNoFalloff = !visible && coverage == 0.0f && distanceScore == 0.0f;
     if (offscreenNoFalloff) {
       hit *= offscreenDecay;
       energy *= offscreenDecay;
     }
+
+    bool becameVisible = visible && !wasVisible;
+    if (becameVisible) {
+      hit *= _residencyConfig.unifiedReentryBoost;
+      energy *= _residencyConfig.unifiedReentryBoost;
+    }
+
+    if (i < _primitiveUnifiedPrevVisible.size())
+      _primitiveUnifiedPrevVisible[i] = visible ? 1 : 0;
 
     float score = alpha * energy + beta * hit + gamma * coverage +
                   delta * distanceScore;

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -487,6 +487,7 @@ private:
   std::vector<uint8_t> _primitiveCoverageDirty;
   std::vector<uint64_t> _primitiveCoverageBoundsVersion;
   std::vector<uint8_t> _primitiveCoverageVisibilityKey;
+  std::vector<uint8_t> _primitiveUnifiedPrevVisible;
   std::vector<uint64_t> _primitiveBoundsVersion;
   std::vector<uint64_t> _objectBoundsVersion;
   uint64_t _boundsVersionCounter = 1;

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -57,6 +57,7 @@ struct ResidencyParameters {
   float unifiedDistanceWeight = 1.2f;
   float cameraHitDecay = 0.1f;
   float unifiedOffscreenDecay = 0.05f;
+  float unifiedReentryBoost = 3.0f;
 
   float rayHitDecay = 0.85f;
   float rayHitTargetFraction = 0.6f;

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -698,6 +698,8 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         root->FloatAttribute("cameraHitDecay", params.cameraHitDecay);
     params.unifiedOffscreenDecay = root->FloatAttribute(
         "unifiedOffscreenDecay", params.unifiedOffscreenDecay);
+    params.unifiedReentryBoost =
+        root->FloatAttribute("unifiedReentryBoost", params.unifiedReentryBoost);
 
     params.rayHitDecay = root->FloatAttribute("rayHitDecay", params.rayHitDecay);
     params.rayHitTargetFraction =


### PR DESCRIPTION
## Summary
- track previous-frame visibility during unified importance computation to boost hit and energy when primitives re-enter the view
- add a configurable `unifiedReentryBoost` residency parameter and plumb it through scene loading

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936116a5ec4832da94a07c377aa9299)