### PR TITLE
Respect camera up vector: export, parse, and use in renderer

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -804,17 +804,39 @@ static bool cameraStatesDiffer(const Camera::State &a, const Camera::State &b,
 
 static Camera::State makeCameraState(const simd::float3 &position,
                                      const simd::float3 &lookAt,
+                                     const simd::float3 &up,
                                      float verticalFov, float focalLength,
-                                     const simd::float3 &fallbackForward) {
+                                     const simd::float3 &fallbackForward,
+                                     const simd::float3 &fallbackUp) {
+  auto normalizeWithFallback = [](const simd::float3 &v,
+                                  const simd::float3 &fallback) {
+    float lenSq = simd::length_squared(v);
+    if (lenSq > 1e-6f) {
+      return simd::normalize(v);
+    }
+    float fallbackLenSq = simd::length_squared(fallback);
+    if (fallbackLenSq > 1e-6f) {
+      return simd::normalize(fallback);
+    }
+    return simd::make_float3(0.0f, 1.0f, 0.0f);
+  };
+
   Camera::State state{};
   state.position = position;
   simd::float3 direction = lookAt - position;
-  if (simd::length_squared(direction) > 1e-6f) {
-    state.forward = simd::normalize(direction);
-  } else {
-    state.forward = fallbackForward;
+  state.forward = normalizeWithFallback(direction, fallbackForward);
+
+  simd::float3 desiredUp = normalizeWithFallback(up, fallbackUp);
+  float alignment = std::abs(simd::dot(desiredUp, state.forward));
+  if (alignment > 0.999f) {
+    simd::float3 reference = std::abs(state.forward.y) < 0.999f
+                                 ? simd::make_float3(0.0f, 1.0f, 0.0f)
+                                 : simd::make_float3(1.0f, 0.0f, 0.0f);
+    simd::float3 right = simd::cross(reference, state.forward);
+    desiredUp = normalizeWithFallback(simd::cross(state.forward, right),
+                                      fallbackUp);
   }
-  state.up = {0, 1, 0};
+  state.up = desiredUp;
   state.verticalFov = verticalFov;
   state.focalLength = focalLength;
   return state;
@@ -2339,8 +2361,9 @@ void Renderer::updateVisibleScene() {
   if (!_pScene->cameraPath.empty()) {
     const auto &k = _pScene->cameraPath.front();
     _primaryCameraState = makeCameraState(
-        k.position, k.lookAt, _primaryCameraState.verticalFov,
-        _primaryCameraState.focalLength, _primaryCameraState.forward);
+        k.position, k.lookAt, k.up, _primaryCameraState.verticalFov,
+        _primaryCameraState.focalLength, _primaryCameraState.forward,
+        _primaryCameraState.up);
   }
 
   Camera::applyState(_primaryCameraState);
@@ -2351,9 +2374,9 @@ void Renderer::updateVisibleScene() {
     float fov = observer.verticalFov > 0.0f ? observer.verticalFov
                                             : _primaryCameraState.verticalFov;
     _observerCameraState =
-        makeCameraState(observer.position, observer.lookAt, fov,
+        makeCameraState(observer.position, observer.lookAt, observer.up, fov,
                         _primaryCameraState.focalLength,
-                        _primaryCameraState.forward);
+                        _primaryCameraState.forward, _primaryCameraState.up);
   } else {
     _observerCameraState = _primaryCameraState;
   }
@@ -6419,16 +6442,18 @@ bool Renderer::updateCameraStates() {
     Camera::State newState = _primaryCameraState;
     if (_animationFrame <= path.front().frame) {
       const auto &k = path.front();
-      newState = makeCameraState(k.position, k.lookAt,
+      newState = makeCameraState(k.position, k.lookAt, k.up,
                                  _primaryCameraState.verticalFov,
                                  _primaryCameraState.focalLength,
-                                 _primaryCameraState.forward);
+                                 _primaryCameraState.forward,
+                                 _primaryCameraState.up);
     } else if (_animationFrame >= path.back().frame) {
       const auto &k = path.back();
-      newState = makeCameraState(k.position, k.lookAt,
+      newState = makeCameraState(k.position, k.lookAt, k.up,
                                  _primaryCameraState.verticalFov,
                                  _primaryCameraState.focalLength,
-                                 _primaryCameraState.forward);
+                                 _primaryCameraState.forward,
+                                 _primaryCameraState.up);
     } else {
       for (size_t i = 0; i + 1 < path.size(); ++i) {
         const auto &k0 = path[i];
@@ -6439,10 +6464,12 @@ bool Renderer::updateCameraStates() {
           simd::float3 position =
               k0.position + t * (k1.position - k0.position);
           simd::float3 look = k0.lookAt + t * (k1.lookAt - k0.lookAt);
-          newState = makeCameraState(position, look,
+          simd::float3 up = k0.up + t * (k1.up - k0.up);
+          newState = makeCameraState(position, look, up,
                                      _primaryCameraState.verticalFov,
                                      _primaryCameraState.focalLength,
-                                     _primaryCameraState.forward);
+                                     _primaryCameraState.forward,
+                                     _primaryCameraState.up);
           break;
         }
       }

--- a/Nomad Path Tracer/Scene/Scene.h
+++ b/Nomad Path Tracer/Scene/Scene.h
@@ -139,11 +139,13 @@ struct CameraKeyframe {
   uint32_t frame;
   simd::float3 position;
   simd::float3 lookAt;
+  simd::float3 up = simd::make_float3(0.0f, 1.0f, 0.0f);
 };
 
 struct ObserverCamera {
   simd::float3 position = simd::make_float3(0.0f, 0.0f, 0.0f);
   simd::float3 lookAt = simd::make_float3(0.0f, 0.0f, -1.0f);
+  simd::float3 up = simd::make_float3(0.0f, 1.0f, 0.0f);
   float verticalFov = 60.0f;
 };
 

--- a/Nomad Path Tracer/Scene/SceneLoader.cpp
+++ b/Nomad Path Tracer/Scene/SceneLoader.cpp
@@ -32,6 +32,14 @@ static simd::float3 parseVec3(const char* str) {
     return simd::make_float3(x, y, z);
 }
 
+static simd::float3 parseVec3OrDefault(const char* str,
+                                       const simd::float3& defaultValue) {
+    if (!str) {
+        return defaultValue;
+    }
+    return parseVec3(str);
+}
+
 static std::vector<float> parseFloatList(const char *attr) {
     std::vector<float> values;
     if (!attr) {
@@ -992,6 +1000,8 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
                 key.frame = kf->UnsignedAttribute("frame", 0);
                 key.position = parseVec3(kf->Attribute("position"));
                 key.lookAt = parseVec3(kf->Attribute("lookAt"));
+                key.up = parseVec3OrDefault(kf->Attribute("up"),
+                                            simd::make_float3(0.0f, 1.0f, 0.0f));
                 scene->cameraPath.push_back(key);
             }
         }
@@ -1003,6 +1013,8 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             if (const char* lookAttr = e->Attribute("lookAt")) {
                 observer.lookAt = parseVec3(lookAttr);
             }
+            observer.up = parseVec3OrDefault(
+                e->Attribute("up"), observer.up);
             observer.verticalFov = e->FloatAttribute("verticalFov", observer.verticalFov);
             scene->setObserverCamera(observer);
         }

--- a/Nomad Path Tracer/lightwave_blender/camera.py
+++ b/Nomad Path Tracer/lightwave_blender/camera.py
@@ -37,11 +37,13 @@ def export_camera(registry: SceneRegistry):
         rotation = matrix.to_quaternion()
         forward = rotation @ mathutils.Vector((0.0, 0.0, -1.0))
         look_at = position + forward
+        up = matrix.to_3x3().col[1]
 
         camera_path.add("Keyframe",
                         frame=frame,
                         position=str_flat_array(position),
-                        lookAt=str_flat_array(look_at))
+                        lookAt=str_flat_array(look_at),
+                        up=str_flat_array(up))
 
     registry.scene.frame_set(current_frame)
 

--- a/Nomad Path Tracer/scene_camera_roll_regression.xml
+++ b/Nomad Path Tracer/scene_camera_roll_regression.xml
@@ -1,0 +1,14 @@
+<Scene width="640" height="360" maxRayDepth="8" startCompacted="true" residencyStrategy="alwaysresident">
+    <!-- Camera is rolled 90 degrees around the forward axis to validate up-vector handling. -->
+    <ObserverCamera position="0,2,6" lookAt="0,2,0" up="0,0,1" verticalFov="45" />
+    <CameraPath>
+        <Keyframe frame="0" position="0,2,6" lookAt="0,2,0" up="0,0,1" />
+    </CameraPath>
+
+    <Rectangle position="0,0,0" u="4,0,0" v="0,0,-4" albedo="0.75,0.75,0.78"
+               emission="0,0,0" materialType="0" emissionPower="0" />
+    <Rectangle position="0,2,-2" u="1,0,0" v="0,1,0" albedo="0.8,0.8,0.82"
+               emission="1.0,0.45,0.35" materialType="-1" emissionPower="18" />
+    <Sphere position="-1.2,0.6,-1.0" radius="0.6" albedo="0.4,0.6,0.9"
+            emission="0,0,0" materialType="0" emissionPower="0" />
+</Scene>


### PR DESCRIPTION
### Motivation
- Camera rolls exported from Blender were not preserved, causing views to appear rotated because the renderer always used a fixed up vector `(0,1,0)`.
- The scene XML schema did not carry an `up` attribute for keyframes or observer views, so rolled cameras could not be round-tripped.

### Description
- Exporter: `lightwave_blender/camera.py` now writes an `up` attribute per `Keyframe` using the converted camera matrix basis column via `matrix.to_3x3().col[1]`.
- Scene format and loader: `Scene.h` adds an `up` field to `CameraKeyframe` and `ObserverCamera` defaulting to `simd::make_float3(0,1,0)`, and `SceneLoader.cpp` parses an optional `up` attribute via `parseVec3OrDefault`.
- Renderer: `Renderer::makeCameraState` signature now accepts an explicit `up` and `fallbackUp`, normalizes with fallbacks, avoids forward/up degeneracy, and all camera-state construction paths (`updateVisibleScene`, camera-path interpolation, observer init) supply and interpolate `up` values.
- Regression scene: added `scene_camera_roll_regression.xml` containing a 90°-rolled camera to validate that a rolled view is rendered with the correct orientation.

### Testing
- Compiled the Blender exporter Python package with `python -m compileall "Nomad Path Tracer/lightwave_blender"` and it completed successfully.
- No automated C++ build/test was run in this rollout; runtime validation is provided by the added regression scene (`scene_camera_roll_regression.xml`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d0ca347d4832d87ef505d6eb0718f)