### PR TITLE
Add bistro v2 residency strategy scene variants and extend camera path

### DIFF
--- a/Nomad Path Tracer/scene_bistro_test_v2_distance.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_distance.xml
@@ -1,4 +1,4 @@
-<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="alwaysresident" environmentBrightness="0">
+<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="distance" environmentBrightness="0">
   <CameraPath>
     <Keyframe frame="1" position="-9.8374,-1.4931,3.4163" lookAt="0,0,0" up="0,0,1" />
     <Keyframe frame="60" position="-6.42,-6.18,3.18" lookAt="0,0,0" up="0,0,1" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_energy.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_energy.xml
@@ -1,4 +1,4 @@
-<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="alwaysresident" environmentBrightness="0">
+<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="energy" environmentBrightness="0">
   <CameraPath>
     <Keyframe frame="1" position="-9.8374,-1.4931,3.4163" lookAt="0,0,0" up="0,0,1" />
     <Keyframe frame="60" position="-6.42,-6.18,3.18" lookAt="0,0,0" up="0,0,1" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_environment.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_environment.xml
@@ -1,4 +1,4 @@
-<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="alwaysresident" environmentBrightness="0">
+<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="environment" environmentBrightness="0">
   <CameraPath>
     <Keyframe frame="1" position="-9.8374,-1.4931,3.4163" lookAt="0,0,0" up="0,0,1" />
     <Keyframe frame="60" position="-6.42,-6.18,3.18" lookAt="0,0,0" up="0,0,1" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_predictive.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_predictive.xml
@@ -1,4 +1,4 @@
-<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="alwaysresident" environmentBrightness="0">
+<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="predictive" environmentBrightness="0">
   <CameraPath>
     <Keyframe frame="1" position="-9.8374,-1.4931,3.4163" lookAt="0,0,0" up="0,0,1" />
     <Keyframe frame="60" position="-6.42,-6.18,3.18" lookAt="0,0,0" up="0,0,1" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_probabilistic.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_probabilistic.xml
@@ -1,4 +1,4 @@
-<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="alwaysresident" environmentBrightness="0">
+<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="probabilistic" environmentBrightness="0">
   <CameraPath>
     <Keyframe frame="1" position="-9.8374,-1.4931,3.4163" lookAt="0,0,0" up="0,0,1" />
     <Keyframe frame="60" position="-6.42,-6.18,3.18" lookAt="0,0,0" up="0,0,1" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_rayhit.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_rayhit.xml
@@ -1,4 +1,4 @@
-<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="alwaysresident" environmentBrightness="0">
+<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="rayHitBudget" environmentBrightness="0">
   <CameraPath>
     <Keyframe frame="1" position="-9.8374,-1.4931,3.4163" lookAt="0,0,0" up="0,0,1" />
     <Keyframe frame="60" position="-6.42,-6.18,3.18" lookAt="0,0,0" up="0,0,1" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_restir.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_restir.xml
@@ -1,4 +1,4 @@
-<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="alwaysresident" environmentBrightness="0">
+<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="restir" environmentBrightness="0">
   <CameraPath>
     <Keyframe frame="1" position="-9.8374,-1.4931,3.4163" lookAt="0,0,0" up="0,0,1" />
     <Keyframe frame="60" position="-6.42,-6.18,3.18" lookAt="0,0,0" up="0,0,1" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_screenspace.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_screenspace.xml
@@ -1,4 +1,4 @@
-<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="alwaysresident" environmentBrightness="0">
+<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="screenSpaceFootprint" environmentBrightness="0">
   <CameraPath>
     <Keyframe frame="1" position="-9.8374,-1.4931,3.4163" lookAt="0,0,0" up="0,0,1" />
     <Keyframe frame="60" position="-6.42,-6.18,3.18" lookAt="0,0,0" up="0,0,1" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_unified.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_unified.xml
@@ -1,4 +1,4 @@
-<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="alwaysresident" environmentBrightness="0">
+<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="unified" environmentBrightness="0">
   <CameraPath>
     <Keyframe frame="1" position="-9.8374,-1.4931,3.4163" lookAt="0,0,0" up="0,0,1" />
     <Keyframe frame="60" position="-6.42,-6.18,3.18" lookAt="0,0,0" up="0,0,1" />


### PR DESCRIPTION
### Motivation
- Provide a more complete camera flythrough for the bistro v2 scene to exercise temporal and spatial behavior. 
- Generate per-residency test variants so each residency strategy can be exercised with the same scene and path. 
- Keep changes data-only to avoid touching renderer/source logic while enabling comparative experiments across strategies. 

### Description
- Extended the `<CameraPath>` in `Nomad Path Tracer/scene_bistro_test_v2.xml` by adding keyframes at frames `60, 120, 180, 240, 300, 360, 420` to form a longer flythrough. 
- Created residency-specific copies of the scene by replacing the `residencyStrategy` attribute: `scene_bistro_test_v2_distance.xml`, `scene_bistro_test_v2_energy.xml`, `scene_bistro_test_v2_rayhit.xml`, `scene_bistro_test_v2_screenspace.xml`, `scene_bistro_test_v2_probabilistic.xml`, `scene_bistro_test_v2_environment.xml`, `scene_bistro_test_v2_predictive.xml`, `scene_bistro_test_v2_unified.xml`, and `scene_bistro_test_v2_restir.xml`. 
- The new files are data-only scene definitions (meshes, rectangles, spheres and camera keyframes) and do not modify C++ source or runtime logic. 

### Testing
- No automated unit or integration tests were run because these are data-only scene additions. 
- A commit was created adding the new scene files and updating the original `scene_bistro_test_v2.xml` and the changes were staged and committed successfully. 
- Basic file presence and simple content checks were performed (scripted replacements and file writes) and completed without error. 
- These variants are intended for manual or automated rendering/benchmark runs as a next step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696655b36d74832dbe281a8578307ba7)