### PR TITLE
Export environment background to scene attributes

### DIFF
--- a/Nomad Path Tracer/lightwave_blender/exporter.py
+++ b/Nomad Path Tracer/lightwave_blender/exporter.py
@@ -197,7 +197,10 @@ def export_scene(op, filepath, context, settings):
     scene.add_children(export_lights(registry))
 
     if settings.enable_background:
-        scene.add_children(export_world_background(registry, depsgraph.scene))
+        environment = export_world_background(registry, depsgraph.scene)
+        if environment:
+            scene.attributes["environmentTexture"] = environment.texture
+            scene.attributes["environmentBrightness"] = environment.brightness
 
     root.add_child(scene)
 

--- a/Nomad Path Tracer/lightwave_blender/world.py
+++ b/Nomad Path Tracer/lightwave_blender/world.py
@@ -1,27 +1,74 @@
 import bpy
+import os
+from dataclasses import dataclass
 from .utils import *
-from .defaults import *
 from .registry import SceneRegistry
-from .xml_node import XMLNode
 from .node_graph import RMNodeGraph, RMInput, RMNode
-from .node import export_node
+from .node import export_node, _handle_image, _export_image
 from .materials import _is_black
-from .transform import export_transform_node
+from .addon_preferences import get_prefs
+
+
+@dataclass
+class EnvironmentSettings:
+    texture: str
+    brightness: float
+
+
+def _normalize_color(color):
+    brightness = max(color)
+    if brightness <= 0:
+        return None, 0.0
+    normalized = [c / brightness for c in color]
+    return normalized, brightness
+
+
+def _write_constant_environment_texture(registry: SceneRegistry, color):
+    normalized, brightness = _normalize_color(color)
+    if brightness <= 0:
+        return None, 0.0
+
+    suffix = "_".join([f"{c:.4f}".replace(".", "p") for c in normalized])
+    image_name = f"NomadEnv_{suffix}"
+
+    image = bpy.data.images.new(
+        image_name, width=1, height=1, alpha=False, float_buffer=True)
+    image.generated_color = (*normalized, 1.0)
+    image.use_generated_float = True
+    image.colorspace_settings.name = "Linear"
+    try:
+        tex_dir_name = get_prefs().tex_dir_name
+        os.makedirs(os.path.join(registry.path, tex_dir_name), exist_ok=True)
+        texture_path = _handle_image(registry, image)
+    finally:
+        bpy.data.images.remove(image)
+
+    return texture_path, brightness
+
+
+def _export_environment_image(registry: SceneRegistry, image: bpy.types.Image):
+    tex_dir_name = get_prefs().tex_dir_name
+    os.makedirs(os.path.join(registry.path, tex_dir_name), exist_ok=True)
+    file_name = bpy.path.clean_name(image.name) + ".exr"
+    relative_path = os.path.join(tex_dir_name, file_name)
+    _export_image(registry, image, os.path.join(
+        registry.path, relative_path), is_f32=True, keep_format=False)
+    return relative_path.replace("\\", "/")
 
 
 def export_world_background(registry: SceneRegistry, scene: bpy.types.Scene):
     if not scene.world:
-        return []
+        return None
 
     # Export basic world if no shading nodes are given
     if not scene.world.node_tree:
-        if scene.world.color[0] > 0 or scene.world.color[1] > 0 or scene.world.color[2] > 0:
-            bg = XMLNode("light", type="envmap")
-            bg.add("texture", type="constant",
-                   value=str_flat_array(scene.world.color))
-            return [bg]
-        else:
-            return []  # No world
+        color = scene.world.color
+        if not _is_black(color):
+            texture_path, brightness = _write_constant_environment_texture(
+                registry, [float(color[0]), float(color[1]), float(color[2])])
+            if texture_path:
+                return EnvironmentSettings(texture=texture_path, brightness=brightness)
+        return None  # No world
 
     node_graph = RMNodeGraph(
         registry, scene.world.name_full, scene.world.node_tree)
@@ -36,16 +83,12 @@ def export_world_background(registry: SceneRegistry, scene: bpy.types.Scene):
             if node.is_active_output:
                 return _export_world(registry, rm_node.input("Surface"))
 
-    return []  # No active output
+    return None  # No active output
 
 
 def _export_background(registry: SceneRegistry, bsdf_node: RMNode):
     color = bsdf_node.input("Color")
     strength = bsdf_node.input("Strength")
-
-    if not color.is_linked():
-        if not color.has_value() or _is_black(color.value):
-            return []
 
     emission_scale = 1
     if strength.is_linked():
@@ -54,18 +97,61 @@ def _export_background(registry: SceneRegistry, bsdf_node: RMNode):
     elif strength.has_value():
         emission_scale = float(strength.value)
     if emission_scale == 0:
-        return []
+        return None
 
-    bg = XMLNode("light", type="envmap")
-    bg.add_child(export_node(
-        registry, color, exposure=emission_scale))
+    linked = color.linked_node() if color.is_linked() else None
 
-    transforms = []
-    transforms += [XMLNode("matrix", value=str_flat_matrix(ENVIRONMENT_MAP_TRANSFORM))]
-    transforms += export_transform_node(registry, color)
+    if not color.is_linked():
+        if not color.has_value() or _is_black(color.value):
+            return None
+        color_values = [float(c) * emission_scale for c in color.value[0:3]]
+        texture_path, brightness = _write_constant_environment_texture(
+            registry, color_values)
+        if texture_path:
+            return EnvironmentSettings(texture=texture_path, brightness=brightness)
+        return None
 
-    bg.add("transform").add_children(transforms)
-    return [bg]
+    if linked and isinstance(linked.bl_node, bpy.types.ShaderNodeTexEnvironment):
+        image = linked.bl_node.image
+        if image:
+            try:
+                path = _export_environment_image(registry, image)
+                if path:
+                    return EnvironmentSettings(texture=path, brightness=emission_scale)
+            except Exception as ex:
+                registry.error(f"Failed to export environment texture {image.name}: {ex}")
+        else:
+            registry.error(f"Environment texture node {linked.bl_node.name} has no image")
+        return None
+
+    exported_texture = export_node(
+        registry, color, exposure=emission_scale)
+    tex_type = exported_texture.attributes.get("type")
+
+    if tex_type == "image":
+        path = exported_texture.attributes.get("filename")
+        if path and not path.lower().endswith(".exr"):
+            if linked and hasattr(linked.bl_node, "image") and linked.bl_node.image:
+                try:
+                    path = _export_environment_image(registry, linked.bl_node.image)
+                except Exception as ex:
+                    registry.error(f"Failed to export environment texture {linked.bl_node.image.name}: {ex}")
+            else:
+                registry.warn("Environment texture is not EXR; attempting to use original path")
+        brightness = float(exported_texture.attributes.get("exposure", 1.0))
+        return EnvironmentSettings(texture=path, brightness=brightness)
+
+    if tex_type == "constant":
+        value = exported_texture.attributes.get("value")
+        if value:
+            values = [float(v) for v in value.split(",")]
+            texture_path, brightness = _write_constant_environment_texture(
+                registry, values)
+            if texture_path:
+                return EnvironmentSettings(texture=texture_path, brightness=brightness)
+
+    registry.error("Unsupported environment configuration for world background")
+    return None
 
 
 _world_handlers: dict[str, any] = {
@@ -76,28 +162,35 @@ _world_handlers: dict[str, any] = {
 
 def _export_world(registry: SceneRegistry, input: RMInput):
     if not input.is_linked():
-        return []  # black world
+        return None  # black world
 
     world_node = input.linked_node()
 
     if world_node is None:
         registry.error(f"Material {input.node_graph.name} has no valid node")
-        return []
+        return None
 
-    result = []
     for (typename, handler) in _world_handlers.items():
         if hasattr(bpy.types, typename) and isinstance(world_node.bl_node, getattr(bpy.types, typename)):
-            result += handler(registry, world_node)
-            break
-    else:
-        # treat as background
-        transforms = []
-        transforms += [XMLNode("matrix", value=str_flat_matrix(ENVIRONMENT_MAP_TRANSFORM))]
-        transforms += export_transform_node(registry, input)
+            return handler(registry, world_node)
 
-        bg = XMLNode("light", type="envmap")
-        bg.add_child(export_node(registry, input))
-        bg.add("transform").add_children(transforms)
-        result.append(bg)
+    exported_texture = export_node(registry, input)
+    tex_type = exported_texture.attributes.get("type")
 
-    return result
+    if tex_type == "image":
+        path = exported_texture.attributes.get("filename")
+        return EnvironmentSettings(
+            texture=path,
+            brightness=float(exported_texture.attributes.get("exposure", 1.0)))
+
+    if tex_type == "constant":
+        value = exported_texture.attributes.get("value")
+        if value:
+            values = [float(v) for v in value.split(",")]
+            texture_path, brightness = _write_constant_environment_texture(
+                registry, values)
+            if texture_path:
+                return EnvironmentSettings(texture=texture_path, brightness=brightness)
+
+    registry.error("Unsupported world setup; unable to export environment")
+    return None


### PR DESCRIPTION
## Summary
- export Blender world backgrounds as scene-level environmentTexture/environmentBrightness values instead of envmap light nodes
- generate EXR environment textures for both linked environment images and constant colors, normalizing color-only worlds and applying brightness scaling
- avoid emitting unsupported envmap lights so the exported XML matches the path tracer loader schema

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69533da87498832d973fa7cd901702da)