### PR TITLE
Apply target color space in texture loader and update bitmap info

### DIFF
--- a/Nomad Path Tracer/Scene/TextureLoader.cpp
+++ b/Nomad Path Tracer/Scene/TextureLoader.cpp
@@ -119,22 +119,32 @@ bool LoadTextureImage(const std::string &path, LoadedTextureImage &outImage,
 
     TextureColorSpace targetSpace = DetermineTextureColorSpace(path, usage);
     CGColorSpaceRef colorSpace = nullptr;
-#if defined(kCGColorSpaceGenericRGBLinear)
     if (targetSpace == TextureColorSpace::Linear) {
+#if defined(kCGColorSpaceGenericRGBLinear)
         colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceGenericRGBLinear);
-    }
 #endif
+    } else if (targetSpace == TextureColorSpace::sRGB) {
 #if defined(kCGColorSpaceSRGB)
-    if (!colorSpace && targetSpace == TextureColorSpace::sRGB) {
         colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
-    }
 #endif
+    }
+
+    if (!colorSpace) {
+        CGColorSpaceRef imageSpace = CGImageGetColorSpace(image);
+        if (imageSpace) {
+            colorSpace = CGColorSpaceRetain(imageSpace);
+        }
+    }
+
     if (!colorSpace) {
         colorSpace = CGColorSpaceCreateDeviceRGB();
     }
+
+    CGBitmapInfo bitmapInfo =
+        kCGBitmapByteOrder32Big |
+        static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedLast);
     CGContextRef context = CGBitmapContextCreate(
-        rawData.data(), width, height, 8, width * 4, colorSpace,
-        kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
+        rawData.data(), width, height, 8, width * 4, colorSpace, bitmapInfo);
 
     if (!context) {
         std::printf("Failed to create bitmap context for texture '%s'\n", path.c_str());


### PR DESCRIPTION
## Summary
- choose the CG color space based on the requested texture target and fall back gracefully to image or device space
- use CGBitmapInfo constants for bitmap context creation to silence deprecated alpha flag warnings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69415eb647d4832d9d2349af1fc837f8)