### PR TITLE
Add camera up vector to bistro test keyframe

### DIFF
--- a/Nomad Path Tracer/scene_bistro_test.xml
+++ b/Nomad Path Tracer/scene_bistro_test.xml
@@ -1,6 +1,6 @@
 <Scene width="720" height="576" maxRayDepth="4" startCompacted="true" environmentTexture="Textures/NomadEnv_1p0000_1p0000_1p0000.exr" environmentBrightness="1.2" residencyStrategy="alwaysresident">
   <CameraPath>
-    <Keyframe frame="1" position="-9.8374,-1.4931,3.4163" lookAt="-10.803,-1.6539,3.6209"/>
+    <Keyframe frame="1" position="-9.8374,-1.4931,3.4163" lookAt="-10.803,-1.6539,3.6209" up="0,1,0"/>
   </CameraPath>
   <Sphere position="-13.6996,-2.1363,4.2347" radius="0.20"
           albedo="0,0,0" emission="8.5,7.9,7.3" materialType="0"


### PR DESCRIPTION
### Motivation
- Ensure the camera `up` vector in the Bistro test scene matches the renderer's Y-up axis so the camera orientation aligns with the exported meshes.
- Prevent unexpected camera roll by making the intended up axis explicit in the scene XML.

### Description
- Updated `Nomad Path Tracer/scene_bistro_test.xml` to add `up="0,1,0"` to the `<Keyframe frame="1" .../>` entry.
- This aligns with how `lightwave_blender/camera.py` computes `up` from the converted camera matrix and with the Blender Z-up to renderer Y-up conversion in `lightwave_blender/utils.py::world_to_renderer_matrix`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e424bdc18832d8f516f3f4b0a823a)