### PR TITLE
Reset accumulation on texture size/format/residency changes

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -5701,6 +5701,12 @@ void Renderer::configureTextureSlot(ManagedTextureSlot &slot, NS::UInteger width
   slot.storageMode = MTL::StorageMode::StorageModePrivate;
   slot.descriptorValid = true;
   slot.stagingValid = false;
+
+  if (&slot == &_accumulationSlots[0] || &slot == &_accumulationSlots[1] ||
+      &slot == &_sampleCountSlot) {
+    _needsAccumulationReset = true;
+    _accumulationTargetsNeedClear = true;
+  }
 }
 
 size_t Renderer::textureByteSize(const ManagedTextureSlot &slot) const {
@@ -5937,6 +5943,12 @@ MTL::Texture *Renderer::requestResidentTexture(ManagedTextureSlot &slot,
     _needsAccumulationReset = true;
     _accumulationTargetsNeedClear = true;
     return nullptr;
+  }
+
+  if (&slot == &_accumulationSlots[0] || &slot == &_accumulationSlots[1] ||
+      &slot == &_sampleCountSlot) {
+    _needsAccumulationReset = true;
+    _accumulationTargetsNeedClear = true;
   }
 
   bool logged = false;


### PR DESCRIPTION
### Motivation
- Ensure any change to accumulation texture size, pixel format, or residency forces a hard reset of accumulation buffers to avoid blending with stale/history data.
- Also ensure the sample count buffer is cleared together with accumulation/albedo/normal when such changes occur to keep sample accounting correct.

### Description
- When a texture descriptor changes in `configureTextureSlot`, mark `_needsAccumulationReset` and `_accumulationTargetsNeedClear` for `&_accumulationSlots[0]`, `&_accumulationSlots[1]`, and `&_sampleCountSlot` via added checks in `configureTextureSlot`.
- When a texture is (re)created in `requestResidentTexture`, set `_needsAccumulationReset` and `_accumulationTargetsNeedClear` for the accumulation and sample-count slots after successful allocation.
- The existing `resetAccumulationTargets` path already iterates the `&_sampleCountSlot` along with accumulation/albedo/normal, so the sample-count buffer is explicitly cleared during the reset.
- No changes were made to `Shaders/Fragment.metal`; the optional nearest-sampler tweak was not applied to avoid altering current output.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e4c65967c832d89bc5a59d3829c29)