### PR TITLE
Add ReSTIR residency strategy option

### DIFF
--- a/MetalCpp Path Tracer/Renderer/Renderer.cpp
+++ b/MetalCpp Path Tracer/Renderer/Renderer.cpp
@@ -1541,6 +1541,8 @@ std::string Renderer::residencyStrategyName(ResidencyStrategy strategy) const {
     return "Screen-space footprint";
   case ResidencyStrategy::Probabilistic:
     return "Probabilistic";
+  case ResidencyStrategy::ReSTIR:
+    return "ReSTIR RIS";
   case ResidencyStrategy::UnifiedScore:
     return "Unified score";
   case ResidencyStrategy::PredictiveEnvironment:
@@ -2358,6 +2360,9 @@ void Renderer::updateVisibleScene() {
     break;
   case ResidencyStrategy::UnifiedScore:
     strategyName = "Unified score";
+    break;
+  case ResidencyStrategy::ReSTIR:
+    strategyName = "ReSTIR RIS";
     break;
   case ResidencyStrategy::PredictiveEnvironment:
     strategyName = "Predictive environment";
@@ -6980,6 +6985,9 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   case ResidencyStrategy::Probabilistic:
     changed = updateProbabilisticResidency(forceAllToggles);
     break;
+  case ResidencyStrategy::ReSTIR:
+    changed = updateProbabilisticResidency(forceAllToggles);
+    break;
   case ResidencyStrategy::ScreenSpaceFootprint:
     changed = updateScreenSpaceFootprint(forceAllToggles);
     break;
@@ -11004,6 +11012,7 @@ void Renderer::processRayHitCounters() {
   bool strategyUsesHits =
       strategy == ResidencyStrategy::RayHitBudget ||
       strategy == ResidencyStrategy::Probabilistic ||
+      strategy == ResidencyStrategy::ReSTIR ||
       strategy == ResidencyStrategy::EnvironmentHit ||
       strategy == ResidencyStrategy::PredictiveEnvironment ||
       strategy == ResidencyStrategy::UnifiedScore;

--- a/MetalCpp Path Tracer/Scene/Scene.h
+++ b/MetalCpp Path Tracer/Scene/Scene.h
@@ -22,6 +22,7 @@ enum class ResidencyStrategy {
   EnvironmentHit = 6,
   PredictiveEnvironment = 7,
   UnifiedScore = 8,
+  ReSTIR = 9,
 };
 
 struct SceneObject {

--- a/MetalCpp Path Tracer/Scene/SceneLoader.cpp
+++ b/MetalCpp Path Tracer/Scene/SceneLoader.cpp
@@ -649,6 +649,9 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
                    value == "probabilistic_residency" ||
                    value == "probability_residency") {
             scene->setResidencyStrategy(ResidencyStrategy::Probabilistic);
+        } else if (value == "restir" || value == "restir_ris" ||
+                   value == "ris") {
+            scene->setResidencyStrategy(ResidencyStrategy::ReSTIR);
         } else if (value == "alwaysresident" || value == "always_resident" ||
                    value == "always" || value == "none" || value == "off") {
             scene->setResidencyStrategy(ResidencyStrategy::AlwaysResident);


### PR DESCRIPTION
## Summary
- add a ReSTIR residency strategy enumerant and reuse probabilistic defaults
- parse restir/ris aliases in scene loader and surface the label in renderer logs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fe1d860cc832d8a04ef52e61fb587)