### PR TITLE
Handle unloaded images during export

### DIFF
--- a/Nomad Path Tracer/lightwave_blender/node.py
+++ b/Nomad Path Tracer/lightwave_blender/node.py
@@ -35,11 +35,49 @@ def _export_rgb_value(registry: SceneRegistry, input: RMInput, exposure):
 
 def _export_image(registry: SceneRegistry, image, path, is_f32=False, keep_format=False):
     if os.path.exists(path) and not registry.settings.overwrite_existing_textures:
-        return
+        return True
+
+    def _try_load_pixels():
+        try:
+            return len(image.pixels)
+        except Exception as exc:
+            registry.warn(f"Unable to read pixel buffer length for {image.name}: {exc}")
+            return 0
 
     # Make sure the image is loaded to memory, so we can write it out
-    if not image.has_data:
-        image.pixels[0]
+    pixel_count = _try_load_pixels()
+    if (not getattr(image, "has_data", True) or pixel_count == 0) and hasattr(image, "reload"):
+        try:
+            image.reload()
+            pixel_count = _try_load_pixels()
+        except Exception as exc:
+            registry.warn(f"Failed to reload image {image.name}: {exc}")
+
+    if pixel_count == 0 and hasattr(image, "update"):
+        try:
+            image.update()
+            pixel_count = _try_load_pixels()
+        except Exception as exc:
+            registry.warn(f"Failed to update image {image.name}: {exc}")
+
+    if pixel_count > 0:
+        try:
+            sample_len = min(pixel_count, 4)
+            if sample_len > 0:
+                sample = [0.0] * sample_len
+                image.pixels.foreach_get(sample)
+        except Exception as exc:
+            registry.warn(f"Unable to read pixels for {image.name}: {exc}")
+
+    if pixel_count == 0:
+        width = 0
+        height = 0
+        try:
+            width, height = image.size
+        except Exception:
+            pass
+        registry.error(f"Image {image.name} has no pixel data loaded (size: {width}x{height}); skipping export")
+        return False
 
     # Export the actual image data
     try:
@@ -59,6 +97,7 @@ def _export_image(registry: SceneRegistry, image, path, is_f32=False, keep_forma
                 "Can not change the original format of given image")
         # Try other way
         image.save_render(path)
+    return True
 
 
 def _handle_image(registry: SceneRegistry, image: bpy.types.Image):
@@ -68,7 +107,8 @@ def _handle_image(registry: SceneRegistry, image: bpy.types.Image):
         img_name = image.name + \
             (".png" if not image.use_generated_float else ".exr")
         img_path = os.path.join(tex_dir_name, img_name)
-        _export_image(registry, image, os.path.join(registry.path, img_path), is_f32=image.use_generated_float)
+        if not _export_image(registry, image, os.path.join(registry.path, img_path), is_f32=image.use_generated_float):
+            return None
         return img_path.replace('\\', '/') # Ensure the image path is not using \ to keep the xml valid
     elif image.source == 'FILE':
         filepath = image.filepath_raw if image.filepath_raw is not None else image.filepath
@@ -105,13 +145,15 @@ def _handle_image(registry: SceneRegistry, image: bpy.types.Image):
                 img_path = os.path.join(tex_dir_name, img_name)
 
             try:
-                _export_image(registry, image, os.path.join(registry.path, img_path),
+                success = _export_image(registry, image, os.path.join(registry.path, img_path),
                                 is_f32=is_f32, keep_format=keep_format)
             except:
                 # Above failed, so give this a try
                 img_path = os.path.join(tex_dir_name, img_name)
-                _export_image(registry, image, os.path.join(registry.path, img_path),
+                success = _export_image(registry, image, os.path.join(registry.path, img_path),
                                   is_f32=False, keep_format=True)
+            if not success:
+                return None
         return img_path.replace('\\', '/') # Ensure the image path is not using \ to keep the xml valid
     else:
         registry.error(f"Image type {image.source} not supported")
@@ -126,6 +168,9 @@ def _export_image_texture(registry: SceneRegistry, input: RMInput, exposure):
 
     def export(unique_name):
         img_path = _handle_image(registry, bl_node.image)
+        if img_path is None:
+            registry.error(f"Skipping texture export for node {bl_node.name} because the image could not be loaded")
+            return _export_fallback()
         kw = {}
 
         if exposure is not None and exposure != 1:
@@ -159,6 +204,9 @@ def _export_env_image_texture(registry: SceneRegistry, input: RMInput, exposure)
 
     def export(unique_name):
         img_path = _handle_image(registry, bl_node.image)
+        if img_path is None:
+            registry.error(f"Skipping environment texture export for node {bl_node.name} because the image could not be loaded")
+            return _export_fallback()
         kw = {}
 
         if exposure is not None and exposure != 1:

--- a/tests/test_node_export_image.py
+++ b/tests/test_node_export_image.py
@@ -1,0 +1,160 @@
+import os
+import sys
+import tempfile
+import types
+import unittest
+import importlib.util
+from pathlib import Path
+
+
+def _install_fake_bpy():
+    fake_bpy = types.ModuleType("bpy")
+    fake_bpy.types = types.SimpleNamespace(
+        Image=type("Image", (), {}),
+        AddonPreferences=type("AddonPreferences", (), {}),
+        Object=type("Object", (), {}),
+        Node=type("Node", (), {}),
+        NodeTree=type("NodeTree", (), {}),
+    )
+    props_module = types.ModuleType("bpy.props")
+    props_module.StringProperty = lambda **kwargs: None
+    fake_bpy.props = props_module
+    fake_bpy.path = types.SimpleNamespace(
+        abspath=lambda path, library=None: path,
+        resolve_ncase=lambda path: path,
+        relpath=lambda path, start=None: path,
+        basename=lambda path: os.path.basename(path),
+    )
+    fake_bpy.utils = types.SimpleNamespace(register_class=lambda cls: None, unregister_class=lambda cls: None)
+    fake_bpy.context = types.SimpleNamespace(
+        preferences=types.SimpleNamespace(addons={"lightwave_blender": types.SimpleNamespace(preferences=types.SimpleNamespace(tex_dir_name="textures", mesh_dir_name="meshes"))})
+    )
+    sys.modules["bpy"] = fake_bpy
+    sys.modules["bpy.props"] = props_module
+    sys.modules["bpy.types"] = fake_bpy.types
+
+
+def _install_fake_mathutils():
+    mathutils = types.ModuleType("mathutils")
+
+    class _Quaternion:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __matmul__(self, other):
+            return self
+
+    class _Vector:
+        @staticmethod
+        def Fill(length, value):
+            return [value] * length
+
+    class _Matrix:
+        @staticmethod
+        def LocRotScale(loc, rot, sca):
+            return (loc, rot, sca)
+
+    mathutils.Quaternion = _Quaternion
+    mathutils.Vector = _Vector
+    mathutils.Matrix = _Matrix
+    sys.modules["mathutils"] = mathutils
+
+
+class _PixelBuffer:
+    def __init__(self, data=None):
+        self._data = data or []
+
+    def __len__(self):
+        return len(self._data)
+
+    def foreach_get(self, out):
+        for idx in range(min(len(out), len(self._data))):
+            out[idx] = self._data[idx]
+
+
+class _FakeImage:
+    def __init__(self):
+        self.name = "EmptyImage"
+        self.has_data = False
+        self.pixels = _PixelBuffer([])
+        self.size = (1024, 1024)
+        self.filepath_raw = ""
+        self.file_format = "PNG"
+        self._saved = False
+        self._render_saved = False
+
+    def reload(self):
+        # Keep pixels empty to simulate an unloaded image that cannot be reloaded
+        return None
+
+    def update(self):
+        # Keep pixels empty to simulate an unloaded image that cannot be updated
+        return None
+
+    def save(self):
+        self._saved = True
+
+    def save_render(self, path):
+        self._render_saved = True
+
+
+class _DummyDepsgraph:
+    scene = None
+
+
+class _DummySettings:
+    overwrite_existing_textures = False
+
+
+class _DummyOperator:
+    def __init__(self):
+        self.messages = []
+
+    def report(self, levels, message):
+        self.messages.append((levels, message))
+
+
+class ExportImageTests(unittest.TestCase):
+    def setUp(self):
+        _install_fake_bpy()
+        _install_fake_mathutils()
+        repo_root = Path(__file__).resolve().parent.parent
+        package_root = repo_root / "Nomad Path Tracer" / "lightwave_blender"
+        base_package = types.ModuleType("lightwave_blender")
+        base_package.__path__ = [str(package_root)]
+        sys.modules["lightwave_blender"] = base_package
+
+        def _load_module(name, path):
+            spec = importlib.util.spec_from_file_location(
+                name, path, submodule_search_locations=base_package.__path__
+            )
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[name] = module
+            spec.loader.exec_module(module)  # type: ignore[arg-type]
+            return module
+
+        registry_module = _load_module("lightwave_blender.registry", package_root / "registry.py")
+        self.node_module = _load_module("lightwave_blender.node", package_root / "node.py")
+        self.registry_cls = registry_module.SceneRegistry
+
+    def test_unloaded_image_is_skipped_with_error(self):
+        dummy_op = _DummyOperator()
+        registry = self.registry_cls(
+            path=tempfile.gettempdir(),
+            depsgraph=_DummyDepsgraph(),
+            settings=_DummySettings(),
+            op=dummy_op,
+        )
+        image = _FakeImage()
+        export_path = os.path.join(tempfile.gettempdir(), "should_not_write.png")
+
+        result = self.node_module._export_image(registry, image, export_path, is_f32=False, keep_format=False)
+
+        self.assertFalse(result)
+        self.assertTrue(any("has no pixel data loaded" in msg for _, msg in dummy_op.messages))
+        self.assertFalse(image._saved)
+        self.assertFalse(image._render_saved)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- safely load Blender images before export and warn when their buffers remain empty
- skip exporting image and environment textures when data cannot be loaded instead of throwing
- add a unit test covering unloaded image handling with lightweight bpy/mathutils stubs

## Testing
- python -m unittest tests/test_node_export_image.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bc24f9964832d8aee097a7a0f6577)