### PR TITLE
Handle missing mathutils rad/deg helpers

### DIFF
--- a/Nomad Path Tracer/lightwave_blender/utils.py
+++ b/Nomad Path Tracer/lightwave_blender/utils.py
@@ -1,5 +1,13 @@
+import math
 import mathutils
 import re
+
+# Blender's mathutils module does not always expose rad2deg/deg2rad,
+# so register lightweight fallbacks to keep the add-on working across versions.
+if not hasattr(mathutils, "rad2deg"):
+    mathutils.rad2deg = math.degrees
+if not hasattr(mathutils, "deg2rad"):
+    mathutils.deg2rad = math.radians
 
 
 def find_unique_name(used: set[str], name: str):


### PR DESCRIPTION
## Summary
- add fallbacks for mathutils.rad2deg and mathutils.deg2rad to maintain compatibility across Blender mathutils versions

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958f9d5ff10832db3b1fc511c834dd8)