### PR TITLE
Reset accumulation when history restore lacks staging data

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -5985,6 +5985,12 @@ MTL::Texture *Renderer::requestResidentTexture(ManagedTextureSlot &slot,
   } else {
     std::printf("[TextureResidency] Restored slot %s without staging data.\n",
                 label);
+    if (&slot == &_accumulationSlots[0] || &slot == &_accumulationSlots[1] ||
+        &slot == &_sampleCountSlot || &slot == &_albedoSlot ||
+        &slot == &_normalSlot) {
+      _needsAccumulationReset = true;
+      _accumulationTargetsNeedClear = true;
+    }
   }
 
   slot.lastUsedFrame = _renderedFrameCount;


### PR DESCRIPTION
### Motivation
- Prevent blank history from being blended into accumulation when a texture slot is restored without staging or history data by forcing an accumulation reset and clear of accumulation targets.
- Previously some restore-failure paths already forced a reset but the "without staging data" path did not handle accumulation-related slots.

### Description
- In `Nomad Path Tracer/Renderer/Renderer.cpp` set `_needsAccumulationReset = true` and `_accumulationTargetsNeedClear = true` in the branch that logs `Restored slot %s without staging data.`.
- Apply this change specifically when the restored slot is one of `&_accumulationSlots[0]`, `&_accumulationSlots[1]`, `&_sampleCountSlot`, `&_albedoSlot`, or `&_normalSlot` to ensure accumulation buffers are cleared before further blending.
- No other behavior or branches were modified.

### Testing
- No automated tests were run for this change.
- The change was compiled/committed locally as part of development (no automated test results to report).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696510c35e94832dad874838d0e42ef4)