### PR TITLE
Force accumulation reset for proxy or missing texture history

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -6623,6 +6623,35 @@ void Renderer::draw(MTK::View *pView) {
   Camera::State viewCamera =
       _observerActive ? _observerCameraState : _primaryCameraState;
 
+  auto historyMissing = [&](const ManagedTextureSlot &slot) {
+    if (slot.texture && !slot.needsGpuRefresh)
+      return false;
+    switch (slot.historyBacking) {
+    case ManagedTextureSlot::HistoryBacking::SharedBuffer:
+      return !slot.stagingBuffer || !slot.stagingValid;
+    case ManagedTextureSlot::HistoryBacking::CpuData:
+      return slot.historyData.empty() || slot.historyWidth == 0 ||
+             slot.historyHeight == 0;
+    case ManagedTextureSlot::HistoryBacking::None:
+    default:
+      return true;
+    }
+  };
+
+  auto proxyRestorePending = [&](const ManagedTextureSlot &slot) {
+    return slot.historyIsProxy && (!slot.texture || slot.needsGpuRefresh);
+  };
+
+  if (proxyRestorePending(_accumulationSlots[0]) ||
+      proxyRestorePending(_accumulationSlots[1]) ||
+      proxyRestorePending(_sampleCountSlot) ||
+      historyMissing(_accumulationSlots[0]) ||
+      historyMissing(_accumulationSlots[1]) ||
+      historyMissing(_sampleCountSlot)) {
+    _needsAccumulationReset = true;
+    _accumulationTargetsNeedClear = true;
+  }
+
   Camera::applyState(_primaryCameraState);
   updateResidency();
 


### PR DESCRIPTION
### Motivation
- Prevent running-average accumulation from mixing mismatched history and sample-count data when history is restored at a different resolution or is absent. 
- Ensure that when history comes from a CPU proxy or is otherwise unavailable the frame accumulation is reinitialized consistently so `previousColor` and `previousSampleCount` stay in sync.

### Description
- Added a `historyMissing` lambda to check whether a `ManagedTextureSlot`'s history is actually available (respecting `historyBacking`, `stagingValid`, `historyData`, and treating a resident texture with `!needsGpuRefresh` as present). 
- Added a `proxyRestorePending` lambda to detect proxy history restores that are pending because the slot is a proxy and the GPU texture is missing or needs refresh. 
- Added a pre-draw guard that forces `_needsAccumulationReset = true` and `_accumulationTargetsNeedClear = true` when any accumulation or sample-count slot has missing history or a pending proxy restore. 
- Change is contained in `Nomad Path Tracer/Renderer/Renderer.cpp` around the start of `Renderer::draw`.

### Testing
- No automated tests were run for this change.
- No runtime or CI validation was executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696639e6b770832dac37f09fbc90900d)