### PR TITLE
Adjust sharpened denoiser strength and sigmas to preserve detail

### DIFF
--- a/Nomad Path Tracer/offline/denoiser_settings.h
+++ b/Nomad Path Tracer/offline/denoiser_settings.h
@@ -7,18 +7,18 @@
 namespace NomadPathTracer::DenoiserSettings {
 
 // Spatial Gaussian sigma controlling the bilateral filter footprint.
-inline constexpr float kSharpenedSpatialSigma = 1.25f;
+inline constexpr float kSharpenedSpatialSigma = 1.0f;
 
 // Albedo Gaussian sigma used to reject neighbors with differing base colors.
-inline constexpr float kSharpenedAlbedoSigma = 0.35f;
+inline constexpr float kSharpenedAlbedoSigma = 0.3f;
 
 // Normal Gaussian sigma controlling how aggressively surface orientation
 // differences suppress contributions from neighbors.
-inline constexpr float kSharpenedNormalSigma = 0.1f;
+inline constexpr float kSharpenedNormalSigma = 0.08f;
 
 // Blend factor between the noisy input color and the filtered color.
 // 0 keeps the original, 1 fully replaces it with the filtered estimate.
-inline constexpr float kSharpenedDenoiseStrength = 1.0f;
+inline constexpr float kSharpenedDenoiseStrength = 0.7f;
 
 // Optional clamp to [0, 1] for LDR previews. Disabled by default so HDR
 // highlights are preserved when writing EXR outputs.


### PR DESCRIPTION
### Motivation
- Reduce the denoiser's tendency to fully overwrite input color so original high-frequency detail (edges, textures) is better preserved.
- Tighten the bilateral filter footprint to avoid over-smoothing fine details while still reducing noise.

### Description
- Updated `Nomad Path Tracer/offline/denoiser_settings.h` to lower `kSharpenedDenoiseStrength` from `1.0f` to `0.7f` so the filtered result is blended with the original color.
- Reduced the spatial kernel by changing `kSharpenedSpatialSigma` from `1.25f` to `1.0f` to tighten the bilateral filter footprint.
- Slightly tightened color similarity by changing `kSharpenedAlbedoSigma` from `0.35f` to `0.3f` and normal similarity by changing `kSharpenedNormalSigma` from `0.1f` to `0.08f`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966317eb5b8832db3854fbdd2865e08)