### PR TITLE
Ensure full activation pass when entering AlwaysResident strategy or reloading scene

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -2445,6 +2445,7 @@ void Renderer::updateVisibleScene() {
   printf("Active primitive residency strategy: %s\n", strategyName);
 
   _alwaysResidentCache.reset();
+  _forceAlwaysResidentActivation = true;
 
   ++_cameraVersion;
   _depthWeightCameraVersion = 0;
@@ -7088,8 +7089,10 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   _frameRestirCandidateAcceptance = 0.0;
   ResidencyStrategy strategy = _pScene->getResidencyStrategy();
   if (strategy != _lastResidencyStrategy) {
-    if (strategy == ResidencyStrategy::AlwaysResident)
+    if (strategy == ResidencyStrategy::AlwaysResident) {
       _alwaysResidentCache.markDirty();
+      _forceAlwaysResidentActivation = true;
+    }
     _lastResidencyStrategy = strategy;
   }
   _frameStrategy = strategy;
@@ -7146,11 +7149,16 @@ bool Renderer::updateAlwaysResident(bool forceAllToggles) {
   size_t primitiveCount = _activePrimitive.size();
   size_t objectCount = _allSceneObjects.size();
   bool hasRecentChanges = !_recentlyActivated.empty() || !_recentlyDeactivated.empty();
+  bool forceActivation = forceAllToggles || _forceAlwaysResidentActivation;
 
   bool changed = false;
 
-  if (_alwaysResidentCache.needsUpdate(forceAllToggles, primitiveCount,
-                                       objectCount, hasRecentChanges)) {
+  if (forceActivation)
+    _recentlyDeactivated.clear();
+
+  if (forceActivation ||
+      _alwaysResidentCache.needsUpdate(forceActivation, primitiveCount, objectCount,
+                                       hasRecentChanges)) {
     for (size_t objectIndex = 0; objectIndex < _allSceneObjects.size();
          ++objectIndex) {
       size_t toggled = setObjectActive(objectIndex, true);
@@ -7164,6 +7172,7 @@ bool Renderer::updateAlwaysResident(bool forceAllToggles) {
     }
 
     _alwaysResidentCache.markUpdated(primitiveCount, objectCount);
+    _forceAlwaysResidentActivation = false;
   }
 
   bool anyInactivePrimitive =

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -648,6 +648,7 @@ private:
   ResidencyStrategy _frameStrategy = ResidencyStrategy::DistanceLOD;
   ResidencyStrategy _lastResidencyStrategy = ResidencyStrategy::DistanceLOD;
   AlwaysResidentCache _alwaysResidentCache;
+  bool _forceAlwaysResidentActivation = false;
   bool _frameCaptureEnabled = false;
   size_t _frameCaptureInterval = 4;
   uint64_t _renderedFrameCount = 0;


### PR DESCRIPTION
### Motivation

- Entering the `ResidencyStrategy::AlwaysResident` path or reloading a scene could skip a full activation pass if the cache reported no update, allowing pending deactivations to persist.
- The residency system must run a one-shot full activation to guarantee all primitives/objects become active under the AlwaysResident policy.
- Existing asserts and cache semantics should be preserved while ensuring the forced activation still runs at least once.

### Description

- Added a one-shot flag `bool _forceAlwaysResidentActivation` to `Renderer` to request a forced activation pass on next residency update via `Renderer.h`.
- Set `_forceAlwaysResidentActivation = true` when the scene is reinitialized (`_alwaysResidentCache.reset()`) and when switching to `ResidencyStrategy::AlwaysResident` in `updateResidency()`.
- In `updateAlwaysResident()` compute `forceActivation = forceAllToggles || _forceAlwaysResidentActivation`, clear `_recentlyDeactivated` when forcing, and run the full activation loop when `forceActivation` is true regardless of `AlwaysResidentCache::needsUpdate()` results, then clear the one-shot flag.
- Preserved existing safety `assert`s and cache `markUpdated` semantics while ensuring the activation pass occurs at least once after entering AlwaysResident or loading a scene.

### Testing

- No automated tests were run as part of this change.
- No CI build or unit test results are included in this PR.
- Manual verification is recommended to confirm that all primitives and objects are active for one frame after switching to AlwaysResident or reloading the scene.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e4bb1e254832d8e790e0b6e35b0eb)