### PR TITLE
Make per-command tile/sample work budget configurable (env/scene)

### DIFF
--- a/Nomad Path Tracer/README.md
+++ b/Nomad Path Tracer/README.md
@@ -1,0 +1,11 @@
+# Nomad Path Tracer runtime controls
+
+## Path tracing tile work budget
+
+Long-running path tracing commands can trigger GPU timeout errors when the pixel/sample workload is too large for a single command buffer. The renderer now exposes a runtime-configurable knob to cap the amount of tile work recorded per command:
+
+- **Environment variable:** set `MPT_MAX_TILE_WORK` to the maximum number of pixel/sample operations per command buffer. Example: `MPT_MAX_TILE_WORK=20000`.
+- **Scene XML:** add `maxTileWorkPerCommand="<value>"` (or the alias `maxTileWork`) to the `<Scene>` root to bake a limit into a scene file.
+- **Default:** when unset, the renderer uses a conservative default budget. For `AlwaysResident` residency, the default budget is halved to keep command buffers short while more geometry remains resident.
+
+The renderer clamps the budget so each command can still process at least one full tile, based on the current tile dimensions and sample count.

--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -518,12 +518,6 @@ struct TileDispatchRegion {
 
 constexpr uint32_t kPathTraceTileWidth = 128;
 constexpr uint32_t kPathTraceTileHeight = 128;
-// Limit the amount of pixel/sample work recorded into a single command buffer to
-// reduce the chance of long-running kernels triggering GPU timeout errors when
-// high sample counts are requested. With the always-resident residency strategy
-// scenes keep significantly more geometry active, so reduce the per-command
-// budget to lower kernel runtimes and avoid tripping the macOS GPU watchdog.
-constexpr size_t kMaxTileSampleWorkPerCommand = 128 * 128 * 4;
 constexpr std::chrono::milliseconds kFrameCommandBufferWaitTimeout(4);
 constexpr uint32_t kMaxMaterialTextureSlots = 64;
 
@@ -6716,10 +6710,36 @@ void Renderer::draw(MTK::View *pView) {
     MTL::Size threadsPerThreadgroup =
         MTL::Size::Make(tgWidth, tgHeight, 1);
 
+    auto parseMaxTileWorkEnv = []() -> size_t {
+      const char *env = std::getenv("MPT_MAX_TILE_WORK");
+      if (!env)
+        return 0;
+      char *end = nullptr;
+      unsigned long long parsed = std::strtoull(env, &end, 10);
+      if (end == env)
+        return 0;
+      return static_cast<size_t>(parsed);
+    };
+
     size_t tileIndex = 0;
-    const size_t maxWorkPerCommand =
-        std::max<size_t>(kMaxTileSampleWorkPerCommand, 1);
     const size_t effectiveMaxSamples = std::max<size_t>(maxSamples, 1);
+    const size_t envTileWork = parseMaxTileWorkEnv();
+    const bool envTileWorkValid = envTileWork > 0;
+    size_t tileWorkBudget = envTileWorkValid ? envTileWork
+                                             : kDefaultMaxTileSampleWorkPerCommand;
+
+    if (!envTileWorkValid && _pScene) {
+      if (_pScene->hasCustomMaxTileSampleWorkPerCommand()) {
+        tileWorkBudget = _pScene->getMaxTileSampleWorkPerCommand();
+      } else if (_frameStrategy == ResidencyStrategy::AlwaysResident) {
+        tileWorkBudget = std::max<size_t>(kDefaultMaxTileSampleWorkPerCommand / 2, 1);
+      }
+    }
+
+    size_t baseTileWork =
+        std::max<size_t>(static_cast<size_t>(tileWidth) * tileHeight, 1);
+    baseTileWork = std::max<size_t>(baseTileWork * effectiveMaxSamples, 1);
+    size_t maxWorkPerCommand = std::max(tileWorkBudget, baseTileWork);
 
     while (tileIndex < tiles.size()) {
       size_t batchStart = tileIndex;

--- a/Nomad Path Tracer/Scene/Scene.cpp
+++ b/Nomad Path Tracer/Scene/Scene.cpp
@@ -88,6 +88,8 @@ void Scene::clear() {
   residencyParams = ResidencyParameters{};
   startCompacted = false;
   textureResidencyMemoryCapMB = 2048.0;
+  maxTileSampleWorkPerCommand = kDefaultMaxTileSampleWorkPerCommand;
+  maxTileSampleWorkPerCommandSet = false;
   observerCameraValid = false;
   observerCamera = ObserverCamera{};
   triangleVerticesCache.clear();
@@ -253,6 +255,19 @@ const ResidencyParameters &Scene::getResidencyParameters() const {
 void Scene::setResidencyParameters(const ResidencyParameters &params) {
   residencyParams = params;
   residencyParams.normalizeEnvironmentDepthSettings();
+}
+
+size_t Scene::getMaxTileSampleWorkPerCommand() const {
+  return maxTileSampleWorkPerCommand;
+}
+
+bool Scene::hasCustomMaxTileSampleWorkPerCommand() const {
+  return maxTileSampleWorkPerCommandSet;
+}
+
+void Scene::setMaxTileSampleWorkPerCommand(size_t work) {
+  maxTileSampleWorkPerCommand = std::max<size_t>(work, 1);
+  maxTileSampleWorkPerCommandSet = true;
 }
 
 bool Scene::getStartCompacted() const { return startCompacted; }

--- a/Nomad Path Tracer/Scene/Scene.h
+++ b/Nomad Path Tracer/Scene/Scene.h
@@ -25,6 +25,11 @@ enum class ResidencyStrategy {
   ReSTIR = 9,
 };
 
+// Default budget for the amount of tile/sample work recorded into a single
+// path tracing command buffer. The renderer clamps user-provided values to be
+// at least 1 tile of work.
+constexpr size_t kDefaultMaxTileSampleWorkPerCommand = 128 * 128 * 4;
+
 struct SceneObject {
   size_t firstPrimitive = 0;
   size_t primitiveCount = 0;
@@ -197,6 +202,10 @@ public:
   const ResidencyParameters &getResidencyParameters() const;
   void setResidencyParameters(const ResidencyParameters &params);
 
+  size_t getMaxTileSampleWorkPerCommand() const;
+  bool hasCustomMaxTileSampleWorkPerCommand() const;
+  void setMaxTileSampleWorkPerCommand(size_t work);
+
   bool getStartCompacted() const;
   void setStartCompacted(bool start);
 
@@ -264,6 +273,8 @@ private:
   ResidencyParameters residencyParams;
   bool startCompacted;
   double textureResidencyMemoryCapMB;
+  size_t maxTileSampleWorkPerCommand;
+  bool maxTileSampleWorkPerCommandSet;
   bool observerCameraValid;
   ObserverCamera observerCamera;
   mutable std::vector<simd::float3> triangleVerticesCache;

--- a/Nomad Path Tracer/Scene/SceneLoader.cpp
+++ b/Nomad Path Tracer/Scene/SceneLoader.cpp
@@ -855,6 +855,13 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         "environmentBrightness", scene->getEnvironmentBrightness());
     scene->setEnvironmentBrightness(envBrightness);
 
+    uint64_t maxTileWork =
+        root->Unsigned64Attribute("maxTileWorkPerCommand", 0);
+    maxTileWork = root->Unsigned64Attribute("maxTileWork", maxTileWork);
+    if (maxTileWork > 0) {
+        scene->setMaxTileSampleWorkPerCommand(static_cast<size_t>(maxTileWork));
+    }
+
     int nextMeshGroupId = 0;
 
     for (auto* e = root->FirstChildElement(); e; e = e->NextSiblingElement()) {


### PR DESCRIPTION
### Motivation

- Long-running path-trace command buffers can trigger GPU watchdog/timeouts when high sample counts or large tiles are used, so the per-command workload needs a tunable cap to avoid those failures.
- A runtime knob allows users and CI to tune batching without changing code and rebuilds.
- Scenes using the `AlwaysResident` residency strategy keep more geometry resident and therefore need a stricter default budget to keep kernel runtimes short.

### Description

- Added an environment override parsed from `MPT_MAX_TILE_WORK` and scene XML attributes `maxTileWorkPerCommand` / `maxTileWork` that set a per-command pixel/sample work budget via the `Scene` API (`getMaxTileSampleWorkPerCommand` / `setMaxTileSampleWorkPerCommand`).
- Replaced the fixed `kMaxTileSampleWorkPerCommand` with a configurable budget (`kDefaultMaxTileSampleWorkPerCommand`) and threaded the chosen value into the computation of `maxWorkPerCommand` used to split command buffers so batches are split more aggressively.
- Budget values are clamped so a command can always process at least one full tile and, when no explicit value is provided, the `AlwaysResident` residency strategy uses a stricter default (halved budget) to reduce runtime per command.
- Added documentation (`README.md`) describing the new `MPT_MAX_TILE_WORK` env var and the scene XML attributes to tune the knob without code changes.

### Testing

- No automated tests were run on the modified code as part of this change.
- The change was committed and staged locally; no CI or unit test results are available in this rollout.
- (Manual verification recommended: run a build and exercise scenes with and without `MPT_MAX_TILE_WORK` and with `residencyStrategy="alwaysresident"` to validate command buffer splitting behavior.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ce0daaf1c832d925fc14285495cee)