### PR TITLE
Reset accumulation when camera path advances

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -6465,6 +6465,7 @@ bool Renderer::updateCameraStates() {
 
   double originalDelta = _deltaTimeSeconds;
 
+  bool pathFrameAdvanced = false;
   if (!path.empty()) {
     Camera::State newState = _primaryCameraState;
     if (_animationFrame <= path.front().frame) {
@@ -6514,6 +6515,7 @@ bool Renderer::updateCameraStates() {
       _observerCameraState = Camera::captureState();
 
     _animationFrame++;
+    pathFrameAdvanced = true;
   } else {
     Camera::State *target =
         _observerActive ? &_observerCameraState : &_primaryCameraState;
@@ -6529,7 +6531,8 @@ bool Renderer::updateCameraStates() {
   Camera::deltaTime = _observerActive ? 0.0f
                                       : static_cast<float>(_deltaTimeSeconds);
 
-  bool viewChanged = toggled || cameraStatesDiffer(activeView, previousViewState) ||
+  bool viewChanged = toggled || pathFrameAdvanced ||
+                     cameraStatesDiffer(activeView, previousViewState) ||
                      hadObserver != _observerActive;
   if (viewChanged) {
     ++_cameraVersion;


### PR DESCRIPTION
### Motivation
- The camera-path branch advanced `_animationFrame` each frame but did not mark the view as changed, which allowed accumulation to blend history across animated frames.
- The goal is to ensure accumulation resets when the camera path advances so rendered frames don't mix stale samples.

### Description
- Added a `pathFrameAdvanced` flag in `Renderer::updateCameraStates()` inside `Nomad Path Tracer/Renderer/Renderer.cpp` to track when `_animationFrame` is incremented.
- Set `pathFrameAdvanced = true` when the camera path branch advances the frame and included it in the `viewChanged` predicate so `updateCameraStates()` returns true for camera-path advances.
- This makes callers that pass `cameraChanged` (e.g. `updateUniforms`) treat path advances as a camera change and thus reset accumulation via `_needsAccumulationReset`.

### Testing
- No automated tests were run for this change.
- Basic repository commands were used to view and modify `Renderer.cpp`, but no build or unit-test steps were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965178a9a40832da73c5421b85cd44e)