### PR TITLE
Add shadow rectangles scene with emissive sphere light

### DIFF
--- a/Nomad Path Tracer/scene_shadow_rectangles.xml
+++ b/Nomad Path Tracer/scene_shadow_rectangles.xml
@@ -1,0 +1,15 @@
+<Scene width="1280" height="720" maxRayDepth="8" startCompacted="true" residencyStrategy="alwaysresident">
+    <ObserverCamera position="0,1.2,4" lookAt="0,0.6,0" verticalFov="40" />
+
+    <!-- Small emissive sphere light above the rectangles -->
+    <Sphere position="0,2,0" radius="0.2" albedo="0,0,0"
+            emission="1,1,1" materialType="0" emissionPower="25" />
+
+    <!-- Occluder rectangle between the light and receiver -->
+    <Rectangle position="0,1,0" u="1.2,0,0" v="0,0,1.2" rotation="0,0,0"
+               albedo="0.7,0.7,0.7" emission="0,0,0" materialType="0" emissionPower="0" />
+
+    <!-- Receiver rectangle beneath the occluder to catch the shadow -->
+    <Rectangle position="0,0,0" u="2.5,0,0" v="0,0,2.5" rotation="0,0,0"
+               albedo="0.75,0.75,0.75" emission="0,0,0" materialType="0" emissionPower="0" />
+</Scene>


### PR DESCRIPTION
### Motivation
- Provide a minimal, self-contained scene to verify shadowing between a rectangular occluder and receiver using the existing scene schema.
- Use neutral albedo/materials to maximize shadow contrast and keep the scene suitable for quick visual/regression checks.
- Replace the rectangular area light with a small emissive `Sphere` per feedback to simplify the test setup.

### Description
- Add `Nomad Path Tracer/scene_shadow_rectangles.xml` which defines an `ObserverCamera`, one emissive `Sphere` light, an occluder `Rectangle`, and a receiver `Rectangle`.
- The light is a `Sphere` at `position="0,2,0"` with `radius="0.2"`, `emission="1,1,1"`, and `emissionPower="25"` to act as the scene emitter.
- The occluder is a `Rectangle` at `position="0,1,0"` sized by `u="1.2,0,0"`/`v="0,0,1.2"`, and the receiver is a larger `Rectangle` at `position="0,0,0"` sized by `u="2.5,0,0"`/`v="0,0,2.5"`.
- All objects use neutral `albedo` values and no external assets or references so the scene should load without missing references.

### Testing
- No automated tests were run for this scene-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696505245204832daf57db270fb6ae12)