### PR TITLE
Adaptive path-trace tiles-per-command budgeting

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -547,6 +547,9 @@ struct TileDispatchRegion {
 constexpr uint32_t kPathTraceTileWidth = 128;
 constexpr uint32_t kPathTraceTileHeight = 128;
 constexpr size_t kPathTraceMaxTilesPerCommand = 16;
+constexpr size_t kPathTraceMinTilesPerCommand = 2;
+constexpr double kPathTraceTargetGpuMsPerCommand = 6.0;
+constexpr size_t kPathTraceCommandHistorySamples = 30;
 constexpr std::chrono::milliseconds kFrameCommandBufferWaitTimeout(4);
 constexpr uint32_t kMaxMaterialTextureSlots = 64;
 
@@ -1195,6 +1198,7 @@ Renderer::Renderer(MTL::Device *pDevice)
   buildShaders();
   buildTextures();
   rebuildEnvironmentTexture();
+  _pathTraceTilesPerCommandBudget = kPathTraceMaxTilesPerCommand;
 
   recalculateViewport();
   initializeBenchmarking();
@@ -6916,7 +6920,12 @@ void Renderer::draw(MTK::View *pView) {
     size_t maxTilesPerCommand = envMaxTilesPerCommand > 0
                                     ? envMaxTilesPerCommand
                                     : kPathTraceMaxTilesPerCommand;
-    maxTilesPerCommand = std::max<size_t>(maxTilesPerCommand, 1);
+    size_t adaptiveTilesPerCommand = updatePathTraceTilesPerCommandBudget();
+    maxTilesPerCommand =
+        std::min<size_t>(maxTilesPerCommand, adaptiveTilesPerCommand);
+    maxTilesPerCommand = std::clamp(maxTilesPerCommand,
+                                    kPathTraceMinTilesPerCommand,
+                                    kPathTraceMaxTilesPerCommand);
 
     if (!envTileWorkValid && _pScene) {
       if (_pScene->hasCustomMaxTileSampleWorkPerCommand()) {
@@ -6955,6 +6964,7 @@ void Renderer::draw(MTK::View *pView) {
       }
 
       size_t batchEnd = std::max<size_t>(batchStart + 1, tileIndex);
+      size_t tilesInCommand = batchEnd - batchStart;
 
       MTL::CommandBuffer *computeCmd = _pCommandQueue->commandBuffer();
       if (!computeCmd)
@@ -7041,6 +7051,15 @@ void Renderer::draw(MTK::View *pView) {
       }
 
       pCompute->endEncoding();
+      computeCmd->addCompletedHandler(
+          [this, tilesInCommand](MTL::CommandBuffer *cmd) {
+            if (!cmd ||
+                cmd->status() != MTL::CommandBufferStatusCompleted)
+              return;
+            double gpuMs =
+                (cmd->GPUEndTime() - cmd->GPUStartTime()) * 1000.0;
+            this->recordPathTraceCommandTime(gpuMs, tilesInCommand);
+          });
       trackFrameCommandBuffer(computeCmd);
       computeCmd->commit();
     }
@@ -12031,6 +12050,57 @@ void Renderer::trackFrameCommandBuffer(MTL::CommandBuffer *commandBuffer) {
   });
 }
 
+void Renderer::recordPathTraceCommandTime(double gpuMs, size_t tileCount) {
+  if (gpuMs <= 0.0 || tileCount == 0)
+    return;
+
+  std::lock_guard<std::mutex> lock(_pathTraceBudgetMutex);
+  const double msPerTile = gpuMs / static_cast<double>(tileCount);
+  if (!std::isfinite(msPerTile) || msPerTile <= 0.0)
+    return;
+
+  _pathTraceGpuMsPerTileHistory.push_back(msPerTile);
+  if (_pathTraceGpuMsPerTileHistory.size() > kPathTraceCommandHistorySamples) {
+    _pathTraceGpuMsPerTileHistory.pop_front();
+  }
+}
+
+size_t Renderer::updatePathTraceTilesPerCommandBudget() {
+  std::lock_guard<std::mutex> lock(_pathTraceBudgetMutex);
+  size_t budget = _pathTraceTilesPerCommandBudget;
+  bool timeoutHit = _pathTraceCommandTimeout;
+  _pathTraceCommandTimeout = false;
+
+  if (timeoutHit) {
+    budget = std::max(kPathTraceMinTilesPerCommand, budget / 2);
+  }
+
+  if (!_pathTraceGpuMsPerTileHistory.empty()) {
+    double totalMs = std::accumulate(
+        _pathTraceGpuMsPerTileHistory.begin(),
+        _pathTraceGpuMsPerTileHistory.end(), 0.0);
+    double avgMsPerTile =
+        totalMs / static_cast<double>(_pathTraceGpuMsPerTileHistory.size());
+    if (avgMsPerTile > 0.0) {
+      double targetTiles =
+          std::floor(kPathTraceTargetGpuMsPerCommand / avgMsPerTile);
+      size_t desired = static_cast<size_t>(std::max(1.0, targetTiles));
+      desired = std::clamp(desired, kPathTraceMinTilesPerCommand,
+                           kPathTraceMaxTilesPerCommand);
+      if (desired < budget) {
+        budget = desired;
+      } else if (!timeoutHit && desired > budget) {
+        budget = std::min(budget + 1, desired);
+      }
+    }
+  }
+
+  budget = std::clamp(budget, kPathTraceMinTilesPerCommand,
+                      kPathTraceMaxTilesPerCommand);
+  _pathTraceTilesPerCommandBudget = budget;
+  return budget;
+}
+
 bool Renderer::waitForPendingFrameCommands(
     std::chrono::milliseconds timeout,
     std::chrono::steady_clock::time_point *waitSnapshot) {
@@ -12104,6 +12174,11 @@ bool Renderer::waitForPendingFrameCommands(
   for (auto &record : pending) {
     if (record.buffer)
       record.buffer->release();
+  }
+
+  if (!infiniteTimeout && !allComplete) {
+    std::lock_guard<std::mutex> lock(_pathTraceBudgetMutex);
+    _pathTraceCommandTimeout = true;
   }
 
   if (newCommandTracked)

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -183,6 +183,8 @@ private:
   void completeFrameMetrics(MTL::CommandBuffer *pCmd);
   std::vector<bool> buildResidentMaskFromGpuResources() const;
   void trackFrameCommandBuffer(MTL::CommandBuffer *commandBuffer);
+  void recordPathTraceCommandTime(double gpuMs, size_t tileCount);
+  size_t updatePathTraceTilesPerCommandBudget();
   bool waitForPendingFrameCommands(
       std::chrono::milliseconds timeout,
       std::chrono::steady_clock::time_point *waitSnapshot = nullptr);
@@ -288,6 +290,10 @@ private:
   std::mutex _frameCommandBufferMutex;
   MTL::CommandBuffer *_lastRayHitCommandBuffer = nullptr;
   bool _rayHitCopyError = false;
+  std::mutex _pathTraceBudgetMutex;
+  std::deque<double> _pathTraceGpuMsPerTileHistory;
+  size_t _pathTraceTilesPerCommandBudget = 0;
+  bool _pathTraceCommandTimeout = false;
   MTL::Buffer *_pLightIndexBuffer = nullptr;
   MTL::Buffer *_pLightCdfBuffer = nullptr;
   MTL::Buffer *_pInstanceBuffer = nullptr;


### PR DESCRIPTION
### Motivation
- Avoid long-running GPU command buffers and timeouts by adaptively reducing the number of tiles batched per path-trace command when recent frames show long GPU durations or hit command wait timeouts.
- Use existing GPU timing metrics (and lightweight command completion timing) to tune batching so individual command GPU time stays below a target threshold.

### Description
- Added tuning constants: `kPathTraceMinTilesPerCommand`, `kPathTraceTargetGpuMsPerCommand`, and `kPathTraceCommandHistorySamples` and kept the existing `kPathTraceMaxTilesPerCommand` cap.
- Added renderer state for budgeting: `_pathTraceGpuMsPerTileHistory`, `_pathTraceTilesPerCommandBudget`, `_pathTraceCommandTimeout`, and `_pathTraceBudgetMutex` in `Renderer` to track recent per-tile GPU ms and timeout signals.
- Implemented `recordPathTraceCommandTime(double gpuMs, size_t tileCount)` to record per-command GPU duration as ms-per-tile, and `updatePathTraceTilesPerCommandBudget()` to compute a per-frame adaptive `tilesPerCommand` (bounded by min/max and nudged gradually upward but halved on timeouts).
- Hooked timing and budget into the render loop by adding a completion handler to path-trace compute command buffers to call `recordPathTraceCommandTime`, initializing the budget in the constructor, and marking `_pathTraceCommandTimeout` in `waitForPendingFrameCommands` when a non-infinite wait times out.
- Replaced the static `maxTilesPerCommand` usage in the tile batching loop with the adaptive value from `updatePathTraceTilesPerCommandBudget()` while preserving environment overrides and clamping.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69677f9625e4832da072ef9431f7f740)