### PR TITLE
Remove unused p3 load in path tracing intersection

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -282,7 +282,6 @@ inline intersection firstHitBVH(thread const Ray &r,
         float4 p0 = primitives[base + 0];
         float4 p1 = primitives[base + 1];
         float4 p2 = primitives[base + 2];
-        float4 p3 = primitives[base + 3];
 
         int primitiveType = int(p0.w);
         float tHit = INFINITY;


### PR DESCRIPTION
## Summary
- remove unused primitive data load in the path tracing intersection routine to silence compiler warnings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69415e2be7c0832da0729548f8ba7e82)