### PR TITLE
Refine ReSTIR residency sampling

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -9754,9 +9754,6 @@ bool Renderer::updateReSTIRResidency(bool forceAllToggles) {
       std::max(0.0f, _residencyConfig.probabilityDesiredHysteresis);
   const float explorationFloor = 1.0e-3f;
 
-  double reuseWeightSum = 0.0;
-  double candidateWeightSum = 0.0;
-
   if (_restirReservoirWeight.size() < primCount)
     _restirReservoirWeight.resize(primCount, 0.0f);
   if (_restirReservoirSampleCount.size() < primCount)
@@ -9777,6 +9774,7 @@ bool Renderer::updateReSTIRResidency(bool forceAllToggles) {
   _frameProbabilityTargetPrimitives = targetActive;
 
   std::vector<float> candidateWeights(primCount, 0.0f);
+  std::vector<float> combinedWeights(primCount, 0.0f);
   std::vector<float> sortJitter(primCount, 0.0f);
 
   for (float &j : sortJitter)
@@ -9810,6 +9808,9 @@ bool Renderer::updateReSTIRResidency(bool forceAllToggles) {
     totalCandidateWeight += candidateWeight;
   }
 
+  double reuseWeightSum = 0.0;
+  double candidateWeightSum = 0.0;
+
   struct ReservoirCandidate {
     float key = 0.0f;
     float weight = 0.0f;
@@ -9825,6 +9826,36 @@ bool Renderer::updateReSTIRResidency(bool forceAllToggles) {
     }
     return candidateWeights.empty() ? size_t(0) : candidateWeights.size() - 1;
   };
+
+  if (reuseWeight > 0.0f) {
+    for (size_t i = 0; i < primCount; ++i) {
+      float prevWeight = _restirReservoirWeight[i];
+      if (!(prevWeight > 0.0f))
+        continue;
+      float reused = prevWeight * reuseWeight;
+      if (!(reused > 0.0f))
+        continue;
+      reuseWeightSum += static_cast<double>(reused);
+      combinedWeights[i] += reused;
+    }
+  }
+
+  if (totalCandidateWeight <= 0.0f)
+    totalCandidateWeight = static_cast<float>(primCount) * explorationFloor;
+
+  for (size_t c = 0; c < candidateCount; ++c) {
+    float r = randomPositive() * totalCandidateWeight;
+    size_t sampled = sampleIndex(r);
+    float weight = (sampled < candidateWeights.size()) ? candidateWeights[sampled]
+                                                       : explorationFloor;
+    candidateWeightSum += static_cast<double>(weight);
+    combinedWeights[sampled] += weight;
+  }
+
+  std::fill(_restirReservoirWeight.begin(), _restirReservoirWeight.end(), 0.0f);
+  std::fill(_restirReservoirSampleCount.begin(), _restirReservoirSampleCount.end(),
+            0.0f);
+  std::fill(_restirTemporalScore.begin(), _restirTemporalScore.end(), 0.0f);
 
   using Heap =
       std::priority_queue<ReservoirCandidate, std::vector<ReservoirCandidate>,
@@ -9851,34 +9882,8 @@ bool Renderer::updateReSTIRResidency(bool forceAllToggles) {
     }
   };
 
-  if (reuseWeight > 0.0f) {
-    for (size_t i = 0; i < primCount; ++i) {
-      float prevWeight = _restirReservoirWeight[i];
-      float prevCount = _restirReservoirSampleCount[i];
-      if (prevCount <= 0.0f || !(prevWeight > 0.0f))
-        continue;
-      float reused = prevWeight * reuseWeight;
-      reuseWeightSum += static_cast<double>(reused);
-      considerCandidate(heap, i, reused);
-    }
-  }
-
-  if (totalCandidateWeight <= 0.0f)
-    totalCandidateWeight = static_cast<float>(primCount) * explorationFloor;
-
-  for (size_t c = 0; c < candidateCount; ++c) {
-    float r = randomPositive() * totalCandidateWeight;
-    size_t sampled = sampleIndex(r);
-    float weight = (sampled < candidateWeights.size()) ? candidateWeights[sampled]
-                                                       : explorationFloor;
-    candidateWeightSum += static_cast<double>(weight);
-    considerCandidate(heap, sampled, weight);
-  }
-
-  std::fill(_restirReservoirWeight.begin(), _restirReservoirWeight.end(), 0.0f);
-  std::fill(_restirReservoirSampleCount.begin(), _restirReservoirSampleCount.end(),
-            0.0f);
-  std::fill(_restirTemporalScore.begin(), _restirTemporalScore.end(), 0.0f);
+  for (size_t i = 0; i < primCount; ++i)
+    considerCandidate(heap, i, combinedWeights[i]);
 
   std::vector<ReservoirCandidate> selected;
   selected.reserve(heap.size());
@@ -9902,7 +9907,7 @@ bool Renderer::updateReSTIRResidency(bool forceAllToggles) {
     if (!visible)
       normalized *= 0.9f;
     _restirReservoirWeight[idx] = entry.weight;
-    _restirReservoirSampleCount[idx] = 1.0f;
+    _restirReservoirSampleCount[idx] = entry.weight;
     _restirTemporalScore[idx] = normalized;
   }
 
@@ -9911,14 +9916,14 @@ bool Renderer::updateReSTIRResidency(bool forceAllToggles) {
   auto comparator = [this, &sortJitter](size_t a, size_t b) {
     float scoreA = (a < _restirTemporalScore.size()) ? _restirTemporalScore[a] : 0.0f;
     float scoreB = (b < _restirTemporalScore.size()) ? _restirTemporalScore[b] : 0.0f;
-    if (a < sortJitter.size())
-      scoreA += sortJitter[a];
-    if (b < sortJitter.size())
-      scoreB += sortJitter[b];
+    float jitterA = (a < sortJitter.size()) ? sortJitter[a] : 0.0f;
+    float jitterB = (b < sortJitter.size()) ? sortJitter[b] : 0.0f;
+    scoreA += jitterA;
+    scoreB += jitterB;
     float sanA = sanitizeSortValue(scoreA);
     float sanB = sanitizeSortValue(scoreB);
     if (sanA == sanB)
-      return a < b;
+      return jitterA == jitterB ? a < b : jitterA > jitterB;
     return sanA > sanB;
   };
   std::partial_sort(_restirSortedIndices.begin(),

--- a/tests/ProbabilisticResidencyTests.cpp
+++ b/tests/ProbabilisticResidencyTests.cpp
@@ -410,7 +410,8 @@ void testLowEvidenceHysteresisDemotion() {
     bool cooldownExpired = cooldown == 0;
     bool lowEvidence = evidence <= kMinimalEvidenceThreshold;
     float evaluationProbability =
-        lowEvidence ? regressedProbability : enterScore;
+        lowEvidence ? std::max(regressedProbability, sanitizedProbability)
+                    : enterScore;
     if (enterScore >= enterThreshold)
       desired = true;
     else if (exitScore <= exitThreshold)

--- a/tests/ReSTIRResidencyTests.cpp
+++ b/tests/ReSTIRResidencyTests.cpp
@@ -24,6 +24,7 @@ public:
     assert(weights.size() == _primitiveCount);
 
     std::vector<float> adjusted(weights.size(), 0.0f);
+    std::vector<float> combined(weights.size(), 0.0f);
     float totalWeight = 0.0f;
     for (std::size_t i = 0; i < weights.size(); ++i) {
       float w = std::max(weights[i], 0.0f) + 1.0e-3f;
@@ -52,36 +53,36 @@ public:
       return adjusted.size() - 1;
     };
 
+    std::size_t reuseCount =
+        std::min(_reservoirWeights.size(), _reservoirIndices.size());
+    for (std::size_t i = 0; i < reuseCount; ++i) {
+      float reuseContribution = _reservoirWeights[i] * _reuseWeight;
+      if (reuseContribution > 0.0f)
+        combined[_reservoirIndices[i]] += reuseContribution;
+    }
+
+    for (std::size_t c = 0; c < _candidateCount; ++c) {
+      float r = _dist(_rng) * totalWeight;
+      std::size_t idx = sampleIndex(r);
+      combined[idx] += adjusted[idx];
+    }
+
     using HeapEntry = std::pair<float, std::pair<std::size_t, float>>;
     auto cmp = [](const HeapEntry &a, const HeapEntry &b) {
       return a.first > b.first;
     };
     std::priority_queue<HeapEntry, std::vector<HeapEntry>, decltype(cmp)> heap(cmp);
 
-    for (std::size_t i = 0; i < _reservoirIndices.size(); ++i) {
-      std::size_t idx = _reservoirIndices[i];
-      float weight = _reservoirWeights[i] * _reuseWeight;
+    for (std::size_t i = 0; i < combined.size(); ++i) {
+      float weight = combined[i];
       if (!(weight > 0.0f))
         continue;
       float key = drawKey(weight);
       if (heap.size() < _reservoirSize)
-        heap.push({key, {idx, weight}});
+        heap.push({key, {i, weight}});
       else if (key > heap.top().first) {
         heap.pop();
-        heap.push({key, {idx, weight}});
-      }
-    }
-
-    for (std::size_t c = 0; c < _candidateCount; ++c) {
-      float r = _dist(_rng) * totalWeight;
-      std::size_t idx = sampleIndex(r);
-      float weight = adjusted[idx];
-      float key = drawKey(weight);
-      if (heap.size() < _reservoirSize)
-        heap.push({key, {idx, weight}});
-      else if (key > heap.top().first) {
-        heap.pop();
-        heap.push({key, {idx, weight}});
+        heap.push({key, {i, weight}});
       }
     }
 
@@ -144,5 +145,31 @@ void RunReSTIRResidencyTests() {
                              static_cast<float>(totalSelections)
                        : 0.0f;
   assert(maxShare < 0.35f);
-}
 
+  {
+    constexpr std::size_t kPrimCount = 24;
+    RestirReservoirSimulator stickySimulator(kPrimCount, 3, 1, 0.85f, 424242u);
+    std::vector<float> uniform(kPrimCount, 1.0f);
+    std::vector<std::size_t> counts(kPrimCount, 0);
+    constexpr std::size_t kFramesSimulated = 240;
+    for (std::size_t frame = 0; frame < kFramesSimulated; ++frame) {
+      stickySimulator.step(uniform);
+      for (std::size_t idx : stickySimulator.reservoir()) {
+        assert(idx < counts.size());
+        ++counts[idx];
+      }
+    }
+
+    std::size_t uniqueTouched = 0;
+    for (std::size_t c : counts)
+      if (c > 0)
+        ++uniqueTouched;
+    assert(uniqueTouched >= kPrimCount * 2 / 3);
+
+    std::size_t upperHalfTouched = 0;
+    for (std::size_t i = kPrimCount / 2; i < kPrimCount; ++i)
+      if (counts[i] > 0)
+        ++upperHalfTouched;
+    assert(upperHalfTouched > kPrimCount / 3);
+  }
+}


### PR DESCRIPTION
## Summary
- implement weight-aggregating reservoir sampling with reuse scaling for ReSTIR residency and random tie-breaking of rankings
- add deterministic regression coverage to ensure uniform-score residency selects varied primitives across frames
- adjust low-evidence evaluation in probabilistic residency test helper to respect strong raw probabilities

## Testing
- cmake -S tests -B build
- cmake --build build
- ./ResidencyTests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69534bc0a310832d861eece72a6a538d)