### PR TITLE
Wait for BLAS/TLAS builds before path tracing dispatch

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -3707,6 +3707,20 @@ bool Renderer::hasPendingTlasBuild() const {
          _tlasBuildEventValue;
 }
 
+void Renderer::waitForPendingBlasBuilds() {
+  constexpr auto kPollInterval = std::chrono::milliseconds(1);
+  bool pending = true;
+  while (pending) {
+    pending = false;
+    for (auto &resident : _residentObjectGpuResources) {
+      if (!resident.hasPendingCommands())
+        continue;
+      pending = true;
+      resident.waitForPendingCommands(kPollInterval);
+    }
+  }
+}
+
 void Renderer::waitForPendingTlasBuild() {
   if (!hasPendingTlasBuild())
     return;
@@ -6856,8 +6870,10 @@ void Renderer::draw(MTK::View *pView) {
 
   if (_pPathTracePSO && !tiles.empty()) {
     if (_useAccelerationStructureBindings && _pTlasStructure &&
-        _pGeometryHandleBuffer)
+        _pGeometryHandleBuffer) {
+      waitForPendingBlasBuilds();
       waitForPendingTlasBuild();
+    }
 
     NS::UInteger tgWidth =
         std::max<NS::UInteger>(1, _pPathTracePSO->threadExecutionWidth());
@@ -6943,11 +6959,6 @@ void Renderer::draw(MTK::View *pView) {
       MTL::CommandBuffer *computeCmd = _pCommandQueue->commandBuffer();
       if (!computeCmd)
         break;
-
-      if (_useAccelerationStructureBindings && _pTlasStructure &&
-          _pGeometryHandleBuffer && _pTlasBuildEvent &&
-          _tlasBuildEventValue > 0)
-        computeCmd->encodeWait(_pTlasBuildEvent, _tlasBuildEventValue);
 
       MTL::ComputeCommandEncoder *pCompute = computeCmd->computeCommandEncoder();
       if (!pCompute) {

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -204,6 +204,7 @@ private:
   SceneAccelerationBuildResult buildSceneAccelerationStructures(
       size_t primitiveCount, size_t primitiveHitBytes);
   void ensureTlasBuildEvent();
+  void waitForPendingBlasBuilds();
   void waitForPendingTlasBuild();
   bool hasPendingTlasBuild() const;
   void finalizePendingTlasScratchResize(bool force = false);


### PR DESCRIPTION
### Motivation

- Prevent BLAS/TLAS build command buffers from being mixed with path-tracing compute work so single command buffers do not accumulate both build and render work and cause long per-command execution times.
- Ensure path-tracing dispatches only start after BLAS and TLAS builds have completed to improve runtime stability and reduce GPU-side stalls.

### Description

- Added `Renderer::waitForPendingBlasBuilds()` (polling with a 1ms interval) and declared it in `Renderer.h` to wait for pending per-object BLAS build command buffers via `ResidentObjectGpuResources::waitForPendingCommands`.
- In `Renderer::draw` gated path-tracing submission: when using acceleration-structure bindings the code now calls `waitForPendingBlasBuilds()` and then `waitForPendingTlasBuild()` before creating path-trace compute command buffers.
- Removed the per-dispatch `computeCmd->encodeWait(_pTlasBuildEvent, _tlasBuildEventValue)` usage because submissions are now gated on build completion, avoiding redundant in-command waits and keeping build and render work in separate submitted command buffers.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69677d933888832d8a058e1143030457)