### PR TITLE
Cap path trace tiles per command buffer with env override

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -544,6 +544,7 @@ struct TileDispatchRegion {
 
 constexpr uint32_t kPathTraceTileWidth = 128;
 constexpr uint32_t kPathTraceTileHeight = 128;
+constexpr size_t kPathTraceMaxTilesPerCommand = 16;
 constexpr std::chrono::milliseconds kFrameCommandBufferWaitTimeout(4);
 constexpr uint32_t kMaxMaterialTextureSlots = 64;
 
@@ -6830,12 +6831,28 @@ void Renderer::draw(MTK::View *pView) {
       return static_cast<size_t>(parsed);
     };
 
+    auto parseMaxTilesPerCommandEnv = []() -> size_t {
+      const char *env = std::getenv("MPT_MAX_TILES_PER_COMMAND");
+      if (!env)
+        return 0;
+      char *end = nullptr;
+      unsigned long long parsed = std::strtoull(env, &end, 10);
+      if (end == env)
+        return 0;
+      return static_cast<size_t>(parsed);
+    };
+
     size_t tileIndex = 0;
     const size_t effectiveMaxSamples = std::max<size_t>(maxSamples, 1);
     const size_t envTileWork = parseMaxTileWorkEnv();
     const bool envTileWorkValid = envTileWork > 0;
     size_t tileWorkBudget = envTileWorkValid ? envTileWork
                                              : kDefaultMaxTileSampleWorkPerCommand;
+    const size_t envMaxTilesPerCommand = parseMaxTilesPerCommandEnv();
+    size_t maxTilesPerCommand = envMaxTilesPerCommand > 0
+                                    ? envMaxTilesPerCommand
+                                    : kPathTraceMaxTilesPerCommand;
+    maxTilesPerCommand = std::max<size_t>(maxTilesPerCommand, 1);
 
     if (!envTileWorkValid && _pScene) {
       if (_pScene->hasCustomMaxTileSampleWorkPerCommand()) {
@@ -6864,7 +6881,9 @@ void Renderer::draw(MTK::View *pView) {
         tileWork = std::max<size_t>(tileWork, 1);
         tileWork *= effectiveMaxSamples;
 
-        if (tileIndex > batchStart && batchWork + tileWork > maxWorkPerCommand)
+        if (tileIndex > batchStart &&
+            (batchWork + tileWork > maxWorkPerCommand ||
+             (tileIndex - batchStart) >= maxTilesPerCommand))
           break;
 
         batchWork += tileWork;


### PR DESCRIPTION
### Motivation

- Avoid oversized GPU command buffers during path tracing by limiting the number of tiles encoded per compute command buffer to stay below watchdog thresholds.
- Provide a tunable limit so different platforms and scenes can adjust batching without changing code.

### Description

- Added a default tiles-per-command cap `kPathTraceMaxTilesPerCommand = 16` in `Renderer/Renderer.cpp`.
- Added environment parsing for `MPT_MAX_TILES_PER_COMMAND` and compute `maxTilesPerCommand` that falls back to the default if unset.
- Enforced `maxTilesPerCommand` in the tile batching loop so each compute command buffer contains at most that many tiles (in addition to the existing work-budget limit).
- Kept accumulation targets and dispatch logic unchanged so accumulation remains correct across per-tile/per-batch command buffers.

### Testing

- No automated tests were executed as part of this change.
- The change was compiled and committed locally (no CI run reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696522e1c0fc832da5d1d90830b625cc)