### PR TITLE
Export OBJ meshes with material metadata

### DIFF
--- a/MetalCpp Path Tracer/lightwave_blender/exporter.py
+++ b/MetalCpp Path Tracer/lightwave_blender/exporter.py
@@ -3,30 +3,81 @@ import mathutils
 import os
 
 from .shape import export_shape
-from .utils import str_flat_array
+from .utils import str_flat_array, str_float
 from .addon_preferences import get_prefs
 from .xml_node import XMLNode, XMLRootNode
 from .registry import SceneRegistry
 from .world import export_world_background
+from .node import _handle_image
 
 
-def _default_material_attributes(inst, mat_id: int):
+def _material_attributes(registry: SceneRegistry, inst, mat_id: int):
     mat = None
     if mat_id < len(inst.object.material_slots):
         mat = inst.object.material_slots[mat_id].material
 
-    if mat is not None and hasattr(mat, "diffuse_color"):
-        color = mat.diffuse_color
-        albedo = (color[0], color[1], color[2])
-    else:
-        albedo = (0.7, 0.7, 0.7)
-
-    return {
-        "albedo": str_flat_array(albedo),
+    attrs = {
+        "albedo": str_flat_array((0.7, 0.7, 0.7)),
         "emission": str_flat_array((0.0, 0.0, 0.0)),
         "materialType": 0,
         "emissionPower": 0,
     }
+
+    if mat is None or not getattr(registry.settings, "export_materials", True):
+        return attrs
+
+    if hasattr(mat, "diffuse_color"):
+        color = mat.diffuse_color
+        attrs["albedo"] = str_flat_array((color[0], color[1], color[2]))
+
+    def _image_from_socket(socket):
+        if socket is None or not socket.is_linked:
+            return None
+        node = socket.links[0].from_node
+        if isinstance(node, bpy.types.ShaderNodeTexImage):
+            return node.image
+        if isinstance(node, bpy.types.ShaderNodeNormalMap):
+            return _image_from_socket(node.inputs.get("Color"))
+        return None
+
+    if mat.use_nodes and mat.node_tree is not None:
+        principled = next((n for n in mat.node_tree.nodes
+                           if isinstance(n, bpy.types.ShaderNodeBsdfPrincipled)), None)
+        if principled is not None:
+            base_color = principled.inputs.get("Base Color")
+            if base_color and base_color.default_value is not None:
+                attrs["albedo"] = str_flat_array(base_color.default_value[0:3])
+
+            emission = principled.inputs.get("Emission")
+            if emission and emission.default_value is not None:
+                attrs["emission"] = str_flat_array(emission.default_value[0:3])
+
+            emission_strength = principled.inputs.get("Emission Strength")
+            if emission_strength is not None:
+                attrs["emissionPower"] = emission_strength.default_value
+
+            diffuse_image = _image_from_socket(base_color)
+            if diffuse_image is not None:
+                diffuse_path = _handle_image(registry, diffuse_image)
+                if diffuse_path:
+                    attrs["diffuseTexture"] = diffuse_path
+
+            specular_image = _image_from_socket(principled.inputs.get("Specular"))
+            if specular_image is not None:
+                specular_path = _handle_image(registry, specular_image)
+                if specular_path:
+                    attrs["specularTexture"] = specular_path
+
+            normal_image = None
+            normal_socket = principled.inputs.get("Normal")
+            if normal_socket is not None:
+                normal_image = _image_from_socket(normal_socket)
+            if normal_image is not None:
+                normal_path = _handle_image(registry, normal_image)
+                if normal_path:
+                    attrs["normalTexture"] = normal_path
+
+    return attrs
 
 def export_objects(registry: SceneRegistry):
     result: list[XMLNode] = []
@@ -43,8 +94,7 @@ def export_objects(registry: SceneRegistry):
         if object_eval.type not in {'MESH', 'CURVE', 'SURFACE', 'META', 'FONT', 'CURVES'}:
             continue
 
-        shapes: list[XMLNode] = registry.export(
-            object_eval.original.data, lambda unique_name: export_shape(registry, object_eval))
+        shapes: list[XMLNode] = export_shape(registry, object_eval)
         if len(shapes) == 0:
             registry.warn(f"Entity {object_eval.name} has no material or shape and will be ignored")
             continue
@@ -53,13 +103,16 @@ def export_objects(registry: SceneRegistry):
         basis_x = basis.col[0]
         basis_y = basis.col[1]
         basis_z = basis.col[2]
-        location = inst.matrix_world.to_translation()
-        rotation = inst.matrix_world.to_euler('XYZ')
 
-        for (mat_id, shape) in enumerate(shapes):
+        location, rotation, scale = inst.matrix_world.decompose()
+        rotation_euler = rotation.to_euler('XYZ')
+
+        for shape in shapes:
             filename = shape.attributes.get("filename")
             if filename is None:
                 continue
+
+            mat_id = shape.attributes.get("material_index", 0)
 
             mesh_node = XMLNode(
                 "Mesh",
@@ -69,15 +122,16 @@ def export_objects(registry: SceneRegistry):
                 basisY=str_flat_array(basis_y),
                 basisZ=str_flat_array(basis_z),
                 rotation=str_flat_array((
-                    mathutils.rad2deg(rotation.x),
-                    mathutils.rad2deg(rotation.y),
-                    mathutils.rad2deg(rotation.z)
+                    mathutils.rad2deg(rotation_euler.x),
+                    mathutils.rad2deg(rotation_euler.y),
+                    mathutils.rad2deg(rotation_euler.z)
                 )),
+                scale=str_float((scale.x + scale.y + scale.z) / 3.0),
                 clusterMaxTriangles=0,
                 clusterMaxExtent=0.0,
             )
 
-            for key, value in _default_material_attributes(inst, mat_id).items():
+            for key, value in _material_attributes(registry, inst, mat_id).items():
                 mesh_node.attributes[key] = value
 
             result.append(mesh_node)

--- a/MetalCpp Path Tracer/lightwave_blender/shape.py
+++ b/MetalCpp Path Tracer/lightwave_blender/shape.py
@@ -4,7 +4,6 @@ import bmesh
 from .addon_preferences import get_prefs
 from .registry import SceneRegistry
 from .xml_node import XMLNode
-from .materials import export_material
 
 
 def get_shape_name_base(obj, inst):
@@ -26,67 +25,86 @@ def get_shape_name_base(obj, inst):
 def _shape_name_material(name, mat_id):
     return f"_m_{mat_id}_{name}"
 
-def _export_bmesh_by_material(registry: SceneRegistry, me) -> list[(str, str)]:
+def _write_obj(filepath, bm: bmesh.types.BMesh):
+    uv_layer = bm.loops.layers.uv.active
+
+    with open(filepath, "w", encoding="utf-8") as f:
+        f.write("# Exported by Lightwave Blender addon\n")
+
+        for v in bm.verts:
+            f.write(f"v {v.co.x} {v.co.y} {v.co.z}\n")
+
+        vt_lookup = {}
+        next_vt_index = 1
+        if uv_layer is not None:
+            for face in bm.faces:
+                for loop in face.loops:
+                    uv = loop[uv_layer].uv
+                    vt_lookup[(face.index, loop.index)] = next_vt_index
+                    f.write(f"vt {uv.x} {uv.y}\n")
+                    next_vt_index += 1
+
+        for v in bm.verts:
+            n = v.normal
+            f.write(f"vn {n.x} {n.y} {n.z}\n")
+
+        for face in bm.faces:
+            parts = []
+            for loop in face.loops:
+                v_idx = loop.vert.index + 1
+                vt_idx = vt_lookup.get((face.index, loop.index))
+                vn_idx = loop.vert.index + 1
+                if uv_layer is not None:
+                    parts.append(f"{v_idx}/{vt_idx}/{vn_idx}")
+                else:
+                    parts.append(f"{v_idx}//{vn_idx}")
+            f.write("f " + " ".join(parts) + "\n")
+
+
+def _export_bmesh_by_material(registry: SceneRegistry, me) -> list[XMLNode]:
     mat_count = len(me.materials)
     shapes = []
 
     def _export_for_mat(mat_id, abs_filepath):
-        from .ply import save_mesh as ply_save
-
         bm = bmesh.new()
         bm.from_mesh(me)
 
-        # remove faces with other materials
         if mat_count > 1:
-            for f in bm.faces:
-                # Remove irrelevant faces
-                # Special case: Assign invalid material indices to the last material 
-                if f.material_index != mat_id and not ((f.material_index < 0 or f.material_index >= mat_count) and mat_id == mat_count-1):
+            for f in list(bm.faces):
+                if f.material_index != mat_id and not ((f.material_index < 0 or f.material_index >= mat_count) and mat_id == mat_count - 1):
                     bm.faces.remove(f)
 
         if len(bm.verts) == 0 or len(bm.faces) == 0 or not bm.is_valid:
             bm.free()
             return False
 
-        # Make sure all faces are convex
         bmesh.ops.connect_verts_concave(bm, faces=bm.faces)
         bmesh.ops.triangulate(bm, faces=bm.faces)
-
         bm.normal_update()
 
-        ply_save(
-            filepath=abs_filepath,
-            bm=bm,
-            use_ascii=False,
-            use_normals=True,
-            use_uv=True,
-            use_color=False
-        )
+        os.makedirs(os.path.dirname(abs_filepath), exist_ok=True)
+        _write_obj(abs_filepath, bm)
 
         bm.free()
         return True
-    
+
     if mat_count == 0:
-        # special case if the mesh has no slots available
         mat_count = 1
-    
+
     for mat_id in range(0, mat_count):
         shape_name = me.name if mat_count <= 1 else _shape_name_material(me.name, mat_id)
-        rel_filepath = os.path.join(get_prefs().mesh_dir_name, shape_name + ".ply")
+        rel_filepath = os.path.join(get_prefs().mesh_dir_name, shape_name + ".obj")
         abs_filepath = os.path.join(registry.path, rel_filepath)
 
         if os.path.exists(abs_filepath) and not registry.settings.overwrite_existing_meshes:
-            # file is already exported
             pass
         elif _export_for_mat(mat_id, abs_filepath):
-            # export successful
             pass
         else:
-            # export failed
             continue
-        
-        shapes.append(rel_filepath.replace('\\', '/')) # Ensure the shape path is not using \ to keep the xml valid
-    
+
+        shapes.append(XMLNode("shape", filename=rel_filepath.replace('\\', '/'), material_index=mat_id))
+
     return shapes
 
 
@@ -103,4 +121,4 @@ def export_shape(registry: SceneRegistry, obj) -> list[XMLNode]:
     shapes = _export_bmesh_by_material(registry, me)
     obj.to_mesh_clear()
 
-    return [ XMLNode("shape", type="mesh", filename=filepath) for filepath in shapes ]
+    return shapes


### PR DESCRIPTION
## Summary
- switch mesh export from per-material PLY dumps to OBJ files
- emit Mesh XML nodes with transform, scale, clustering hints, and material attributes
- surface material textures as diffuse/specular/normal texture paths for SceneLoader

## Testing
- Not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69414900016c832d8a63a62f6695b31d)