### PR TITLE
Add stochastic ReSTIR residency sampling and regression test

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -33,6 +33,7 @@
 #include <iomanip>
 #include <mutex>
 #include <numeric>
+#include <queue>
 #include <atomic>
 #include <deque>
 #include <simd/simd.h>
@@ -9732,6 +9733,12 @@ bool Renderer::updateReSTIRResidency(bool forceAllToggles) {
   if (_activePrimitive.empty())
     return false;
 
+  auto randomPositive = []() {
+    float r = randomFloat();
+    constexpr float kEpsilon = 1e-6f;
+    return (r <= 0.0f) ? kEpsilon : r;
+  };
+
   _frameProbabilityTargetPrimitives = 0;
   _frameProbabilityInitialDesiredPrimitives = 0;
   _frameProbabilityFinalDesiredPrimitives = 0;
@@ -9749,6 +9756,7 @@ bool Renderer::updateReSTIRResidency(bool forceAllToggles) {
   const size_t toggleBudget = _residencyConfig.restirMaxTogglesPerFrame;
   const float hysteresis =
       std::max(0.0f, _residencyConfig.probabilityDesiredHysteresis);
+  const float explorationFloor = 1.0e-3f;
 
   double reuseWeightSum = 0.0;
   double candidateWeightSum = 0.0;
@@ -9772,6 +9780,13 @@ bool Renderer::updateReSTIRResidency(bool forceAllToggles) {
   targetActive = std::min(targetActive, primCount);
   _frameProbabilityTargetPrimitives = targetActive;
 
+  std::vector<float> candidateWeights(primCount, 0.0f);
+  std::vector<float> sortJitter(primCount, 0.0f);
+
+  for (float &j : sortJitter)
+    j = (randomFloat() - 0.5f) * 1e-3f;
+
+  float totalCandidateWeight = 0.0f;
   for (size_t i = 0; i < primCount; ++i) {
     float probability = (i < _primitiveHitProbability.size())
                             ? _primitiveHitProbability[i]
@@ -9792,35 +9807,118 @@ bool Renderer::updateReSTIRResidency(bool forceAllToggles) {
       candidateWeight += std::min(exploration, 8.0f) * 0.05f;
     candidateWeight = std::max(candidateWeight, 0.0f);
 
-    float prevWeight = _restirReservoirWeight[i] * reuseWeight;
-    float prevCount = _restirReservoirSampleCount[i] * reuseWeight;
-    float accumulatedWeight =
-        prevWeight + candidateWeight * static_cast<float>(candidateCount);
-    float accumulatedCount =
-        prevCount + static_cast<float>(candidateCount);
-    reuseWeightSum += static_cast<double>(prevWeight);
-    candidateWeightSum +=
-        static_cast<double>(candidateWeight) * static_cast<double>(candidateCount);
-    if (accumulatedCount > static_cast<float>(reservoirSize)) {
-      float scale = static_cast<float>(reservoirSize) / accumulatedCount;
-      accumulatedCount = static_cast<float>(reservoirSize);
-      accumulatedWeight *= scale;
+    candidateWeight = std::max(candidateWeight + explorationFloor,
+                               explorationFloor);
+    candidateWeight += explorationFloor * (randomFloat() * 0.25f);
+    candidateWeights[i] = candidateWeight;
+    totalCandidateWeight += candidateWeight;
+  }
+
+  struct ReservoirCandidate {
+    float key = 0.0f;
+    float weight = 0.0f;
+    size_t index = 0;
+  };
+
+  auto sampleIndex = [&](float r) {
+    float accum = 0.0f;
+    for (size_t i = 0; i < candidateWeights.size(); ++i) {
+      accum += candidateWeights[i];
+      if (r <= accum)
+        return i;
     }
-    float normalized =
-        (accumulatedCount > 0.0f) ? (accumulatedWeight / accumulatedCount) : 0.0f;
+    return candidateWeights.empty() ? size_t(0) : candidateWeights.size() - 1;
+  };
+
+  using Heap =
+      std::priority_queue<ReservoirCandidate, std::vector<ReservoirCandidate>,
+                          std::function<bool(const ReservoirCandidate &,
+                                             const ReservoirCandidate &)>>;
+  auto cmp = [](const ReservoirCandidate &a, const ReservoirCandidate &b) {
+    return a.key > b.key;
+  };
+  Heap heap(cmp);
+
+  auto considerCandidate = [&](Heap &heap, size_t index, float weight) {
+    if (!(weight > 0.0f))
+      return;
+    float key = std::pow(randomPositive(), 1.0f / std::max(weight, 1e-6f));
+    key += (randomFloat() - 0.5f) * 1e-4f;
+    ReservoirCandidate candidate{key, weight, index};
+    if (heap.size() < reservoirSize) {
+      heap.push(candidate);
+      return;
+    }
+    if (key > heap.top().key) {
+      heap.pop();
+      heap.push(candidate);
+    }
+  };
+
+  if (reuseWeight > 0.0f) {
+    for (size_t i = 0; i < primCount; ++i) {
+      float prevWeight = _restirReservoirWeight[i];
+      float prevCount = _restirReservoirSampleCount[i];
+      if (prevCount <= 0.0f || !(prevWeight > 0.0f))
+        continue;
+      float reused = prevWeight * reuseWeight;
+      reuseWeightSum += static_cast<double>(reused);
+      considerCandidate(heap, i, reused);
+    }
+  }
+
+  if (totalCandidateWeight <= 0.0f)
+    totalCandidateWeight = static_cast<float>(primCount) * explorationFloor;
+
+  for (size_t c = 0; c < candidateCount; ++c) {
+    float r = randomPositive() * totalCandidateWeight;
+    size_t sampled = sampleIndex(r);
+    float weight = (sampled < candidateWeights.size()) ? candidateWeights[sampled]
+                                                       : explorationFloor;
+    candidateWeightSum += static_cast<double>(weight);
+    considerCandidate(heap, sampled, weight);
+  }
+
+  std::fill(_restirReservoirWeight.begin(), _restirReservoirWeight.end(), 0.0f);
+  std::fill(_restirReservoirSampleCount.begin(), _restirReservoirSampleCount.end(),
+            0.0f);
+  std::fill(_restirTemporalScore.begin(), _restirTemporalScore.end(), 0.0f);
+
+  std::vector<ReservoirCandidate> selected;
+  selected.reserve(heap.size());
+  while (!heap.empty()) {
+    selected.push_back(heap.top());
+    heap.pop();
+  }
+
+  float selectedWeightSum = 0.0f;
+  for (const auto &entry : selected)
+    selectedWeightSum += entry.weight;
+
+  for (const auto &entry : selected) {
+    size_t idx = entry.index;
+    if (idx >= _restirReservoirWeight.size() || selectedWeightSum <= 0.0f)
+      continue;
+    float normalized = entry.weight / selectedWeightSum;
+    bool visible = (idx < _primitiveVisible.size())
+                       ? (_primitiveVisible[idx] != 0)
+                       : true;
     if (!visible)
       normalized *= 0.9f;
-
-    _restirReservoirWeight[i] = accumulatedWeight;
-    _restirReservoirSampleCount[i] = accumulatedCount;
-    _restirTemporalScore[i] = normalized;
+    _restirReservoirWeight[idx] = entry.weight;
+    _restirReservoirSampleCount[idx] = 1.0f;
+    _restirTemporalScore[idx] = normalized;
   }
 
   size_t sortCount = std::max<size_t>(1, targetActive);
   sortCount = std::min(sortCount, primCount);
-  auto comparator = [this](size_t a, size_t b) {
+  auto comparator = [this, &sortJitter](size_t a, size_t b) {
     float scoreA = (a < _restirTemporalScore.size()) ? _restirTemporalScore[a] : 0.0f;
     float scoreB = (b < _restirTemporalScore.size()) ? _restirTemporalScore[b] : 0.0f;
+    if (a < sortJitter.size())
+      scoreA += sortJitter[a];
+    if (b < sortJitter.size())
+      scoreB += sortJitter[b];
     float sanA = sanitizeSortValue(scoreA);
     float sanB = sanitizeSortValue(scoreB);
     if (sanA == sanB)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(ResidencyTests
   ResidencyTestsMain.cpp
   ResidencyBudgetTests.cpp
   ProbabilisticResidencyTests.cpp
+  ReSTIRResidencyTests.cpp
 )
 
 target_include_directories(ResidencyTests PRIVATE

--- a/tests/ProbabilisticResidencyTests.cpp
+++ b/tests/ProbabilisticResidencyTests.cpp
@@ -18,6 +18,8 @@ struct ProbabilityResidencyConfig {
   float evidenceWindow = 64.0f;
 };
 
+constexpr float kUncertaintyBoost = 0.25f;
+
 class ProbabilityResidencyHarness {
 public:
   explicit ProbabilityResidencyHarness(std::size_t primitiveCount)

--- a/tests/ReSTIRResidencyTests.cpp
+++ b/tests/ReSTIRResidencyTests.cpp
@@ -1,0 +1,148 @@
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <queue>
+#include <random>
+#include <vector>
+
+namespace {
+
+class RestirReservoirSimulator {
+public:
+  RestirReservoirSimulator(std::size_t primitiveCount, std::size_t reservoirSize,
+                           std::size_t candidateCount, float reuseWeight,
+                           std::uint32_t seed = 1337u)
+      : _primitiveCount(primitiveCount),
+        _reservoirSize(std::max<std::size_t>(1, reservoirSize)),
+        _candidateCount(std::max<std::size_t>(1, candidateCount)),
+        _reuseWeight(std::clamp(reuseWeight, 0.0f, 1.0f)), _rng(seed),
+        _dist(0.0f, 1.0f) {}
+
+  void step(const std::vector<float> &weights) {
+    assert(weights.size() == _primitiveCount);
+
+    std::vector<float> adjusted(weights.size(), 0.0f);
+    float totalWeight = 0.0f;
+    for (std::size_t i = 0; i < weights.size(); ++i) {
+      float w = std::max(weights[i], 0.0f) + 1.0e-3f;
+      w += 1.0e-3f * 0.25f * _dist(_rng);
+      adjusted[i] = w;
+      totalWeight += w;
+    }
+
+    if (!(totalWeight > 0.0f))
+      return;
+
+    auto drawKey = [&](float weight) {
+      float u = std::max(_dist(_rng), 1.0e-6f);
+      float key = std::pow(u, 1.0f / std::max(weight, 1.0e-6f));
+      key += (_dist(_rng) - 0.5f) * 1.0e-4f;
+      return key;
+    };
+
+    auto sampleIndex = [&](float r) {
+      float accum = 0.0f;
+      for (std::size_t i = 0; i < adjusted.size(); ++i) {
+        accum += adjusted[i];
+        if (r <= accum)
+          return i;
+      }
+      return adjusted.size() - 1;
+    };
+
+    using HeapEntry = std::pair<float, std::pair<std::size_t, float>>;
+    auto cmp = [](const HeapEntry &a, const HeapEntry &b) {
+      return a.first > b.first;
+    };
+    std::priority_queue<HeapEntry, std::vector<HeapEntry>, decltype(cmp)> heap(cmp);
+
+    for (std::size_t i = 0; i < _reservoirIndices.size(); ++i) {
+      std::size_t idx = _reservoirIndices[i];
+      float weight = _reservoirWeights[i] * _reuseWeight;
+      if (!(weight > 0.0f))
+        continue;
+      float key = drawKey(weight);
+      if (heap.size() < _reservoirSize)
+        heap.push({key, {idx, weight}});
+      else if (key > heap.top().first) {
+        heap.pop();
+        heap.push({key, {idx, weight}});
+      }
+    }
+
+    for (std::size_t c = 0; c < _candidateCount; ++c) {
+      float r = _dist(_rng) * totalWeight;
+      std::size_t idx = sampleIndex(r);
+      float weight = adjusted[idx];
+      float key = drawKey(weight);
+      if (heap.size() < _reservoirSize)
+        heap.push({key, {idx, weight}});
+      else if (key > heap.top().first) {
+        heap.pop();
+        heap.push({key, {idx, weight}});
+      }
+    }
+
+    _reservoirIndices.clear();
+    _reservoirWeights.clear();
+    while (!heap.empty()) {
+      auto entry = heap.top();
+      heap.pop();
+      _reservoirIndices.push_back(entry.second.first);
+      _reservoirWeights.push_back(entry.second.second);
+    }
+
+    ++_frameCount;
+  }
+
+  const std::vector<std::size_t> &reservoir() const { return _reservoirIndices; }
+  std::size_t selectionsPerFrame() const { return _reservoirSize; }
+  std::size_t framesSimulated() const { return _frameCount; }
+
+private:
+  std::size_t _primitiveCount = 0;
+  std::size_t _reservoirSize = 1;
+  std::size_t _candidateCount = 1;
+  float _reuseWeight = 0.0f;
+  std::mt19937 _rng;
+  std::uniform_real_distribution<float> _dist;
+  std::vector<std::size_t> _reservoirIndices;
+  std::vector<float> _reservoirWeights;
+  std::size_t _frameCount = 0;
+};
+
+} // namespace
+
+void RunReSTIRResidencyTests() {
+  constexpr std::size_t kPrimitiveCount = 32;
+  RestirReservoirSimulator simulator(kPrimitiveCount, 6, 4, 0.6f);
+  std::vector<float> uniformWeights(kPrimitiveCount, 1.0f);
+  std::vector<std::size_t> hitCount(kPrimitiveCount, 0);
+
+  constexpr std::size_t kFrames = 200;
+  for (std::size_t frame = 0; frame < kFrames; ++frame) {
+    simulator.step(uniformWeights);
+    for (std::size_t idx : simulator.reservoir()) {
+      assert(idx < hitCount.size());
+      ++hitCount[idx];
+    }
+  }
+
+  std::size_t uniqueHits = 0;
+  for (std::size_t count : hitCount)
+    if (count > 0)
+      ++uniqueHits;
+  assert(uniqueHits > kPrimitiveCount / 2);
+
+  std::size_t totalSelections = simulator.selectionsPerFrame() * kFrames;
+  std::size_t maxCount =
+      *std::max_element(hitCount.begin(), hitCount.end());
+  float maxShare = (totalSelections > 0)
+                       ? static_cast<float>(maxCount) /
+                             static_cast<float>(totalSelections)
+                       : 0.0f;
+  assert(maxShare < 0.35f);
+}
+

--- a/tests/ResidencyTestsMain.cpp
+++ b/tests/ResidencyTestsMain.cpp
@@ -1,8 +1,10 @@
 void RunResidencyBudgetTests();
 void RunProbabilisticResidencyTests();
+void RunReSTIRResidencyTests();
 
 int main() {
   RunResidencyBudgetTests();
   RunProbabilisticResidencyTests();
+  RunReSTIRResidencyTests();
   return 0;
 }


### PR DESCRIPTION
## Summary
- implement weighted stochastic reservoir sampling for ReSTIR residency, mixing reused entries with fresh candidates and exploration jitter
- introduce random tie-breaking and exploration noise so low-index primitives are no longer favored and inactive primitives can re-enter
- add a deterministic ReSTIR residency regression simulation to ensure uniform coverage over time

## Testing
- cmake -S tests -B build/tests && cmake --build build/tests
- ./build/tests/ResidencyTests *(fails: ProbabilisticResidencyTests assertion uncovered during run)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953427460b0832d98e01a9cf70e4567)