### PR TITLE
Add environment escape feedback to residency budget

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1408,7 +1408,8 @@ void Renderer::writeBenchmarkHeader() {
          "lod_exit_view_margin,energy_target_fraction,"
          "energy_min_active,energy_visibility_boost,screen_target_fraction,"
          "screen_min_pixels,screen_min_active,environment_target_fraction,"
-         "environment_escape_threshold,environment_min_active,environment_toggle_budget,"
+         "environment_escape_threshold,env_high_escape,env_low_escape,global_env_escape,"
+         "environment_activation_floor,environment_min_active,environment_toggle_budget,"
          "unified_offscreen_decay,unified_offscreen_floor,environment_depth_weights,"
          "environment_depth_radii";
   _benchmarkStream << '\n';
@@ -1514,6 +1515,10 @@ void Renderer::writeBenchmarkRow(const BenchmarkSample &sample) {
       << _residencyConfig.screenFootprintMinActivePrimitives << ','
       << formatFixed(sample.environmentTargetActiveFraction, 3) << ','
       << formatFixed(sample.environmentEscapeThreshold, 3) << ','
+      << formatFixed(sample.envHighEscapeThreshold, 3) << ','
+      << formatFixed(sample.envLowEscapeThreshold, 3) << ','
+      << formatFixed(sample.globalEnvEscape, 6) << ','
+      << sample.environmentActivationFloor << ','
       << _residencyConfig.environmentMinActivePrimitives << ','
       << _residencyConfig.environmentMaxTogglesPerFrame << ','
       << formatFixed(_residencyConfig.unifiedOffscreenDecay, 3) << ','
@@ -1538,6 +1543,8 @@ std::string Renderer::residencyStrategyName(ResidencyStrategy strategy) const {
     return "Probabilistic";
   case ResidencyStrategy::UnifiedScore:
     return "Unified score";
+  case ResidencyStrategy::PredictiveEnvironment:
+    return "Predictive environment";
   case ResidencyStrategy::EnvironmentHit:
     return "Environment hit";
   case ResidencyStrategy::AlwaysResident:
@@ -2352,6 +2359,9 @@ void Renderer::updateVisibleScene() {
   case ResidencyStrategy::UnifiedScore:
     strategyName = "Unified score";
     break;
+  case ResidencyStrategy::PredictiveEnvironment:
+    strategyName = "Predictive environment";
+    break;
   case ResidencyStrategy::EnvironmentHit:
     strategyName = "Environment hit";
     break;
@@ -2468,8 +2478,11 @@ void Renderer::updateVisibleScene() {
                       0.0f);
 
   constexpr size_t kStatsPerPrimitive = 2;
+  constexpr size_t kGlobalRayStatsCount = 2;
   size_t hitCount = std::max<size_t>(_maxPrimitiveCount, 1);
-  size_t hitBytes = hitCount * kStatsPerPrimitive * sizeof(uint32_t);
+  size_t hitBytes =
+      hitCount * kStatsPerPrimitive * sizeof(uint32_t) +
+      kGlobalRayStatsCount * sizeof(uint32_t);
   flushRayHitCopy();
   ensureBufferCapacity(_pPrimitiveHitBufferGPU, hitBytes,
                        _primitiveHitBufferCapacity, false,
@@ -6930,6 +6943,7 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   _frameObjectActivations = 0;
   _frameObjectDeactivations = 0;
   _frameProbabilisticToggles = 0;
+  _frameEnvironmentActivationFloor = 0;
   ResidencyStrategy strategy = _pScene->getResidencyStrategy();
   if (strategy != _lastResidencyStrategy) {
     if (strategy == ResidencyStrategy::AlwaysResident)
@@ -6963,6 +6977,9 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
     break;
   case ResidencyStrategy::ScreenSpaceFootprint:
     changed = updateScreenSpaceFootprint(forceAllToggles);
+    break;
+  case ResidencyStrategy::PredictiveEnvironment:
+    changed = updatePredictiveResidency(forceAllToggles);
     break;
   case ResidencyStrategy::EnvironmentHit:
     changed = updateEnvironmentHitResidency(forceAllToggles);
@@ -9964,11 +9981,369 @@ bool Renderer::updateScreenSpaceFootprint(bool forceAllToggles) {
   return changed;
 }
 
+bool Renderer::updatePredictiveResidency(bool forceAllToggles) {
+  size_t objectCount = _allSceneObjects.size();
+  size_t primitiveCount = _activePrimitive.size();
+  if (objectCount == 0 || primitiveCount == 0)
+    return false;
+
+  _frameEnvironmentActivationFloor = 0;
+
+  if (_objectProbabilitySortedIndices.size() != objectCount) {
+    _objectProbabilitySortedIndices.resize(objectCount);
+    std::iota(_objectProbabilitySortedIndices.begin(),
+              _objectProbabilitySortedIndices.end(), size_t(0));
+  }
+
+  if (_objectImportance.size() != objectCount)
+    _objectImportance.assign(objectCount, 0.0f);
+  else
+    std::fill(_objectImportance.begin(), _objectImportance.end(), 0.0f);
+
+  if (_objectVisible.size() < objectCount)
+    _objectVisible.resize(objectCount, 0u);
+
+  std::vector<uint8_t> desiredObjectState(objectCount, 0);
+  std::vector<float> weightedPredictive(objectCount, 0.0f);
+
+  auto computeDepthWeight = [&](size_t objectIndex) -> float {
+    const auto &weights = _residencyConfig.environmentDepthWeights;
+    if (weights.empty())
+      return 1.0f;
+    const auto &radii = _residencyConfig.environmentDepthRadii;
+    size_t pairCount = std::min(weights.size(), radii.size());
+    if (pairCount == 0)
+      return weights.back();
+    float fallbackWeight = weights[pairCount - 1];
+    if (objectIndex >= _objectBounds.size())
+      return fallbackWeight;
+
+    simd::float3 toCenter = _objectBounds[objectIndex].center - Camera::position;
+    float distance = simd::length(toCenter);
+    if (!(distance > 0.0f))
+      return weights.front();
+
+    auto end = radii.begin() + pairCount;
+    auto lowerBound = std::lower_bound(radii.begin(), end, distance);
+    if (lowerBound != end)
+      return weights[std::distance(radii.begin(), lowerBound)];
+    return fallbackWeight;
+  };
+
+  constexpr float kExplorationPriorFloor = 1.0e-4f;
+  constexpr float kExplorationPriorScale = 0.5f;
+
+  constexpr float kVisibleWeightBoost = 2.0f;
+  constexpr float kHiddenWeightPenalty = 0.05f;
+
+  for (size_t objectIndex = 0; objectIndex < objectCount; ++objectIndex) {
+    float hitProbability =
+        (objectIndex < _objectHitProbability.size())
+            ? std::clamp(_objectHitProbability[objectIndex], 0.0f, 1.0f)
+            : 0.0f;
+    bool hasEvidence =
+        (objectIndex < _objectRaysTestedLastFrame.size())
+            ? (_objectRaysTestedLastFrame[objectIndex] > 0)
+            : false;
+    bool currentlyActive =
+        (objectIndex < _objectActive.size()) ? _objectActive[objectIndex] : false;
+
+    bool visible =
+        (objectIndex < _objectBounds.size()) ? isInView(_objectBounds[objectIndex])
+                                             : false;
+    if (objectIndex < _objectVisible.size())
+      _objectVisible[objectIndex] = visible ? 1u : 0u;
+
+    if (!hasEvidence && !currentlyActive) {
+      float exploration =
+          (objectIndex < _objectExplorationScore.size())
+              ? std::max(_objectExplorationScore[objectIndex], 0.0f)
+              : 0.0f;
+      float visibilityHint =
+          (objectIndex < _objectVisible.size()) ? _objectVisible[objectIndex] : 0u;
+      float explorationPrior = 1.0f -
+                               std::exp(-exploration * kExplorationPriorScale);
+      if (visibilityHint) {
+        float hintedPrior = 1.0f -
+                            std::exp(-kIdleVisibleExploreSeed *
+                                     kExplorationPriorScale);
+        explorationPrior = std::max(explorationPrior, hintedPrior);
+      }
+      explorationPrior =
+          std::clamp(explorationPrior, kExplorationPriorFloor, 1.0f);
+      hitProbability = std::max(hitProbability, explorationPrior);
+    }
+
+    float rayHitScore =
+        (objectIndex < _objectRayHitScore.size()) ? _objectRayHitScore[objectIndex]
+                                                  : 0.0f;
+    size_t primitiveBudget =
+        (objectIndex < _allSceneObjects.size())
+            ? _allSceneObjects[objectIndex].primitiveCount
+            : size_t(0);
+    float normalizedHitScore = rayHitScore;
+    if (primitiveBudget > 0)
+      normalizedHitScore /= static_cast<float>(primitiveBudget);
+    if (normalizedHitScore <= 0.0f && (currentlyActive || visible))
+      normalizedHitScore = 1.0f;
+
+    _objectImportance[objectIndex] = hitProbability;
+
+    float predictiveScore = normalizedHitScore * hitProbability;
+    float depthWeight = computeDepthWeight(objectIndex);
+    float visibilityWeight = visible ? kVisibleWeightBoost : kHiddenWeightPenalty;
+    float weighted = predictiveScore * std::max(depthWeight, 0.0f) *
+                     std::max(visibilityWeight, 0.0f);
+    weightedPredictive[objectIndex] = std::isfinite(weighted) ? weighted : 0.0f;
+  }
+
+  auto &sortedIndices = _objectProbabilitySortedIndices;
+  std::sort(sortedIndices.begin(), sortedIndices.end(),
+            [&](size_t a, size_t b) {
+              float scoreA =
+                  (a < weightedPredictive.size()) ? weightedPredictive[a] : 0.0f;
+              float scoreB =
+                  (b < weightedPredictive.size()) ? weightedPredictive[b] : 0.0f;
+              if (scoreA == scoreB) {
+                float importanceA =
+                    (a < _objectImportance.size()) ? _objectImportance[a] : 0.0f;
+                float importanceB =
+                    (b < _objectImportance.size()) ? _objectImportance[b] : 0.0f;
+                if (importanceA == importanceB)
+                  return a < b;
+                return importanceA > importanceB;
+              }
+              return scoreA > scoreB;
+            });
+
+  float escapeThreshold =
+      std::clamp(_residencyConfig.environmentEscapeThreshold, 0.0f, 1.0f);
+  size_t minActivePrimitives =
+      std::min(primitiveCount, _residencyConfig.environmentMinActivePrimitives);
+  if (minActivePrimitives == 0 && primitiveCount > 0)
+    minActivePrimitives = 1;
+
+  float targetFraction =
+      std::clamp(_residencyConfig.environmentTargetActiveFraction, 0.0f, 1.0f);
+  size_t targetPrimitiveCount = 0;
+  if (targetFraction > 0.0f && primitiveCount > 0) {
+    targetPrimitiveCount = static_cast<size_t>(std::ceil(
+        targetFraction * static_cast<float>(primitiveCount)));
+    targetPrimitiveCount = std::min(targetPrimitiveCount, primitiveCount);
+  }
+  size_t activationFloor = std::max(minActivePrimitives, targetPrimitiveCount);
+
+  float globalEscape = _lastFrameGlobalEnvEscape;
+  float high = std::clamp(_residencyConfig.envHighEscapeThreshold, 0.0f, 1.0f);
+  float low = std::clamp(_residencyConfig.envLowEscapeThreshold, 0.0f, high);
+
+  if (globalEscape > high) {
+    activationFloor = std::min(
+        primitiveCount, static_cast<size_t>(activationFloor * 1.5f));
+  } else if (globalEscape < low) {
+    activationFloor = std::max(
+        minActivePrimitives, static_cast<size_t>(activationFloor * 0.8f));
+  }
+
+  if (activationFloor == 0 && primitiveCount > 0)
+    activationFloor = 1;
+  _frameEnvironmentActivationFloor = activationFloor;
+
+  size_t desiredPrimitiveCount = 0;
+  float weightedEscape = 0.0f;
+  auto averageEscape = [](size_t primCount, float weighted) {
+    if (primCount == 0)
+      return 1.0f;
+    return weighted / static_cast<float>(primCount);
+  };
+
+  for (size_t objectIndex : sortedIndices) {
+    if (objectIndex >= _allSceneObjects.size())
+      continue;
+    const SceneObject &object = _allSceneObjects[objectIndex];
+    if (object.primitiveCount == 0)
+      continue;
+
+    bool needMorePrimitives = desiredPrimitiveCount < activationFloor;
+    bool needsEscapeReduction =
+        averageEscape(desiredPrimitiveCount, weightedEscape) > escapeThreshold;
+    if (!needMorePrimitives && !needsEscapeReduction)
+      break;
+
+    desiredObjectState[objectIndex] = 1;
+    desiredPrimitiveCount += object.primitiveCount;
+    float escapeProbability =
+        1.0f - ((objectIndex < _objectImportance.size())
+                    ? _objectImportance[objectIndex]
+                    : 0.0f);
+    weightedEscape += escapeProbability * static_cast<float>(object.primitiveCount);
+  }
+
+  if (desiredPrimitiveCount == 0 && primitiveCount > 0) {
+    for (size_t objectIndex : sortedIndices) {
+      if (objectIndex >= _allSceneObjects.size())
+        continue;
+      const SceneObject &object = _allSceneObjects[objectIndex];
+      if (object.primitiveCount == 0)
+        continue;
+      desiredObjectState[objectIndex] = 1;
+      desiredPrimitiveCount = object.primitiveCount;
+      float escapeProbability =
+          1.0f - ((objectIndex < _objectImportance.size())
+                      ? _objectImportance[objectIndex]
+                      : 0.0f);
+      weightedEscape =
+          escapeProbability * static_cast<float>(object.primitiveCount);
+      break;
+    }
+  }
+
+  bool changed = false;
+  size_t offscreenActivePrimitiveCount = 0;
+  for (size_t objectIndex = 0; objectIndex < objectCount; ++objectIndex) {
+    bool active =
+        (objectIndex < _objectActive.size()) ? _objectActive[objectIndex] : false;
+    bool visible = (objectIndex < _objectVisible.size())
+                       ? (_objectVisible[objectIndex] != 0)
+                       : false;
+    if (!active || visible)
+      continue;
+
+    size_t primitives = 0;
+    if (objectIndex < _objectPrimitiveCounts.size())
+      primitives = _objectPrimitiveCounts[objectIndex];
+    else if (objectIndex < _allSceneObjects.size())
+      primitives = _allSceneObjects[objectIndex].primitiveCount;
+
+    offscreenActivePrimitiveCount += primitives;
+  }
+
+  size_t baseToggleBudget = _residencyConfig.environmentMaxTogglesPerFrame;
+  size_t maxToggleBudget = baseToggleBudget;
+  if (offscreenActivePrimitiveCount > baseToggleBudget) {
+    size_t catchUpBudget = (offscreenActivePrimitiveCount + 1) / 2;
+    maxToggleBudget = std::max(baseToggleBudget, catchUpBudget);
+  }
+
+  size_t reservedOffscreenBudget =
+      (maxToggleBudget == 0) ? 0 : std::max<size_t>(1, maxToggleBudget / 4);
+  size_t generalBudget =
+      (maxToggleBudget > reservedOffscreenBudget)
+          ? (maxToggleBudget - reservedOffscreenBudget)
+          : 0;
+  size_t totalBudget = maxToggleBudget + reservedOffscreenBudget;
+
+  size_t toggledPrimitiveCount = 0;
+
+  for (size_t objectIndex : sortedIndices) {
+    bool shouldBeActive =
+        (objectIndex < desiredObjectState.size()) ? desiredObjectState[objectIndex]
+                                                  : 0;
+    bool currentlyActive =
+        (objectIndex < _objectActive.size()) ? _objectActive[objectIndex] : false;
+    if (shouldBeActive == currentlyActive)
+      continue;
+
+    bool visible = (objectIndex < _objectVisible.size())
+                       ? (_objectVisible[objectIndex] != 0)
+                       : false;
+    float importance =
+        (objectIndex < _objectImportance.size()) ? _objectImportance[objectIndex]
+                                                 : 0.0f;
+    bool lowImportanceOffscreen = !visible && (importance < escapeThreshold);
+    bool bypassCooldowns = currentlyActive && !shouldBeActive &&
+                           lowImportanceOffscreen;
+
+    if (!forceAllToggles && !bypassCooldowns && objectIndex < _objectCooldown.size() &&
+        _objectCooldown[objectIndex] > 0)
+      continue;
+
+    const SceneObject &object = _allSceneObjects[objectIndex];
+    size_t first = object.firstPrimitive;
+    size_t last = std::min(first + object.primitiveCount, _activePrimitive.size());
+    if (last <= first)
+      continue;
+
+    bool canToggle = true;
+    size_t pendingToggles = 0;
+    for (size_t prim = first; prim < last; ++prim) {
+      if (_activePrimitive[prim] == shouldBeActive)
+        continue;
+      if (!forceAllToggles && !bypassCooldowns && prim < _primitiveCooldown.size() &&
+          _primitiveCooldown[prim] > 0) {
+        canToggle = false;
+        break;
+      }
+      ++pendingToggles;
+    }
+
+    if (!canToggle || pendingToggles == 0)
+      continue;
+
+    if (!forceAllToggles) {
+      if (bypassCooldowns) {
+        if (toggledPrimitiveCount >= totalBudget)
+          continue;
+      } else {
+        if (toggledPrimitiveCount >= generalBudget)
+          continue;
+      }
+    }
+
+    size_t toggled = setObjectActive(objectIndex, shouldBeActive);
+    if (toggled > 0) {
+      changed = true;
+      if (!forceAllToggles) {
+        toggledPrimitiveCount =
+            std::min(toggledPrimitiveCount + toggled, totalBudget);
+      }
+    }
+  }
+
+  bool anyActiveObject = false;
+  for (size_t objectIndex = 0; objectIndex < objectCount; ++objectIndex) {
+    if (objectIndex >= _objectActive.size())
+      continue;
+    if (objectIndex >= _objectPrimitiveCounts.size())
+      continue;
+    if (_objectPrimitiveCounts[objectIndex] == 0)
+      continue;
+    if (_objectActive[objectIndex]) {
+      anyActiveObject = true;
+      break;
+    }
+  }
+
+  if (!anyActiveObject) {
+    for (size_t objectIndex : sortedIndices) {
+      if (objectIndex >= _objectPrimitiveCounts.size())
+        continue;
+      if (_objectPrimitiveCounts[objectIndex] == 0)
+        continue;
+      if (setObjectActive(objectIndex, true) > 0) {
+        changed = true;
+        anyActiveObject = true;
+      }
+      if (anyActiveObject)
+        break;
+    }
+  }
+
+  if (!anyActiveObject && !_activePrimitive.empty()) {
+    if (setPrimitiveActive(0, true))
+      changed = true;
+  }
+
+  return changed;
+}
+
 bool Renderer::updateEnvironmentHitResidency(bool forceAllToggles) {
   size_t objectCount = _allSceneObjects.size();
   size_t primitiveCount = _activePrimitive.size();
   if (objectCount == 0 || primitiveCount == 0)
     return false;
+
+  _frameEnvironmentActivationFloor = 0;
 
   if (_objectProbabilitySortedIndices.size() != objectCount) {
     _objectProbabilitySortedIndices.resize(objectCount);
@@ -10099,8 +10474,22 @@ bool Renderer::updateEnvironmentHitResidency(bool forceAllToggles) {
     targetPrimitiveCount = std::min(targetPrimitiveCount, primitiveCount);
   }
   size_t activationFloor = std::max(minActivePrimitives, targetPrimitiveCount);
+
+  float globalEscape = _lastFrameGlobalEnvEscape;
+  float high = std::clamp(_residencyConfig.envHighEscapeThreshold, 0.0f, 1.0f);
+  float low = std::clamp(_residencyConfig.envLowEscapeThreshold, 0.0f, high);
+
+  if (globalEscape > high) {
+    activationFloor = std::min(
+        primitiveCount, static_cast<size_t>(activationFloor * 1.5f));
+  } else if (globalEscape < low) {
+    activationFloor = std::max(
+        minActivePrimitives, static_cast<size_t>(activationFloor * 0.8f));
+  }
+
   if (activationFloor == 0 && primitiveCount > 0)
     activationFloor = 1;
+  _frameEnvironmentActivationFloor = activationFloor;
 
   size_t desiredPrimitiveCount = 0;
   float weightedEscape = 0.0f;
@@ -10499,6 +10888,8 @@ bool Renderer::flushRayHitCopy() {
 }
 
 void Renderer::processRayHitCounters() {
+  _lastFrameGlobalEnvEscape = 0.0f;
+
   if (!flushRayHitCopy())
     return;
 
@@ -10520,6 +10911,7 @@ void Renderer::processRayHitCounters() {
     _objectHitVariance.clear();
     _objectPosteriorMass.clear();
     _objectExplorationScore.clear();
+    _objectRayHitScore.clear();
     _objectHitLastFrame.clear();
     _objectRaysTestedLastFrame.clear();
     _objectVisible.clear();
@@ -10549,6 +10941,7 @@ void Renderer::processRayHitCounters() {
     _objectHitVariance.clear();
     _objectPosteriorMass.clear();
     _objectExplorationScore.clear();
+    _objectRayHitScore.clear();
     _objectHitLastFrame.clear();
     _objectRaysTestedLastFrame.clear();
     _objectVisible.clear();
@@ -10577,6 +10970,7 @@ void Renderer::processRayHitCounters() {
     _objectHitVariance.clear();
     _objectPosteriorMass.clear();
     _objectExplorationScore.clear();
+    _objectRayHitScore.clear();
     _objectHitLastFrame.clear();
     _objectRaysTestedLastFrame.clear();
     _objectVisible.clear();
@@ -10592,6 +10986,7 @@ void Renderer::processRayHitCounters() {
       strategy == ResidencyStrategy::RayHitBudget ||
       strategy == ResidencyStrategy::Probabilistic ||
       strategy == ResidencyStrategy::EnvironmentHit ||
+      strategy == ResidencyStrategy::PredictiveEnvironment ||
       strategy == ResidencyStrategy::UnifiedScore;
   if (!strategyUsesHits) {
     std::memset(hitPtr, 0, bufferLength);
@@ -10625,9 +11020,22 @@ void Renderer::processRayHitCounters() {
     return;
 
   constexpr size_t kStatsPerPrimitive = 2;
+  constexpr size_t kGlobalRayStatsCount = 2;
   size_t bufferCount = bufferLength / sizeof(uint32_t);
-  size_t count = std::min(totalPrimitiveCount, bufferCount / kStatsPerPrimitive);
-  if (count == 0)
+  size_t availableForPrimitives =
+      (bufferCount >= kGlobalRayStatsCount)
+          ? (bufferCount - kGlobalRayStatsCount)
+          : size_t(0);
+  size_t count =
+      std::min(totalPrimitiveCount, availableForPrimitives / kStatsPerPrimitive);
+  size_t globalStatsBase = count * kStatsPerPrimitive;
+  uint32_t envHitCount = 0;
+  uint32_t totalRayCount = 0;
+  if (bufferCount >= globalStatsBase + kGlobalRayStatsCount) {
+    envHitCount = hitPtr[globalStatsBase + 0];
+    totalRayCount = hitPtr[globalStatsBase + 1];
+  }
+  if (count == 0 && totalRayCount == 0)
     return;
 
   if (_primitiveHitScores.size() < totalPrimitiveCount)
@@ -10831,10 +11239,21 @@ void Renderer::processRayHitCounters() {
                              if (wasVisible)
                                exploration =
                                    std::max(exploration, kIdleVisibleExploreSeed);
-                             _primitiveExplorationScore[i] = exploration;
-                           }
-                         });
+                           _primitiveExplorationScore[i] = exploration;
+                         }
+                       });
   }
+
+  if (bufferCount >= globalStatsBase + kGlobalRayStatsCount) {
+    hitPtr[globalStatsBase + 0] = 0;
+    hitPtr[globalStatsBase + 1] = 0;
+  }
+
+  _lastFrameGlobalEnvEscape =
+      (totalRayCount > 0)
+          ? static_cast<float>(envHitCount) /
+                static_cast<float>(std::max(totalRayCount, 1u))
+          : 0.0f;
 
   size_t objectCount = _allSceneObjects.size();
   if (objectCount == 0) {
@@ -10844,6 +11263,7 @@ void Renderer::processRayHitCounters() {
     _objectHitVariance.clear();
     _objectPosteriorMass.clear();
     _objectExplorationScore.clear();
+    _objectRayHitScore.clear();
     _objectHitLastFrame.clear();
     _objectRaysTestedLastFrame.clear();
     _objectVisible.clear();
@@ -10863,6 +11283,8 @@ void Renderer::processRayHitCounters() {
     _objectPosteriorMass.resize(objectCount, 2.0f);
   if (_objectExplorationScore.size() < objectCount)
     _objectExplorationScore.resize(objectCount, 0.0f);
+  if (_objectRayHitScore.size() < objectCount)
+    _objectRayHitScore.resize(objectCount, 0.0f);
   if (_objectHitLastFrame.size() < objectCount)
     _objectHitLastFrame.resize(objectCount, 0u);
   if (_objectRaysTestedLastFrame.size() < objectCount)
@@ -10911,6 +11333,9 @@ void Renderer::processRayHitCounters() {
     _objectHitLastFrame[objectIndex] = static_cast<uint32_t>(success);
     _objectRaysTestedLastFrame[objectIndex] =
         static_cast<uint32_t>(raysTested);
+    float decayedHits =
+        (_objectRayHitScore[objectIndex] * rayHitDecay) + success;
+    _objectRayHitScore[objectIndex] = decayedHits;
 
     float failure = std::max(raysTested - success, 0.0f);
     float alpha = _objectHitAlpha[objectIndex] * probabilityDecay + success;
@@ -11144,6 +11569,10 @@ void Renderer::beginFrameMetrics() {
         _residencyConfig.environmentTargetActiveFraction;
     sample.environmentEscapeThreshold =
         _residencyConfig.environmentEscapeThreshold;
+    sample.envHighEscapeThreshold = _residencyConfig.envHighEscapeThreshold;
+    sample.envLowEscapeThreshold = _residencyConfig.envLowEscapeThreshold;
+    sample.globalEnvEscape = _lastFrameGlobalEnvEscape;
+    sample.environmentActivationFloor = _frameEnvironmentActivationFloor;
     sample.environmentDepthWeights =
         formatFloatList(_residencyConfig.environmentDepthWeights);
     sample.environmentDepthRadii =

--- a/MetalCpp Path Tracer/Renderer/Renderer.h
+++ b/MetalCpp Path Tracer/Renderer/Renderer.h
@@ -172,6 +172,7 @@ private:
   void resetProbabilisticResidencyState();
   bool updateScreenSpaceFootprint(bool forceAllToggles);
   bool updateEnvironmentHitResidency(bool forceAllToggles);
+  bool updatePredictiveResidency(bool forceAllToggles);
   bool updateAlwaysResident(bool forceAllToggles);
   void flushResidencyChanges(bool forceFullRebuild);
   void beginFrameMetrics();
@@ -404,6 +405,10 @@ private:
     double environmentEscapeThreshold = 0.0;
     std::string environmentDepthWeights;
     std::string environmentDepthRadii;
+    double envHighEscapeThreshold = 0.0;
+    double envLowEscapeThreshold = 0.0;
+    double globalEnvEscape = 0.0;
+    size_t environmentActivationFloor = 0;
     ResidencyStrategy strategy = ResidencyStrategy::DistanceLOD;
     std::string strategyName;
     uint32_t minSamplesPerPixel = 1;
@@ -476,6 +481,7 @@ private:
   std::vector<float> _objectHitVariance;
   std::vector<float> _objectPosteriorMass;
   std::vector<float> _objectExplorationScore;
+  std::vector<float> _objectRayHitScore;
   std::vector<uint32_t> _objectHitLastFrame;
   std::vector<uint32_t> _objectRaysTestedLastFrame;
   std::vector<uint32_t> _objectIdleFrames;
@@ -537,6 +543,7 @@ private:
   size_t _lightCount = 0;
   float _lightTotalWeight = 0.0f;
   float _lastActivePrimitiveRatio = 1.0f;
+  float _lastFrameGlobalEnvEscape = 0.0f;
 
   bool _residentBuffersInitialized = false;
   bool _residentCompacted = false;
@@ -622,6 +629,7 @@ private:
   size_t _frameProbabilityFinalDesiredPrimitives = 0;
   size_t _frameProbabilityTrimmedPrimitives = 0;
   bool _frameProbabilityBudgetHit = false;
+  size_t _frameEnvironmentActivationFloor = 0;
   ResidencyStrategy _frameStrategy = ResidencyStrategy::DistanceLOD;
   ResidencyStrategy _lastResidencyStrategy = ResidencyStrategy::DistanceLOD;
   AlwaysResidentCache _alwaysResidentCache;

--- a/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/MetalCpp Path Tracer/Renderer/Shaders/PathTracing.h
@@ -681,7 +681,16 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
   float4 absorption = float4(1.0);
   float4 light = float4(0.0);
 
+  uint globalStatsBase = totalPrimitiveCount * 2u;
+  uint envHitIndex = globalStatsBase;
+  uint totalRayIndex = globalStatsBase + 1u;
+
   for (uint depth = 0; depth < maxRayDepth; ++depth) {
+    if (primitiveRayStats) {
+      atomic_fetch_add_explicit(&primitiveRayStats[totalRayIndex], 1u,
+                                memory_order_relaxed);
+    }
+
     TlasLeafCache bounceCache;
     bounceCache.valid = false;
     intersection bestHit = firstHitTLAS(
@@ -690,6 +699,11 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
         totalPrimitiveCount, primitiveRayStats, &bounceCache);
 
     if (bestHit.primitiveId == -1) {
+      if (primitiveRayStats) {
+        atomic_fetch_add_explicit(&primitiveRayStats[envHitIndex], 1u,
+                                  memory_order_relaxed);
+      }
+
       float3 unitDir = normalize(r.direction);
       if (environmentEnabled > 0 && environmentIntensity > 0.0f) {
         uint envWidth = environmentMap.get_width();

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -20,7 +20,8 @@ enum class ResidencyStrategy {
   Probabilistic = 4,
   AlwaysResident = 5,
   EnvironmentHit = 6,
-  UnifiedScore = 7,
+  PredictiveEnvironment = 7,
+  UnifiedScore = 8,
 };
 
 struct SceneObject {
@@ -92,6 +93,8 @@ struct ResidencyParameters {
 
   float environmentTargetActiveFraction = 0.0f;
   float environmentEscapeThreshold = 0.4f;
+  float envHighEscapeThreshold = 0.6f;
+  float envLowEscapeThreshold = 0.3f;
   size_t environmentMinActivePrimitives = 16;
   size_t environmentMaxTogglesPerFrame = 16;
   std::vector<float> environmentDepthWeights;

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -656,6 +656,9 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
                    value == "environment_hit" || value == "envhit" ||
                    value == "env_hit" || value == "env") {
             scene->setResidencyStrategy(ResidencyStrategy::EnvironmentHit);
+        } else if (value == "predictive" || value == "predictive_environment" ||
+                   value == "predictive-env" || value == "predictive_env") {
+            scene->setResidencyStrategy(ResidencyStrategy::PredictiveEnvironment);
         } else {
             printf("Unknown residency strategy '%s', defaulting to distance LOD.\n",
                    residencyAttr);
@@ -770,6 +773,15 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         "environmentTargetEscapeFraction", params.environmentEscapeThreshold);
     params.environmentEscapeThreshold = root->FloatAttribute(
         "envEscapeThreshold", params.environmentEscapeThreshold);
+
+    params.envHighEscapeThreshold = root->FloatAttribute(
+        "environmentHighEscapeThreshold", params.envHighEscapeThreshold);
+    params.envHighEscapeThreshold = root->FloatAttribute(
+        "envHighEscapeThreshold", params.envHighEscapeThreshold);
+    params.envLowEscapeThreshold = root->FloatAttribute(
+        "environmentLowEscapeThreshold", params.envLowEscapeThreshold);
+    params.envLowEscapeThreshold = root->FloatAttribute(
+        "envLowEscapeThreshold", params.envLowEscapeThreshold);
 
     uint64_t minEnvActive = root->Unsigned64Attribute(
         "environmentMinActive",

--- a/MetalCpp Path Tracer/scene_predictive_crossfire.xml
+++ b/MetalCpp Path Tracer/scene_predictive_crossfire.xml
@@ -1,0 +1,54 @@
+<Scene width="960" height="540" maxRayDepth="4" startCompacted="true" residencyStrategy="predictive"
+       textureResidencyMemoryCapMB="512"
+       envTargetFraction="0.72" envEscapeThreshold="0.16" envMinActive="150" envToggleBudget="15000"
+       envDepthRadii="18,36,60" envDepthWeights="1.4,1.0,0.6">
+    <CameraPath>
+        <!-- Same crossfire walk as the environment test, but tuned for predictive scoring -->
+        <Keyframe frame="0" position="-40,8,20" lookAt="0,6,-20" />
+        <Keyframe frame="45" position="-20,8,0" lookAt="0,6,-40" />
+        <Keyframe frame="90" position="0,8,-20" lookAt="0,6,-60" />
+        <Keyframe frame="140" position="20,8,-40" lookAt="0,6,-80" />
+    </CameraPath>
+
+    <Sphere position="0,-10000,0" radius="10000" albedo="0.68,0.68,0.68" emission="0,0,0"
+            materialType="0" emissionPower="0" />
+
+    <Rectangle position="-10,10,-15" u="0,0,25" v="0,20,0" albedo="0.52,0.52,0.55"
+               emission="0,0,0" materialType="0" emissionPower="0" />
+    <Rectangle position="10,12,-35" u="0,0,25" v="0,20,0" albedo="0.55,0.52,0.52"
+               emission="0,0,0" materialType="0" emissionPower="0" />
+    <Rectangle position="-10,14,-55" u="0,0,25" v="0,20,0" albedo="0.52,0.55,0.52"
+               emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <Rectangle position="0,25,-60" u="18,0,0" v="0,0,30" albedo="1.0,1.0,1.0"
+               emission="0.92,0.9,0.85" materialType="-1" emissionPower="20" />
+
+    <!-- Mesh groups behind each occluder toggle residency as predictive scores ramp up or fall off -->
+    <Mesh file="assets/bunny.obj" position="-22,0,-10" scale="7.8"
+          clusterMaxTriangles="1280" clusterMaxExtent="30"
+          albedo="0.66,0.62,0.58" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-2,0,-10" scale="7.8"
+          clusterMaxTriangles="1280" clusterMaxExtent="30"
+          albedo="0.58,0.66,0.62" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <Mesh file="assets/bunny.obj" position="18,0,-30" scale="9.0"
+          clusterMaxTriangles="1280" clusterMaxExtent="30"
+          albedo="0.64,0.6,0.62" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-2,0,-30" scale="9.0"
+          clusterMaxTriangles="1280" clusterMaxExtent="30"
+          albedo="0.62,0.64,0.6" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <Mesh file="assets/bunny.obj" position="-22,0,-50" scale="10.2"
+          clusterMaxTriangles="1280" clusterMaxExtent="30"
+          albedo="0.6,0.62,0.64" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-2,0,-50" scale="10.2"
+          clusterMaxTriangles="1280" clusterMaxExtent="30"
+          albedo="0.64,0.6,0.62" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <Mesh file="assets/bunny.obj" position="18,0,-70" scale="11.4"
+          clusterMaxTriangles="1280" clusterMaxExtent="30"
+          albedo="0.6,0.64,0.62" emission="0,0,0" materialType="0" emissionPower="0" />
+    <Mesh file="assets/bunny.obj" position="-2,0,-70" scale="11.4"
+          clusterMaxTriangles="1280" clusterMaxExtent="30"
+          albedo="0.62,0.6,0.64" emission="0,0,0" materialType="0" emissionPower="0" />
+</Scene>


### PR DESCRIPTION
## Summary
- record global environment hit and total ray counts to derive last-frame escape probability
- use environment escape thresholds to adapt residency activation floors while preserving ray-hit ranking
- expose new escape thresholds, logging, and scene parameters for benchmarking and configuration

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936270f6f38832d8627aa019f2603b5)