### PR TITLE
Convert light exports to renderer space

### DIFF
--- a/Nomad Path Tracer/lightwave_blender/light.py
+++ b/Nomad Path Tracer/lightwave_blender/light.py
@@ -15,7 +15,7 @@ def _emissive_attributes(emission):
     }
 
 
-def _build_point_light(registry: SceneRegistry, light: bpy.types.Light, inst: bpy.types.DepsgraphObjectInstance):
+def _build_point_light(registry: SceneRegistry, light: bpy.types.Light, matrix_world):
     radius = max(light.shadow_soft_size, 1e-3)
     normalization = 1.0 / (4.0 * (math.pi * radius) ** 2)
 
@@ -24,7 +24,7 @@ def _build_point_light(registry: SceneRegistry, light: bpy.types.Light, inst: bp
         for chan in range(3)
     ]
 
-    position = inst.matrix_world.translation
+    position = matrix_world.translation
 
     return XMLNode(
         "Sphere",
@@ -46,8 +46,8 @@ def _area_light_extents(registry: SceneRegistry, light: bpy.types.Light):
     return scale_x, scale_y
 
 
-def _build_rectangle_light(registry: SceneRegistry, light: bpy.types.Light, inst: bpy.types.DepsgraphObjectInstance, *, scale_x: float, scale_y: float):
-    basis = inst.matrix_world.to_3x3()
+def _build_rectangle_light(registry: SceneRegistry, light: bpy.types.Light, inst_name: str, matrix_world, *, scale_x: float, scale_y: float):
+    basis = matrix_world.to_3x3()
     u = basis.col[0] * (scale_x * 0.5)
     v = basis.col[1] * (scale_y * 0.5)
 
@@ -55,7 +55,7 @@ def _build_rectangle_light(registry: SceneRegistry, light: bpy.types.Light, inst
     lensqr_y = v.length_squared
 
     if lensqr_x <= 0.0 or lensqr_y <= 0.0:
-        registry.warn(f"Light '{inst.object.name}' has zero area and will be skipped")
+        registry.warn(f"Light '{inst_name}' has zero area and will be skipped")
         return None
 
     normalization = 1.0 / (16.0 * (lensqr_x * lensqr_y) ** 0.5)
@@ -66,7 +66,7 @@ def _build_rectangle_light(registry: SceneRegistry, light: bpy.types.Light, inst
 
     return XMLNode(
         "Rectangle",
-        position=str_flat_array(inst.matrix_world.translation),
+        position=str_flat_array(matrix_world.translation),
         u=str_flat_array(u),
         v=str_flat_array(v),
         **_emissive_attributes(emission),
@@ -84,21 +84,23 @@ def export_light(registry: SceneRegistry, inst):
         registry.warn("Light portals are not supported")
         return []
 
+    converted_matrix = convert_world_matrix(inst.matrix_world)
+
     if light.type in {"POINT", "SPOT"}:
-        return [_build_point_light(registry, light, inst)]
+        return [_build_point_light(registry, light, converted_matrix)]
 
     if light.type == "AREA":
         if not getattr(registry.settings, "enable_area_lights", True):
-            return [_build_point_light(registry, light, inst)]
+            return [_build_point_light(registry, light, converted_matrix)]
         scale_x, scale_y = _area_light_extents(registry, light)
-        rect_node = _build_rectangle_light(registry, light, inst, scale_x=scale_x, scale_y=scale_y)
+        rect_node = _build_rectangle_light(registry, light, inst.object.name, converted_matrix, scale_x=scale_x, scale_y=scale_y)
         return [rect_node] if rect_node is not None else []
 
     if light.type == "SUN":
         if not getattr(registry.settings, "enable_area_lights", True):
-            return [_build_point_light(registry, light, inst)]
+            return [_build_point_light(registry, light, converted_matrix)]
         size = _sun_extents(light)
-        rect_node = _build_rectangle_light(registry, light, inst, scale_x=size, scale_y=size)
+        rect_node = _build_rectangle_light(registry, light, inst.object.name, converted_matrix, scale_x=size, scale_y=size)
         return [rect_node] if rect_node is not None else []
 
     registry.warn(f"Light type {light.type} unsupported")

--- a/tests/test_light_export.py
+++ b/tests/test_light_export.py
@@ -1,0 +1,210 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+def _install_fake_bpy():
+    fake_bpy = types.ModuleType("bpy")
+    fake_bpy.types = types.SimpleNamespace(
+        Light=type("Light", (), {}),
+        Object=type("Object", (), {}),
+    )
+    fake_bpy.ops = types.SimpleNamespace()
+    fake_bpy.context = types.SimpleNamespace()
+    fake_bpy.props = types.ModuleType("bpy.props")
+    fake_bpy.props.StringProperty = lambda **kwargs: None
+    fake_bpy.utils = types.SimpleNamespace(register_class=lambda cls: None, unregister_class=lambda cls: None)
+    return {
+        "bpy": fake_bpy,
+        "bpy.types": fake_bpy.types,
+        "bpy.props": fake_bpy.props,
+    }
+
+
+class _Vector:
+    def __init__(self, seq):
+        self._data = list(seq)
+
+    def __mul__(self, scalar):
+        return _Vector([component * scalar for component in self._data])
+
+    __rmul__ = __mul__
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        return len(self._data)
+
+    def __getitem__(self, index):
+        return self._data[index]
+
+    @property
+    def x(self):
+        return self._data[0]
+
+    @property
+    def y(self):
+        return self._data[1]
+
+    @property
+    def z(self):
+        return self._data[2]
+
+    @property
+    def length(self):
+        return sum(v * v for v in self._data) ** 0.5
+
+    @property
+    def length_squared(self):
+        return sum(v * v for v in self._data)
+
+
+class _Matrix:
+    def __init__(self, rows):
+        self._rows = [list(row) for row in rows]
+
+    def __matmul__(self, other):
+        result = []
+        for r in range(len(self._rows)):
+            new_row = []
+            for c in range(len(other._rows[0])):
+                new_row.append(sum(self._rows[r][k] * other._rows[k][c] for k in range(len(other._rows))))
+            result.append(new_row)
+        return _Matrix(result)
+
+    def to_3x3(self):
+        return _Matrix([row[:3] for row in self._rows[:3]])
+
+    @property
+    def translation(self):
+        return _Vector([self._rows[0][3], self._rows[1][3], self._rows[2][3]])
+
+    @property
+    def col(self):
+        cols = []
+        for c in range(len(self._rows[0])):
+            cols.append(_Vector([self._rows[r][c] for r in range(min(3, len(self._rows)))]))
+        return cols
+
+
+def _install_fake_mathutils():
+    mathutils = types.ModuleType("mathutils")
+    mathutils.Matrix = _Matrix
+    mathutils.Vector = _Vector
+    mathutils.Quaternion = type("Quaternion", (), {})  # placeholder to satisfy imports
+    return {"mathutils": mathutils}
+
+
+def _load_lightwave_module(name, path, search_path):
+    spec = importlib.util.spec_from_file_location(
+        name, path, submodule_search_locations=search_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    import sys
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+    return module
+
+
+class _DummyDepsgraph:
+    def __init__(self, *instances):
+        self.object_instances = list(instances)
+        self.scene = types.SimpleNamespace(frame_current=0)
+
+
+class _DummyOperator:
+    def __init__(self):
+        self.messages = []
+
+    def report(self, levels, message):
+        self.messages.append((levels, message))
+
+
+class _DummySettings:
+    enable_area_lights = True
+    export_lights = True
+    use_selection = False
+
+
+class LightExportTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        sys.modules.update(_install_fake_mathutils())
+        sys.modules.update(_install_fake_bpy())
+
+        repo_root = Path(__file__).resolve().parent.parent / "Nomad Path Tracer"
+        package_root = repo_root / "lightwave_blender"
+        base_package = types.ModuleType("lightwave_blender")
+        base_package.__path__ = [str(package_root)]
+        sys.modules["lightwave_blender"] = base_package
+
+        cls.utils_module = _load_lightwave_module("lightwave_blender.utils", package_root / "utils.py", base_package.__path__)
+        cls.registry_module = _load_lightwave_module("lightwave_blender.registry", package_root / "registry.py", base_package.__path__)
+        cls.light_module = _load_lightwave_module("lightwave_blender.light", package_root / "light.py", base_package.__path__)
+
+    def _build_light_instance(self, light_type, matrix_rows, **kwargs):
+        import types
+
+        light = types.SimpleNamespace(
+            type=light_type,
+            shadow_soft_size=kwargs.get("shadow_soft_size", 0.1),
+            energy=kwargs.get("energy", 10.0),
+            color=kwargs.get("color", (1.0, 1.0, 1.0)),
+            shape=kwargs.get("shape", "SQUARE"),
+            size=kwargs.get("size", 2.0),
+            size_y=kwargs.get("size_y", 2.0),
+            cycles=types.SimpleNamespace(is_portal=False),
+            angle=kwargs.get("angle", 0.0),
+        )
+        obj = types.SimpleNamespace(data=light, type="LIGHT", name="TestLight", original=types.SimpleNamespace(select_get=lambda: True))
+        inst = types.SimpleNamespace(object=obj, matrix_world=self.utils_module.mathutils.Matrix(matrix_rows), show_self=True)
+        return inst
+
+    def test_point_light_uses_converted_matrix(self):
+        inst = self._build_light_instance("POINT", (
+            (1.0, 0.0, 0.0, 1.0),
+            (0.0, 1.0, 0.0, 2.0),
+            (0.0, 0.0, 1.0, 3.0),
+            (0.0, 0.0, 0.0, 1.0),
+        ))
+        registry = self.registry_module.SceneRegistry(
+            path="/tmp",
+            depsgraph=_DummyDepsgraph(inst),
+            settings=_DummySettings(),
+            op=_DummyOperator(),
+        )
+
+        lights = self.light_module.export_light(registry, inst)
+
+        self.assertEqual(len(lights), 1)
+        position = lights[0].attributes["position"]
+        self.assertEqual(position, "1,3,-2")
+
+    def test_area_light_orientation_matches_converted_space(self):
+        inst = self._build_light_instance("AREA", (
+            (1.0, 0.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0, 1.5),
+            (0.0, 0.0, 1.0, 2.5),
+            (0.0, 0.0, 0.0, 1.0),
+        ))
+        registry = self.registry_module.SceneRegistry(
+            path="/tmp",
+            depsgraph=_DummyDepsgraph(inst),
+            settings=_DummySettings(),
+            op=_DummyOperator(),
+        )
+
+        lights = self.light_module.export_light(registry, inst)
+
+        self.assertEqual(len(lights), 1)
+        rect = lights[0]
+        self.assertEqual(rect.attributes["position"], "0,2.5,-1.5")
+        self.assertEqual(rect.attributes["u"], "1,0,0")
+        self.assertEqual(rect.attributes["v"], "0,0,-1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Light transforms were being extracted directly from Blender `matrix_world` which did not match the renderer/world conversion used for meshes and cameras. 
- This mismatch caused light positions and area/sun orientations to be misaligned with exported geometry and camera space. 

### Description

- Apply `convert_world_matrix(inst.matrix_world)` in `export_light` and pass the converted matrix into light builders so all light transforms are in renderer space. 
- Update `_build_point_light` and `_build_rectangle_light` to use a `matrix_world` parameter for position and to compute basis/u/v from the converted matrix, and adjust warnings to use the instance name. 
- Recompute point/spot positions and area/sun `u`/`v` vectors from the converted matrix so lights align with meshes and camera exports. 
- Add a unit test `tests/test_light_export.py` that fakes `bpy`/`mathutils` and verifies exported point and area light positions/orientations in renderer space. 

### Testing

- Ran the unit test suite target `python -m unittest tests.test_light_export`. 
- The test run executed 2 tests and completed successfully (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d0ef9d0d8832d9cbd030dde74e11d)