### PR TITLE
Rename ViewDelegate for Objective-C++ support

### DIFF
--- a/Nomad Path Tracer/Window/ViewDelegate.mm
+++ b/Nomad Path Tracer/Window/ViewDelegate.mm
@@ -9,6 +9,11 @@
 #include <fstream>
 #include <limits>
 
+@class ViewBridge;
+@interface ViewBridge (ControlUpdates)
++ (void)updateControlValues;
+@end
+
 using namespace NomadPathTracer;
 
 ViewDelegate::ViewDelegate(MTL::Device *pDevice)


### PR DESCRIPTION
## Summary
- rename the view delegate source to .mm so Objective-C++ syntax is accepted
- add a forward declaration for the ViewBridge control update call used during rendering

## Testing
- Not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695347196acc832d90cf479f8ea6a783)