### PR TITLE
Defer BLAS eviction until pending commands finish

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -216,9 +216,11 @@ bool ResidentObjectGpuResources::hasPendingCommands() {
   return false;
 }
 
-void ResidentObjectGpuResources::transitionToCold(
+bool ResidentObjectGpuResources::transitionToCold(
     BlasInstanceRecord &instanceRecord) {
   clearPendingCommand();
+  if (hasPendingCommands())
+    return false;
   resources.makeResourcesPurgeable();
   resources.releaseAllAllocations();
   byteSize = 0;
@@ -233,6 +235,7 @@ void ResidentObjectGpuResources::transitionToCold(
   instanceRecord.primitiveIndexBase = 0;
   instanceRecord.blasRootIndex = -1;
   instanceRecord.primitiveCount = 0;
+  return true;
 }
 
 bool ResidentObjectGpuResources::ensureResident(
@@ -3206,8 +3209,14 @@ bool Renderer::transitionResidentToCold(size_t objectIndex,
     return false;
   }
 
-  resident.transitionToCold(instanceRecord);
+  bool transitioned = resident.transitionToCold(instanceRecord);
   lock.unlock();
+
+  if (!transitioned) {
+    if (removePending)
+      _pendingBlasEvictions.enqueue(objectIndex, resident);
+    return false;
+  }
 
   if (removePending)
     _pendingBlasEvictions.cancel(objectIndex, resident);

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -62,7 +62,7 @@ struct ResidentObjectGpuResources {
                       BlasInstanceRecord &instanceRecord,
                       bool forceRebuild);
   void transitionToStreaming(MTL::CommandBuffer *pending = nullptr);
-  void transitionToCold(BlasInstanceRecord &instanceRecord);
+  bool transitionToCold(BlasInstanceRecord &instanceRecord);
   void clearPendingCommand();
   bool hasPendingCommands();
   bool isResident() const { return state == ResidencyState::Resident; }


### PR DESCRIPTION
## Summary
- add a pending-command guard before purging BLAS resources
- requeue BLAS evictions when GPU work is still outstanding
- propagate transition results so evictions wait for command completion

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936155a2ec8832d8f29a854b7b545ce)