### PR TITLE
Update Blender exporter branding to Nomad Scene

### DIFF
--- a/Nomad Path Tracer/lightwave_blender/__init__.py
+++ b/Nomad Path Tracer/lightwave_blender/__init__.py
@@ -1,9 +1,9 @@
 from . import exporter_ui, addon_preferences
 
 bl_info = {
-    "name": "Metal Scene",
+    "name": "Nomad Scene",
     "author": "Ömercan Yazici, Alexander Rath",
-    "description": "Export scene to MetalPathtracer",
+    "description": "Export scene to Nomad Pathtracer",
     "version": (0, 2, 5),
     "blender": (3, 0, 0),
     "location": "File > Import-Export",

--- a/Nomad Path Tracer/lightwave_blender/exporter_ui.py
+++ b/Nomad Path Tracer/lightwave_blender/exporter_ui.py
@@ -16,11 +16,11 @@ from .exporter import *
 
 
 class ExportLightwave(bpy.types.Operator, ExportHelper):
-    """Export scene to Lightwave"""
+    """Export scene to Nomad Scene"""
 
     bl_idname = "export_scene.lightwave"
-    bl_label = "Export Lightwave Scene"
-    bl_description = "Export scene to Lightwave"
+    bl_label = "Export Nomad Scene"
+    bl_description = "Export scene to Nomad Scene"
     bl_options = {'PRESET'}
 
     filename_ext = ".xml"
@@ -180,7 +180,7 @@ class LIGHTWAVE_PT_export_include(bpy.types.Panel):
 
 
 def menu_func_export(self, context):
-    self.layout.operator(ExportLightwave.bl_idname, text="Lightwave (.xml)")
+    self.layout.operator(ExportLightwave.bl_idname, text="Nomad Scene (.xml)")
 
 
 classes = (


### PR DESCRIPTION
## Summary
- rename the Blender addon name and description to Nomad Scene
- update exporter UI labels and menu text to use the new Nomad Scene branding

## Testing
- not run (UI string updates only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958e92df22c832db31b909568d0c59f)