### PR TITLE
Use 32-bit float textures for accumulation, sample count, albedo and normal targets

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -6340,15 +6340,15 @@ void Renderer::buildTextures() {
 
   for (auto &slot : _accumulationSlots)
     configureTextureSlot(slot, width, height,
-                         MTL::PixelFormat::PixelFormatRGBA16Float, usage);
+                         MTL::PixelFormat::PixelFormatRGBA32Float, usage);
   configureTextureSlot(_sampleCountSlot, width, height,
-                       MTL::PixelFormat::PixelFormatR16Float, usage);
+                       MTL::PixelFormat::PixelFormatR32Float, usage);
   configureTextureSlot(_sampleImportanceSlot, width, height,
                        MTL::PixelFormat::PixelFormatR16Float, usage);
   configureTextureSlot(_albedoSlot, width, height,
-                       MTL::PixelFormat::PixelFormatRGBA16Float, usage);
+                       MTL::PixelFormat::PixelFormatRGBA32Float, usage);
   configureTextureSlot(_normalSlot, width, height,
-                       MTL::PixelFormat::PixelFormatRGBA16Float, usage);
+                       MTL::PixelFormat::PixelFormatRGBA32Float, usage);
 
   _needsAccumulationReset = true;
   _accumulationTargetsNeedClear = true;

--- a/Nomad Path Tracer/Renderer/Shaders/AdaptiveSampling.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/AdaptiveSampling.metal
@@ -9,7 +9,7 @@ inline float luminance(float3 color)
     return dot(color, float3(0.2126, 0.7152, 0.0722));
 }
 
-inline float fetchLuminance(texture2d<half, access::read> accumulation,
+inline float fetchLuminance(texture2d<float, access::read> accumulation,
                             uint width, uint height, int2 coord)
 {
     int x = clamp(coord.x, 0, int(width - 1));
@@ -18,7 +18,7 @@ inline float fetchLuminance(texture2d<half, access::read> accumulation,
 }
 
 kernel void adaptiveSamplingMain(
-    texture2d<half, access::read> accumulation [[texture(0)]],
+    texture2d<float, access::read> accumulation [[texture(0)]],
     texture2d<half, access::write> importance [[texture(1)]],
     constant UniformsData& uniforms [[buffer(0)]],
     uint2 gid [[thread_position_in_grid]])

--- a/Nomad Path Tracer/Renderer/Shaders/Fragment.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/Fragment.metal
@@ -5,7 +5,7 @@ using namespace metal;
 #include "Structs.h"
 
 fragment float4 presentMain(v2f in [[stage_in]],
-                             texture2d<half, access::sample> accumulation [[texture(0)]]) {
+                             texture2d<float, access::sample> accumulation [[texture(0)]]) {
   constexpr sampler linearSampler(filter::linear, address::clamp_to_edge);
   return float4(accumulation.sample(linearSampler, in.uv));
 }

--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -19,12 +19,12 @@ kernel void pathTraceKernel(
     device const uint *primitiveRemap [[buffer(11)]],
     device atomic_uint *primitiveRayStats [[buffer(12)]],
     device const InstanceRecord *instanceRecords [[buffer(13)]],
-    texture2d<half, access::read> lastFrame [[texture(0)]],
-    texture2d<half, access::write> currentFrame [[texture(1)]],
-    texture2d<half, access::read_write> sampleCount [[texture(2)]],
+    texture2d<float, access::read> lastFrame [[texture(0)]],
+    texture2d<float, access::write> currentFrame [[texture(1)]],
+    texture2d<float, access::read_write> sampleCount [[texture(2)]],
     texture2d<half, access::read> sampleImportance [[texture(3)]],
-    texture2d<half, access::read_write> albedoAccum [[texture(4)]],
-    texture2d<half, access::read_write> normalAccum [[texture(5)]],
+    texture2d<float, access::read_write> albedoAccum [[texture(4)]],
+    texture2d<float, access::read_write> normalAccum [[texture(5)]],
     array<texture2d<float, access::sample>, kMaxMaterialTextures>
         materialTextures [[texture(6)]],
     texture2d<float, access::sample> environmentMap
@@ -128,8 +128,8 @@ kernel void pathTraceKernel(
   averagedNormal = clamp(averagedNormal, -1.0f, 1.0f);
 
   float4 result = float4(averaged, 1.0f);
-  currentFrame.write(half4(result), pixel);
-  albedoAccum.write(half4(float4(averagedAlbedo, 1.0f)), pixel);
-  normalAccum.write(half4(float4(averagedNormal, 1.0f)), pixel);
-  sampleCount.write(half4(totalSamples, half(0.0f), half(0.0f), half(0.0f)), pixel);
+  currentFrame.write(result, pixel);
+  albedoAccum.write(float4(averagedAlbedo, 1.0f), pixel);
+  normalAccum.write(float4(averagedNormal, 1.0f), pixel);
+  sampleCount.write(float4(totalSamples, 0.0f, 0.0f, 0.0f), pixel);
 }


### PR DESCRIPTION
### Motivation
- Increase precision for accumulation and denoiser feedback by switching render targets from 16-bit to 32-bit float formats.
- Ensure Metal shader bindings and read/write operations match the new texture formats to avoid mismatches at runtime.
- Keep the adaptive sampling importance buffer in half precision while reading higher-precision accumulation data.

### Description
- Change `_accumulationSlots` to `PixelFormatRGBA32Float` and `_sampleCountSlot` to `PixelFormatR32Float` in `Renderer::buildTextures` in `Renderer.cpp`.
- Update `_albedoSlot` and `_normalSlot` to `PixelFormatRGBA32Float` in `Renderer.cpp` to provide full 32-bit feedback for denoiser use.
- Modify Metal shaders to use `texture2d<float>` where accumulation/sample-count/albedo/normal must be 32-bit and adjust writes (`PathTraceKernel.metal`, `AdaptiveSampling.metal`, `Fragment.metal`).
- Leave adaptive sampling importance as `half` output while reading accumulation as `float` to preserve the original importance buffer precision.

### Testing
- No automated tests were executed as part of this change.
- Source changes were staged and committed locally (`git commit`), but no compile or CI run was performed.
- Manual verification was done by updating shader texture types and corresponding writes to align with the new textures; runtime validation is recommended.
- Recommend running the renderer and GPU shader compile/CI to confirm runtime correctness on target Metal devices.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696514aa2570832d94e1c60e61314625)