### PR TITLE
Add environment lighting and visible bistro light

### DIFF
--- a/Nomad Path Tracer/scene_bistro_test.xml
+++ b/Nomad Path Tracer/scene_bistro_test.xml
@@ -1,7 +1,10 @@
-<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="alwaysresident">
+<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" environmentTexture="Textures/NomadEnv_1p0000_1p0000_1p0000.exr" environmentBrightness="1.2" residencyStrategy="alwaysresident">
   <CameraPath>
     <Keyframe frame="1" position="-9.8374,-1.4931,3.4163" lookAt="-10.803,-1.6539,3.6209"/>
   </CameraPath>
+  <Sphere position="-13.6996,-2.1363,4.2347" radius="0.20"
+          albedo="0,0,0" emission="8.5,7.9,7.3" materialType="0"
+          emissionPower="18"/>
   <Mesh file="meshes/_m_0_Mesh.obj" position="-1.2857,13.082,5.4094" scale="0.0089" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-9.8066,-3.3111,-131.57" albedo="1,1,1" emission="0,0,0" materialType="0" emissionPower="1"/>
   <Mesh file="meshes/_m_1_Mesh.obj" position="-1.2857,13.082,5.4094" scale="0.0089" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-9.8066,-3.3111,-131.57" albedo="1,1,1" emission="0,0,0" materialType="0" emissionPower="50"/>
   <Mesh file="meshes/_m_2_Mesh.obj" position="-1.2857,13.082,5.4094" scale="0.0089" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-9.8066,-3.3111,-131.57" albedo="1,1,1" emission="0,0,0" materialType="0" emissionPower="50"/>


### PR DESCRIPTION
## Summary
- add an HDR environment map and brightness to the bistro test scene for global illumination
- place a forward-facing emissive sphere in view of the camera to guarantee visible lighting

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bca822c74832d8be8aa16e3215aef)