### PR TITLE
Apply renderer world-space conversion to exported objects and cameras

### DIFF
--- a/Nomad Path Tracer/lightwave_blender/exporter.py
+++ b/Nomad Path Tracer/lightwave_blender/exporter.py
@@ -4,7 +4,7 @@ import mathutils
 import os
 
 from .shape import export_shape
-from .utils import str_flat_array, str_float
+from .utils import convert_world_matrix, str_flat_array, str_float
 from .addon_preferences import get_prefs
 from .xml_node import XMLNode, XMLRootNode
 from .registry import SceneRegistry
@@ -217,12 +217,14 @@ def export_objects(registry: SceneRegistry):
             registry.warn(f"Entity {object_eval.name} has no material or shape and will be ignored")
             continue
 
-        basis = inst.matrix_world.to_3x3()
+        converted_matrix = convert_world_matrix(inst.matrix_world)
+
+        basis = converted_matrix.to_3x3()
         basis_x = basis.col[0]
         basis_y = basis.col[1]
         basis_z = basis.col[2]
 
-        location, rotation, scale = inst.matrix_world.decompose()
+        location, rotation, scale = converted_matrix.decompose()
         rotation_euler = rotation.to_euler('XYZ')
         has_uniform_scale = _is_uniform_scale(scale)
         uses_rotation_attributes = has_uniform_scale and _basis_matches_rotation(

--- a/Nomad Path Tracer/lightwave_blender/utils.py
+++ b/Nomad Path Tracer/lightwave_blender/utils.py
@@ -48,10 +48,27 @@ def str_flat_array(array):
     return ",".join([str_float(x) for x in array])
 
 
+def world_to_renderer_matrix():
+    # Converts from Blender (X right, Y forward, Z up) to renderer (X right, Y up, -Z forward)
+    return mathutils.Matrix((
+        (1.0, 0.0, 0.0, 0.0),
+        (0.0, 0.0, 1.0, 0.0),
+        (0.0, -1.0, 0.0, 0.0),
+        (0.0, 0.0, 0.0, 1.0),
+    ))
+
+
+def convert_world_matrix(matrix):
+    return world_to_renderer_matrix() @ matrix
+
+
 def orient_camera(matrix, skip_scale=False):
-    # Y Up, Front -Z
-    loc, rot, sca = matrix.decompose()
-    return mathutils.Matrix.LocRotScale(loc, rot @ mathutils.Quaternion((0, 0, 1, 0)) @ mathutils.Quaternion((0, 0, 0, 1)), mathutils.Vector.Fill(3, 1) if skip_scale else sca)
+    converted = convert_world_matrix(matrix)
+    loc, rot, sca = converted.decompose()
+    return mathutils.Matrix.LocRotScale(
+        loc,
+        rot,
+        mathutils.Vector.Fill(3, 1) if skip_scale else sca)
 
 
 def try_extract_node_value(value, default=0):


### PR DESCRIPTION
### Motivation
- Exported object positions and orientations were left in Blender's Z-up frame and did not match the renderer's Y-up/-Z-forward coordinate system.
- Camera export only adjusted orientation via `orient_camera` but reused Blender-space translation, producing incorrect camera position and `lookAt` targets.

### Description
- Add `world_to_renderer_matrix()` and `convert_world_matrix()` utilities in `lightwave_blender/utils.py` to convert Blender world transforms to the renderer frame. 
- Change `orient_camera` to convert the full input transform before decomposing so camera position, rotation, and `lookAt` derive from the converted matrix. 
- Apply `convert_world_matrix(inst.matrix_world)` in `lightwave_blender/exporter.py` so object `position`, `basisX/Y/Z` and rotation decomposition use the renderer-space transform. 
- Import and use `convert_world_matrix` where object transforms are computed so exported mesh placement and orientation match the renderer.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ced811dfc832daa4e486116ccd27a)