### PR TITLE
Only mark camera path advanced when playing or camera state changes

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -6504,6 +6504,9 @@ bool Renderer::updateCameraStates() {
       }
     }
 
+    bool isPlaying = path.size() > 1 && _animationFrame >= path.front().frame &&
+                     _animationFrame < path.back().frame;
+    bool stateChanged = cameraStatesDiffer(newState, _primaryCameraState);
     _primaryCameraState = newState;
 
     _deltaTimeSeconds = 0.0;
@@ -6515,7 +6518,7 @@ bool Renderer::updateCameraStates() {
       _observerCameraState = Camera::captureState();
 
     _animationFrame++;
-    pathFrameAdvanced = true;
+    pathFrameAdvanced = isPlaying || stateChanged;
   } else {
     Camera::State *target =
         _observerActive ? &_observerCameraState : &_primaryCameraState;


### PR DESCRIPTION
### Motivation
- Prevent unnecessary accumulation resets when the camera path is clamped to a single keyframe or when the computed camera state does not actually change.
- Ensure `viewChanged` only becomes true when the animation is actively playing or when the camera state has truly changed.

### Description
- In `Renderer::updateCameraStates()` compute `isPlaying` for multi-keyframe playback and `stateChanged` by comparing `newState` against the prior `_primaryCameraState` using `cameraStatesDiffer`.
- Assign `_primaryCameraState = newState` after the comparison and set `pathFrameAdvanced = isPlaying || stateChanged` instead of always setting it to `true`.
- This change keeps `_animationFrame` increment behavior but avoids flagging a frame advancement for clamped/single-keyframe paths.

### Testing
- No automated tests were run for this change.
- The change was committed to the repository as a single-file update to `Nomad Path Tracer/Renderer/Renderer.cpp`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966394658e0832da5b123fd40047fdc)