### PR TITLE
Disable environment lighting in bistro test scene

### DIFF
--- a/Nomad Path Tracer/scene_bistro_test_v2.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2.xml
@@ -1,4 +1,4 @@
-<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="alwaysresident" environmentBrightness="1.25">
+<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="alwaysresident" environmentBrightness="0">
   <CameraPath>
     <Keyframe frame="1" position="-9.8374,-1.4931,3.4163" lookAt="0,0,0" up="0,0,1" />
   </CameraPath>


### PR DESCRIPTION
### Motivation
- Reduce/remove warm HDRI lighting in the Bistro test scene to produce a flatter, neutral-lit render.
- Prefer disabling the environment contribution quickly without altering geometry or material definitions.

### Description
- Updated `environmentBrightness` from `1.25` to `0` in `Nomad Path Tracer/scene_bistro_test_v2.xml` to disable HDRI/environment lighting.
- No other scene elements were modified and existing `Rectangle` light entries were left unchanged.

### Testing
- No automated tests were run for this change.
- The modified scene file was saved and validated as well-formed XML by the editor/commit process.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69650a672f0c832d87fb0d539cfa2b52)