### PR TITLE
Fix camera up export orientation

### DIFF
--- a/Nomad Path Tracer/lightwave_blender/camera.py
+++ b/Nomad Path Tracer/lightwave_blender/camera.py
@@ -37,7 +37,8 @@ def export_camera(registry: SceneRegistry):
         rotation = matrix.to_quaternion()
         forward = rotation @ mathutils.Vector((0.0, 0.0, -1.0))
         look_at = position + forward
-        up = matrix.to_3x3().col[1]
+        up = rotation @ mathutils.Vector((0.0, 1.0, 0.0))
+        up.normalize()
 
         camera_path.add("Keyframe",
                         frame=frame,


### PR DESCRIPTION
### Motivation

- Ensure the exported camera `up` vector is consistent with the exported `lookAt` and the renderer’s Y-up, -Z forward convention to avoid sideways roll.
- The previous code used `matrix.to_3x3().col[1]` which could be inconsistent with the rotation applied by `orient_camera` and the renderer convention.

### Description

- Replace the `up` export computation in `Nomad Path Tracer/lightwave_blender/camera.py` to use the camera rotation: `up = rotation @ mathutils.Vector((0.0, 1.0, 0.0))`.
- Normalize the `up` vector after rotation with `up.normalize()` to ensure a unit up direction.
- The change relies on the existing `orient_camera` conversion and does not modify `world_to_renderer_matrix`.
- Affected file: `lightwave_blender/camera.py` (updated the `export_camera` keyframe `up` value).

### Testing

- No automated tests were run for this change.
- There were no test failures reported because no tests were executed.
- Manual re-export of a camera (recommended) should show `position`/`lookAt`/`up` triples without sideways roll.
- If desired, add an automated export-and-compare test to assert the `up` aligns with the rotation-derived Y-up vector.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e4303c974832da775328a07990105)