### PR TITLE
Adjust staircase test camera path target

### DIFF
--- a/Nomad Path Tracer/scene_staircase_test.xml
+++ b/Nomad Path Tracer/scene_staircase_test.xml
@@ -1,6 +1,6 @@
 <Scene width="720" height="576" maxRayDepth="4" startCompacted="true" environmentTexture="Textures/NomadEnv_1p0000_1p0000_1p0000.exr" environmentBrightness="1.25" residencyStrategy="alwaysresident">
   <CameraPath>
-    <Keyframe frame="0" position="0,-4.8365,0.90248" lookAt="0,-5.8175,0.70843"/>
+    <Keyframe frame="0" position="0,-5.2,0.9" lookAt="0.6,3.6,4.3"/>
   </CameraPath>
   <Rectangle position="0,-4.2,1.5" u="1.6,0,0" v="0,1.6,0"
              albedo="1,1,1" emission="1,0.98,0.95"


### PR DESCRIPTION
### Motivation
- The test scene camera was aimed at the flat environment and hid the staircase geometry, so the test render did not show the intended staircase meshes.
- The change aligns the test camera with the view used by the `staircase.xml` scene so the positive-Y staircase is visible.

### Description
- Updated `Nomad Path Tracer/scene_staircase_test.xml` by changing the `<CameraPath>` keyframe position to `0,-5.2,0.9` and `lookAt` to `0.6,3.6,4.3`.
- This mirrors the observer camera orientation used in `staircase.xml` to retarget the test camera toward the staircase geometry.

### Testing
- No automated rendering tests were run because the renderer binary/CLI is not available in the repository.
- No other automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cdc4a3c70832db238bb4d65d50f77)