### PR TITLE
Only flag path frame advance when camera state actually changes

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -6504,7 +6504,8 @@ bool Renderer::updateCameraStates() {
       }
     }
 
-    if (cameraStatesDiffer(newState, _primaryCameraState))
+    bool stateChanged = cameraStatesDiffer(newState, _primaryCameraState);
+    if (stateChanged)
       _primaryCameraState = newState;
 
     _deltaTimeSeconds = 0.0;
@@ -6516,7 +6517,7 @@ bool Renderer::updateCameraStates() {
       _observerCameraState = Camera::captureState();
 
     _animationFrame++;
-    pathFrameAdvanced = true;
+    pathFrameAdvanced = stateChanged;
   } else {
     Camera::State *target =
         _observerActive ? &_observerCameraState : &_primaryCameraState;


### PR DESCRIPTION
### Motivation

- Prevent spurious view-change notifications when advancing along a camera path with static keyframes.
- Avoid forcing `_needsAccumulationReset` every frame when the camera pose is unchanged, which wastes accumulation work.
- Ensure `_cameraVersion` and viewport recalculation are only triggered for true camera changes.

### Description

- In `Renderer::updateCameraStates()` compute `stateChanged = cameraStatesDiffer(newState, _primaryCameraState)` before assigning the new state.
- Only assign `_primaryCameraState = newState` when `stateChanged` is true.
- Set `pathFrameAdvanced` to `stateChanged` instead of always setting it to `true` when a path frame is advanced.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69662bf6f4e4832d91702a0cd066484f)