### PR TITLE
Export Blender lights as emissive primitives

### DIFF
--- a/Nomad Path Tracer/lightwave_blender/exporter.py
+++ b/Nomad Path Tracer/lightwave_blender/exporter.py
@@ -9,6 +9,7 @@ from .xml_node import XMLNode, XMLRootNode
 from .registry import SceneRegistry
 from .world import export_world_background
 from .node import _handle_image
+from .light import export_lights
 
 
 def _material_attributes(registry: SceneRegistry, inst, mat_id: int):
@@ -193,6 +194,7 @@ def export_scene(op, filepath, context, settings):
         scene.add_child(camera_path)
 
     scene.add_children(export_objects(registry))
+    scene.add_children(export_lights(registry))
 
     if settings.enable_background:
         scene.add_children(export_world_background(registry, depsgraph.scene))

--- a/Nomad Path Tracer/lightwave_blender/light.py
+++ b/Nomad Path Tracer/lightwave_blender/light.py
@@ -1,53 +1,82 @@
 import bpy
+import math
+
 from .utils import *
-from .defaults import *
 from .registry import SceneRegistry
 from .xml_node import XMLNode
 
 
-def _export_area_light(registry: SceneRegistry, instance_node, light: bpy.types.Light, inst: bpy.types.DepsgraphObjectInstance):
-    # Compute actual matrix
-    # From my understanding, object transforms in Blender are always similarity transformations.
-    # This means we do not need to worry about the angle formed by the spanning vectors of our
-    # area light when computing the area for power normalization, as they will still be orthogonal.
+def _emissive_attributes(emission):
+    return {
+        "albedo": str_flat_array((0.0, 0.0, 0.0)),
+        "emission": str_flat_array(emission),
+        "materialType": 0,
+        "emissionPower": 1.0,
+    }
+
+
+def _build_point_light(registry: SceneRegistry, light: bpy.types.Light, inst: bpy.types.DepsgraphObjectInstance):
+    radius = max(light.shadow_soft_size, 1e-3)
+    normalization = 1.0 / (4.0 * (math.pi * radius) ** 2)
+
+    emission = [
+        normalization * light.energy * light.color[chan]
+        for chan in range(3)
+    ]
+
+    position = inst.matrix_world.translation
+
+    return XMLNode(
+        "Sphere",
+        position=str_flat_array(position),
+        radius=str_float(radius),
+        **_emissive_attributes(emission),
+    )
+
+
+def _area_light_extents(registry: SceneRegistry, light: bpy.types.Light):
     scale_x = light.size
-    if light.shape == "SQUARE" or light.shape == "DISK":
+    if light.shape in {"SQUARE", "DISK"}:
         scale_y = light.size
-    elif light.shape == "RECTANGLE" or light.shape == "ELLIPSE":
+    elif light.shape in {"RECTANGLE", "ELLIPSE"}:
         scale_y = light.size_y
     else:
         registry.warn(f"Unsupported light shape '{light.shape}'")
         scale_y = light.size
-    
-    matrix_world = [ [ x for x in row ] for row in inst.matrix_world ]
-    lensqr_x = 0
-    lensqr_y = 0
-    for i in range(3):
-        matrix_world[i][0] *= scale_x / 2
-        matrix_world[i][1] *= scale_y / 2
-        matrix_world[i][2] *= -1
-        lensqr_x += matrix_world[i][0] ** 2
-        lensqr_y += matrix_world[i][1] ** 2
+    return scale_x, scale_y
 
-    instance_node.add("shape", type="rectangle")
-    transform = instance_node.add("transform")
-    transform.add("matrix", value=str_flat_matrix(matrix_world))
 
-    return 1 / (16 * (lensqr_x * lensqr_y) ** 0.5)
+def _build_rectangle_light(registry: SceneRegistry, light: bpy.types.Light, inst: bpy.types.DepsgraphObjectInstance, *, scale_x: float, scale_y: float):
+    basis = inst.matrix_world.to_3x3()
+    u = basis.col[0] * (scale_x * 0.5)
+    v = basis.col[1] * (scale_y * 0.5)
 
-def _export_point_light(registry: SceneRegistry, instance_node, light: bpy.types.Light, inst: bpy.types.DepsgraphObjectInstance):
-    radius = max(light.shadow_soft_size, 1e-3)
+    lensqr_x = u.length_squared
+    lensqr_y = v.length_squared
 
-    instance_node.add("shape", type="sphere")
-    transform = instance_node.add("transform")
-    transform.add("scale", value=radius)
-    transform.add("translate",
-        x=inst.matrix_world[0][3],
-        y=inst.matrix_world[1][3],
-        z=inst.matrix_world[2][3])
+    if lensqr_x <= 0.0 or lensqr_y <= 0.0:
+        registry.warn(f"Light '{inst.object.name}' has zero area and will be skipped")
+        return None
 
-    # I don't understand any of this either, but it's Blender's convention :-)
-    return 1 / (4 * (3.14159 * radius) ** 2)
+    normalization = 1.0 / (16.0 * (lensqr_x * lensqr_y) ** 0.5)
+    emission = [
+        normalization * light.energy * light.color[chan]
+        for chan in range(3)
+    ]
+
+    return XMLNode(
+        "Rectangle",
+        position=str_flat_array(inst.matrix_world.translation),
+        u=str_flat_array(u),
+        v=str_flat_array(v),
+        **_emissive_attributes(emission),
+    )
+
+
+def _sun_extents(light: bpy.types.Light):
+    half_size = math.tan(getattr(light, "angle", 0.0) * 0.5)
+    return max(half_size * 2.0, 1e-3)
+
 
 def export_light(registry: SceneRegistry, inst):
     light = inst.object.data
@@ -55,37 +84,42 @@ def export_light(registry: SceneRegistry, inst):
         registry.warn("Light portals are not supported")
         return []
 
-    if light.type == "POINT" and light.shadow_soft_size < 1e-3:
-        power = str_flat_array([ light.energy * light.color[chan] for chan in range(3) ])
-        position = str_flat_array([ inst.matrix_world[dim][3] for dim in range(3) ])
-        return [XMLNode("light", type="point", position=position, power=power)]
+    if light.type in {"POINT", "SPOT"}:
+        return [_build_point_light(registry, light, inst)]
+
+    if light.type == "AREA":
+        if not getattr(registry.settings, "enable_area_lights", True):
+            return [_build_point_light(registry, light, inst)]
+        scale_x, scale_y = _area_light_extents(registry, light)
+        rect_node = _build_rectangle_light(registry, light, inst, scale_x=scale_x, scale_y=scale_y)
+        return [rect_node] if rect_node is not None else []
 
     if light.type == "SUN":
-        intensity = str_flat_array([ light.energy * light.color[chan] for chan in range(3) ])
-        position = str_flat_array([ inst.matrix_world[dim][2] for dim in range(3) ])
-        return [XMLNode("light", type="directional", direction=position, intensity=intensity)]
+        if not getattr(registry.settings, "enable_area_lights", True):
+            return [_build_point_light(registry, light, inst)]
+        size = _sun_extents(light)
+        rect_node = _build_rectangle_light(registry, light, inst, scale_x=size, scale_y=size)
+        return [rect_node] if rect_node is not None else []
 
-    if registry.settings.enable_area_lights:
-        light_node = XMLNode("light", type="area")
-        instance_node = light_node.add("instance") # id=registry._make_unique_name(light.name)
-    else:
-        # Fallback if students did not implement area lights yet
-        light_node = XMLNode("instance")
-        instance_node = light_node
+    registry.warn(f"Light type {light.type} unsupported")
+    return []
 
-    if light.type == "POINT":
-        normalization = _export_point_light(registry, instance_node, light, inst)
-    elif light.type == "AREA":
-        normalization = _export_area_light(registry, instance_node, light, inst)
-    else:
-        registry.warn(f"Light type {light.type} unsupported")
-        return []
 
-    emission = [
-        normalization * light.energy * light.color[chan]
-        for chan in range(3)
-    ]
+def export_lights(registry: SceneRegistry):
+    result: list[XMLNode] = []
 
-    instance_node.add("emission", type="lambertian").add(
-        "texture", name="emission", type="constant", value=str_flat_array(emission))
-    return [light_node]
+    if not getattr(registry.settings, "export_lights", True):
+        return result
+
+    for inst in registry.depsgraph.object_instances:
+        object_eval = inst.object
+        if object_eval is None or object_eval.type != 'LIGHT':
+            continue
+        if registry.settings.use_selection and not object_eval.original.select_get():
+            continue
+        if not registry.settings.use_selection and not inst.show_self:
+            continue
+
+        result.extend(export_light(registry, inst))
+
+    return result


### PR DESCRIPTION
## Summary
- integrate light export into the scene writer and emit Blender lights as primitives the loader can parse
- convert point and spot lights to emissive spheres, and map area or sun lights to emissive rectangles using their transforms
- default to emissive geometry even when selection filtering is enabled while warning on unsupported light setups

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69533b889728832d8cf6276fd3fdfbef)