### PR TITLE
Cache path trace tile dimensions for work budget calculation

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -6654,6 +6654,8 @@ void Renderer::draw(MTK::View *pView) {
   uint32_t minSamples = 1;
   uint32_t maxSamples = 1;
   std::vector<TileDispatchRegion> tiles;
+  NS::UInteger generatedTileWidth = 0;
+  NS::UInteger generatedTileHeight = 0;
   if (_pPathTracePSO && accum1) {
     NS::UInteger width = accum1->width();
     NS::UInteger height = accum1->height();
@@ -6681,6 +6683,8 @@ void Renderer::draw(MTK::View *pView) {
         tileHeight = std::max<NS::UInteger>(
             1, static_cast<NS::UInteger>(std::max(1.0, scaledHeight)));
       }
+      generatedTileWidth = tileWidth;
+      generatedTileHeight = tileHeight;
       for (NS::UInteger y = 0; y < height; y += tileHeight) {
         NS::UInteger actualHeight = std::min(tileHeight, height - y);
         for (NS::UInteger x = 0; x < width; x += tileWidth) {
@@ -6736,8 +6740,12 @@ void Renderer::draw(MTK::View *pView) {
       }
     }
 
+    size_t tileBaseWidth =
+        std::max<size_t>(static_cast<size_t>(generatedTileWidth), 1);
+    size_t tileBaseHeight =
+        std::max<size_t>(static_cast<size_t>(generatedTileHeight), 1);
     size_t baseTileWork =
-        std::max<size_t>(static_cast<size_t>(tileWidth) * tileHeight, 1);
+        std::max<size_t>(tileBaseWidth * tileBaseHeight, 1);
     baseTileWork = std::max<size_t>(baseTileWork * effectiveMaxSamples, 1);
     size_t maxWorkPerCommand = std::max(tileWorkBudget, baseTileWork);
 


### PR DESCRIPTION
### Motivation
- Fix use of out-of-scope tile dimension identifiers in the path trace dispatch budget calculation.
- Ensure the per-command tile work clamp always accounts for the actual tile shape used to generate dispatch regions.
- Prevent GPU command buffers from being undersized or oversized due to missing tile dimension information.

### Description
- Add local variables `generatedTileWidth` and `generatedTileHeight` to capture the final tile dimensions when tiles are generated.
- Populate the new variables once the computed `tileWidth`/`tileHeight` are finalized during tile generation.
- Compute `baseTileWork` using the cached `generatedTileWidth`/`generatedTileHeight` instead of the out-of-scope `tileWidth`/`tileHeight`, preserving the existing `max(1, ...)` guards. 

### Testing
- Attempted to build with `xcodebuild -project "Nomad Path Tracer.xcodeproj" -scheme "Nomad Path Tracer" build`, but the `xcodebuild` tool is not available in this environment so compilation could not be verified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cea380ce8832db88687733e760bd3)