### PR TITLE
Restore camera path advance behavior

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -6504,9 +6504,7 @@ bool Renderer::updateCameraStates() {
       }
     }
 
-    bool stateChanged = cameraStatesDiffer(newState, _primaryCameraState);
-    if (stateChanged)
-      _primaryCameraState = newState;
+    _primaryCameraState = newState;
 
     _deltaTimeSeconds = 0.0;
     Camera::deltaTime = 0.0f;
@@ -6517,7 +6515,7 @@ bool Renderer::updateCameraStates() {
       _observerCameraState = Camera::captureState();
 
     _animationFrame++;
-    pathFrameAdvanced = stateChanged;
+    pathFrameAdvanced = true;
   } else {
     Camera::State *target =
         _observerActive ? &_observerCameraState : &_primaryCameraState;


### PR DESCRIPTION
### Motivation
- Ensure camera path advancement always marks the view as changed so renders update when animation frames progress.
- Reinstate unconditional assignment of the primary camera state so the path-following code always writes the computed state.

### Description
- Updated `Nomad Path Tracer/Renderer/Renderer.cpp` inside `Renderer::updateCameraStates()` to unconditionally assign `_primaryCameraState = newState`.
- Removed the local `stateChanged` usage and set `pathFrameAdvanced = true` whenever `_animationFrame` is advanced.
- Kept the existing view-change detection and viewport recalculation logic that uses `viewChanged`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696633895704832da4986477901bc16e)