### PR TITLE
Defer BLAS rebuilds while commands are in flight

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -217,6 +217,19 @@ bool ResidentObjectGpuResources::hasPendingCommands() {
   return false;
 }
 
+bool ResidentObjectGpuResources::waitForPendingCommands(
+    std::chrono::milliseconds timeout) {
+  using namespace std::chrono;
+  const auto deadline = steady_clock::now() + timeout;
+  while (hasPendingCommands()) {
+    if (timeout.count() == 0 || steady_clock::now() >= deadline)
+      return false;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  clearPendingCommand();
+  return true;
+}
+
 bool ResidentObjectGpuResources::transitionToCold(
     BlasInstanceRecord &instanceRecord) {
   clearPendingCommand();
@@ -251,6 +264,19 @@ bool ResidentObjectGpuResources::ensureResident(
   if (isResident() && !forceRebuild) {
     lastStateChange = std::chrono::steady_clock::now();
     return true;
+  }
+
+  constexpr auto kPendingCommandWait =
+      std::chrono::milliseconds(50);
+  if (hasPendingCommands()) {
+    if (!waitForPendingCommands(kPendingCommandWait)) {
+      std::printf(
+          "[BLAS] Deferred rebuild for object %zu: pending command buffer "
+          "still in flight.\n",
+          objectIndex);
+      lastStateChange = std::chrono::steady_clock::now();
+      return true;
+    }
   }
 
   transitionToStreaming();
@@ -2717,6 +2743,18 @@ bool Renderer::buildObjectBlas(size_t objectIndex, const SceneObject &object,
   if (!_pDevice || !_pCommandQueue)
     return false;
 
+  constexpr auto kPendingCommandWait =
+      std::chrono::milliseconds(50);
+  if (resident.hasPendingCommands()) {
+    if (!resident.waitForPendingCommands(kPendingCommandWait)) {
+      std::printf(
+          "[BLAS] Deferred build for object %zu: waiting for prior command "
+          "buffer to complete.\n",
+          objectIndex);
+      return false;
+    }
+  }
+
   NS::AutoreleasePool *pool = NS::AutoreleasePool::alloc()->init();
 
   auto cleanupPool = [&]() {
@@ -2879,6 +2917,16 @@ void Renderer::processBlasBuildQueue() {
   while (!_pendingBlasBuilds.empty() &&
          _activeBlasBuilds.size() < kMaxBlasBuildsInFlight) {
     auto buildRequest = _pendingBlasBuilds.front();
+    if (buildRequest && buildRequest->resident &&
+        buildRequest->resident->hasPendingCommands()) {
+      std::printf(
+          "[BLAS] Deferred queued build for object %zu: pending command buffer "
+          "still in flight.\n",
+          buildRequest->objectIndex);
+      _pendingBlasBuilds.pop_front();
+      _pendingBlasBuilds.push_back(buildRequest);
+      break;
+    }
     if (!startBlasBuild(buildRequest)) {
       _pendingBlasBuilds.pop_front();
       if (buildRequest && buildRequest->resident &&

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -65,6 +65,7 @@ struct ResidentObjectGpuResources {
   bool transitionToCold(BlasInstanceRecord &instanceRecord);
   void clearPendingCommand();
   bool hasPendingCommands();
+  bool waitForPendingCommands(std::chrono::milliseconds timeout);
   bool isResident() const { return state == ResidencyState::Resident; }
 
   ResidentObjectGpuResources() = default;


### PR DESCRIPTION
### Motivation

- Prevent heap/buffer reallocation while a previous BLAS build command buffer may still be using those resources to avoid freeing in-use handles.
- Ensure eviction and rebuild paths respect in-flight GPU work to prevent use-after-free or GPU errors.
- Provide lightweight logging when rebuilds are deferred to aid debugging.

### Description

- Add `ResidentObjectGpuResources::waitForPendingCommands(std::chrono::milliseconds)` to wait for pending command buffers and clear completed records.
- In `ResidentObjectGpuResources::ensureResident` add a short wait and a defer path with a log message when pending commands remain, preserving prior heap/buffer state.
- In `Renderer::buildObjectBlas` check `resident.hasPendingCommands()` and call `waitForPendingCommands` to defer builds if prior command buffers are still in flight, logging when deferral occurs.
- In `Renderer::processBlasBuildQueue` detect queued builds targeting resources with pending commands and re-queue (defer) them with a log message instead of starting a rebuild that could reallocate heaps.

### Testing

- No automated tests were executed for this change.
- Manual/runtime validation was not run as part of this PR (read-only review changes only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d038ac464832dbbb6d1f70f4b60de)