### PR TITLE
Use size_t-compatible loader for LOD toggle budget

### DIFF
--- a/Nomad Path Tracer/Scene/SceneLoader.cpp
+++ b/Nomad Path Tracer/Scene/SceneLoader.cpp
@@ -678,8 +678,8 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         root->FloatAttribute("lodExitViewDegrees", params.lodExitViewDegrees);
     params.stateCooldownFrames =
         root->UnsignedAttribute("residencyCooldown", params.stateCooldownFrames);
-    params.lodMaxTogglesPerFrame =
-        root->UnsignedAttribute("lodToggleBudget", params.lodMaxTogglesPerFrame);
+    params.lodMaxTogglesPerFrame = static_cast<size_t>(root->Unsigned64Attribute(
+        "lodToggleBudget", static_cast<uint64_t>(params.lodMaxTogglesPerFrame)));
 
     params.energyTargetFraction =
         root->FloatAttribute("energyTargetFraction", params.energyTargetFraction);


### PR DESCRIPTION
## Summary
- load the LOD toggle budget using the 64-bit XML attribute to match the size_t residency parameter

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69415f9c6dd0832dbaf50f4441a07abd)