### PR TITLE
Add depth-of-field camera parameters and lens sampling

### DIFF
--- a/Nomad Path Tracer/Renderer/Camera.h
+++ b/Nomad Path Tracer/Renderer/Camera.h
@@ -16,6 +16,8 @@ struct State
     simd::float3 up {0, 1, 0};
     float verticalFov = 60.0f;
     float focalLength = 1.0f;
+    float aperture = 0.0f;
+    float focusDistance = 1.0f;
 };
 
 inline simd::float3 position;
@@ -24,6 +26,8 @@ inline simd::float3 up;
 
 inline float verticalFov;
 inline float focalLength;
+inline float aperture;
+inline float focusDistance;
 inline simd::float2 screenSize;
 inline float deltaTime = 0.0f;
 
@@ -39,12 +43,14 @@ inline static void reset()
 
     verticalFov = 60.0;
     focalLength = 1.0;
+    aperture = 0.0f;
+    focusDistance = 1.0f;
     deltaTime = 0.0f;
 }
 
 inline State captureState()
 {
-    return {position, forward, up, verticalFov, focalLength};
+    return {position, forward, up, verticalFov, focalLength, aperture, focusDistance};
 }
 
 inline void applyState(const State& state)
@@ -54,6 +60,8 @@ inline void applyState(const State& state)
     up = state.up;
     verticalFov = state.verticalFov;
     focalLength = state.focalLength;
+    aperture = state.aperture;
+    focusDistance = state.focusDistance;
 }
 
 

--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -505,6 +505,8 @@ struct UniformsData {
   int primitiveIndex;
   simd::float3 cameraPosition;
   simd::float2 screenSize;
+  float aperture;
+  float focusDistance;
 
   simd::float3 viewportU;
   simd::float3 viewportV;
@@ -800,6 +802,10 @@ static bool cameraStatesDiffer(const Camera::State &a, const Camera::State &b,
     return true;
   if (std::abs(a.focalLength - b.focalLength) > epsilon)
     return true;
+  if (std::abs(a.aperture - b.aperture) > epsilon)
+    return true;
+  if (std::abs(a.focusDistance - b.focusDistance) > epsilon)
+    return true;
   return false;
 }
 
@@ -807,6 +813,7 @@ static Camera::State makeCameraState(const simd::float3 &position,
                                      const simd::float3 &lookAt,
                                      const simd::float3 &up,
                                      float verticalFov, float focalLength,
+                                     float aperture, float focusDistance,
                                      const simd::float3 &fallbackForward,
                                      const simd::float3 &fallbackUp) {
   auto normalizeWithFallback = [](const simd::float3 &v,
@@ -840,6 +847,8 @@ static Camera::State makeCameraState(const simd::float3 &position,
   state.up = desiredUp;
   state.verticalFov = verticalFov;
   state.focalLength = focalLength;
+  state.aperture = aperture;
+  state.focusDistance = focusDistance;
   return state;
 }
 
@@ -2363,8 +2372,8 @@ void Renderer::updateVisibleScene() {
     const auto &k = _pScene->cameraPath.front();
     _primaryCameraState = makeCameraState(
         k.position, k.lookAt, k.up, _primaryCameraState.verticalFov,
-        _primaryCameraState.focalLength, _primaryCameraState.forward,
-        _primaryCameraState.up);
+        _primaryCameraState.focalLength, k.aperture, k.focusDistance,
+        _primaryCameraState.forward, _primaryCameraState.up);
   }
 
   Camera::applyState(_primaryCameraState);
@@ -2376,7 +2385,8 @@ void Renderer::updateVisibleScene() {
                                             : _primaryCameraState.verticalFov;
     _observerCameraState =
         makeCameraState(observer.position, observer.lookAt, observer.up, fov,
-                        _primaryCameraState.focalLength,
+                        _primaryCameraState.focalLength, observer.aperture,
+                        observer.focusDistance,
                         _primaryCameraState.forward, _primaryCameraState.up);
   } else {
     _observerCameraState = _primaryCameraState;
@@ -6473,14 +6483,16 @@ bool Renderer::updateCameraStates() {
       const auto &k = path.front();
       newState = makeCameraState(k.position, k.lookAt, k.up,
                                  _primaryCameraState.verticalFov,
-                                 _primaryCameraState.focalLength,
+                                 _primaryCameraState.focalLength, k.aperture,
+                                 k.focusDistance,
                                  _primaryCameraState.forward,
                                  _primaryCameraState.up);
     } else if (_animationFrame >= path.back().frame) {
       const auto &k = path.back();
       newState = makeCameraState(k.position, k.lookAt, k.up,
                                  _primaryCameraState.verticalFov,
-                                 _primaryCameraState.focalLength,
+                                 _primaryCameraState.focalLength, k.aperture,
+                                 k.focusDistance,
                                  _primaryCameraState.forward,
                                  _primaryCameraState.up);
     } else {
@@ -6497,6 +6509,9 @@ bool Renderer::updateCameraStates() {
           newState = makeCameraState(position, look, up,
                                      _primaryCameraState.verticalFov,
                                      _primaryCameraState.focalLength,
+                                     k0.aperture + t * (k1.aperture - k0.aperture),
+                                     k0.focusDistance +
+                                         t * (k1.focusDistance - k0.focusDistance),
                                      _primaryCameraState.forward,
                                      _primaryCameraState.up);
           break;
@@ -6576,6 +6591,11 @@ void Renderer::updateUniforms(bool cameraChanged) {
   u.environmentMapIntensity = _environmentBrightness;
   u.environmentPadding0 = 0.0f;
   u.environmentPadding1 = 0.0f;
+
+  const Camera::State &activeView =
+      _observerActive ? _observerCameraState : _primaryCameraState;
+  u.aperture = activeView.aperture;
+  u.focusDistance = activeView.focusDistance;
 
   uint64_t residentPrimitiveCount = _residentPrimitiveCount;
   uint64_t residentTriangleCount = _residentTriangleCount;

--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -84,10 +84,28 @@ kernel void pathTraceKernel(
     float3 rayDir = (u.firstPixelPosition + (uv.x + xOff) * u.viewportU +
                      (uv.y + yOff) * u.viewportV) -
                     u.cameraPosition;
+    float3 rayOrigin = u.cameraPosition;
+    float3 rayDirection = normalize(rayDir);
+    if (u.aperture > 0.0f) {
+      float lensU = randomFloat(seed);
+      seed = random(seed);
+      float lensV = randomFloat(seed);
+      seed = random(seed);
+      float2 diskSample = concentricSampleDisk(float2(lensU, lensV));
+      float lensRadius = u.aperture;
+      float3 cameraRight = normalize(u.viewportU);
+      float3 cameraUp = normalize(u.viewportV);
+      float3 lensOffset =
+          lensRadius * (diskSample.x * cameraRight + diskSample.y * cameraUp);
+      float focusDistance = max(u.focusDistance, 0.0001f);
+      float3 focusPoint = u.cameraPosition + rayDirection * focusDistance;
+      rayOrigin = u.cameraPosition + lensOffset;
+      rayDirection = normalize(focusPoint - rayOrigin);
+    }
 
     Ray r;
-    r.origin = u.cameraPosition;
-    r.direction = normalize(rayDir);
+    r.origin = rayOrigin;
+    r.direction = rayDirection;
     r.minDistance = 0.0001f;
     r.maxDistance = INFINITY;
 

--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -65,6 +65,25 @@ inline float3 randomInUnitSphere(thread uint32_t &seed) {
   }
 }
 
+inline float2 concentricSampleDisk(float2 u) {
+  float2 uOffset = 2.0 * u - float2(1.0);
+  if (uOffset.x == 0.0f && uOffset.y == 0.0f) {
+    return float2(0.0f);
+  }
+
+  float r;
+  float theta;
+  if (abs(uOffset.x) > abs(uOffset.y)) {
+    r = uOffset.x;
+    theta = (M_PI / 4.0f) * (uOffset.y / uOffset.x);
+  } else {
+    r = uOffset.y;
+    theta = (M_PI / 2.0f) - (M_PI / 4.0f) * (uOffset.x / uOffset.y);
+  }
+
+  return r * float2(cos(theta), sin(theta));
+}
+
 inline int decodeTextureIndex(float value) {
   return (value >= -0.5f) ? int(floor(value + 0.5f)) : -1;
 }

--- a/Nomad Path Tracer/Renderer/Shaders/Structs.h
+++ b/Nomad Path Tracer/Renderer/Shaders/Structs.h
@@ -53,6 +53,8 @@ struct UniformsData
     int primitiveIndex;
     simd::float3 cameraPosition;
     simd::float2 screenSize;
+    float aperture;
+    float focusDistance;
 
     simd::float3 viewportU;
     simd::float3 viewportV;

--- a/Nomad Path Tracer/Scene/Scene.h
+++ b/Nomad Path Tracer/Scene/Scene.h
@@ -140,6 +140,8 @@ struct CameraKeyframe {
   simd::float3 position;
   simd::float3 lookAt;
   simd::float3 up = simd::make_float3(0.0f, 1.0f, 0.0f);
+  float aperture = 0.0f;
+  float focusDistance = 1.0f;
 };
 
 struct ObserverCamera {
@@ -147,6 +149,8 @@ struct ObserverCamera {
   simd::float3 lookAt = simd::make_float3(0.0f, 0.0f, -1.0f);
   simd::float3 up = simd::make_float3(0.0f, 1.0f, 0.0f);
   float verticalFov = 60.0f;
+  float aperture = 0.0f;
+  float focusDistance = 1.0f;
 };
 
 struct Texture {

--- a/Nomad Path Tracer/Scene/SceneLoader.cpp
+++ b/Nomad Path Tracer/Scene/SceneLoader.cpp
@@ -1044,6 +1044,9 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
                 key.lookAt = parseVec3(kf->Attribute("lookAt"));
                 key.up = parseVec3OrDefault(kf->Attribute("up"),
                                             simd::make_float3(0.0f, 1.0f, 0.0f));
+                key.aperture = kf->FloatAttribute("aperture", key.aperture);
+                key.focusDistance =
+                    kf->FloatAttribute("focusDistance", key.focusDistance);
                 scene->cameraPath.push_back(key);
             }
         }
@@ -1058,6 +1061,9 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
             observer.up = parseVec3OrDefault(
                 e->Attribute("up"), observer.up);
             observer.verticalFov = e->FloatAttribute("verticalFov", observer.verticalFov);
+            observer.aperture = e->FloatAttribute("aperture", observer.aperture);
+            observer.focusDistance =
+                e->FloatAttribute("focusDistance", observer.focusDistance);
             scene->setObserverCamera(observer);
         }
     }


### PR DESCRIPTION
### Motivation

- Expose depth-of-field controls so the renderer can produce DOF via `aperture` and `focusDistance` parameters on the camera state.
- Propagate DOF parameters to GPU uniforms so the path tracing kernel can generate lens-sampled rays on the GPU.
- Allow scene camera keyframes and the observer camera to specify DOF settings so they can be authored/animated in XML.
- Ensure changing DOF parameters counts as a camera change that triggers accumulation reset to avoid ghosting.

### Description

- Add `aperture` and `focusDistance` to `Camera::State` (defaults `0.0f` and `1.0f`) and include them in `captureState`, `applyState`, `makeCameraState`, and `cameraStatesDiffer` comparisons.
- Extend CPU-side `UniformsData` and the shader `UniformsData` (`Renderer::Renderer.cpp` and `Renderer/Shaders/Structs.h`) and set `u.aperture`/`u.focusDistance` from the active view in `Renderer::updateUniforms()`.
- Extend `Scene::CameraKeyframe` and `Scene::ObserverCamera` and update `SceneLoader` to parse `aperture` and `focusDistance` from the scene XML so keyframes and observer cameras can carry DOF values.
- Implement concentric-disk lens sampling (`concentricSampleDisk`) and lens-offset ray generation in the path tracing kernel (`PathTraceKernel.metal` / `PathTracing.h`) to move the ray origin onto the lens and aim at the focus point when `aperture > 0`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69664b979278832dac66685c51e318fb)