### PR TITLE
Add camera-path fill area lights to bistro v2 scenes

### DIFF
--- a/Nomad Path Tracer/scene_bistro_test_v2.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2.xml
@@ -1600,6 +1600,13 @@
   <Mesh file="meshes/_m_5_Mesh.1294.obj" position="1.5035,-8.9493,3.7368" scale="0.01102" clusterMaxTriangles="0" clusterMaxExtent="0" basisX="0.010029,-0.0041933,4.3839e-05" basisY="0.0042877,0.010252,-0.0003048" basisZ="7.5949e-05,0.00029738,0.01107" />
   <Mesh file="meshes/_m_0_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
   <Mesh file="meshes/_m_1_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
+  <!-- Camera path fill lights -->
+  <Rectangle position="-8,-2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,-7,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="4,-4,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="6,2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,6,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <!-- End camera path fill lights -->
   <Rectangle position="0.5,1.2,6.4" u="1.8,0,0" v="0,1.2,0" />
   <Rectangle position="-3.2,-4.5,6.2" u="1.4,0,0" v="0,1.4,0" />
   <Sphere position="2.8,-1.0,5.9" radius="0.18" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_distance.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_distance.xml
@@ -1600,6 +1600,13 @@
   <Mesh file="meshes/_m_5_Mesh.1294.obj" position="1.5035,-8.9493,3.7368" scale="0.01102" clusterMaxTriangles="0" clusterMaxExtent="0" basisX="0.010029,-0.0041933,4.3839e-05" basisY="0.0042877,0.010252,-0.0003048" basisZ="7.5949e-05,0.00029738,0.01107" />
   <Mesh file="meshes/_m_0_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
   <Mesh file="meshes/_m_1_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
+  <!-- Camera path fill lights -->
+  <Rectangle position="-8,-2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,-7,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="4,-4,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="6,2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,6,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <!-- End camera path fill lights -->
   <Rectangle position="0.5,1.2,6.4" u="1.8,0,0" v="0,1.2,0" />
   <Rectangle position="-3.2,-4.5,6.2" u="1.4,0,0" v="0,1.4,0" />
   <Sphere position="2.8,-1.0,5.9" radius="0.18" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_energy.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_energy.xml
@@ -1600,6 +1600,13 @@
   <Mesh file="meshes/_m_5_Mesh.1294.obj" position="1.5035,-8.9493,3.7368" scale="0.01102" clusterMaxTriangles="0" clusterMaxExtent="0" basisX="0.010029,-0.0041933,4.3839e-05" basisY="0.0042877,0.010252,-0.0003048" basisZ="7.5949e-05,0.00029738,0.01107" />
   <Mesh file="meshes/_m_0_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
   <Mesh file="meshes/_m_1_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
+  <!-- Camera path fill lights -->
+  <Rectangle position="-8,-2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,-7,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="4,-4,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="6,2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,6,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <!-- End camera path fill lights -->
   <Rectangle position="0.5,1.2,6.4" u="1.8,0,0" v="0,1.2,0" />
   <Rectangle position="-3.2,-4.5,6.2" u="1.4,0,0" v="0,1.4,0" />
   <Sphere position="2.8,-1.0,5.9" radius="0.18" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_environment.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_environment.xml
@@ -1600,6 +1600,13 @@
   <Mesh file="meshes/_m_5_Mesh.1294.obj" position="1.5035,-8.9493,3.7368" scale="0.01102" clusterMaxTriangles="0" clusterMaxExtent="0" basisX="0.010029,-0.0041933,4.3839e-05" basisY="0.0042877,0.010252,-0.0003048" basisZ="7.5949e-05,0.00029738,0.01107" />
   <Mesh file="meshes/_m_0_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
   <Mesh file="meshes/_m_1_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
+  <!-- Camera path fill lights -->
+  <Rectangle position="-8,-2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,-7,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="4,-4,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="6,2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,6,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <!-- End camera path fill lights -->
   <Rectangle position="0.5,1.2,6.4" u="1.8,0,0" v="0,1.2,0" />
   <Rectangle position="-3.2,-4.5,6.2" u="1.4,0,0" v="0,1.4,0" />
   <Sphere position="2.8,-1.0,5.9" radius="0.18" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_predictive.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_predictive.xml
@@ -1600,6 +1600,13 @@
   <Mesh file="meshes/_m_5_Mesh.1294.obj" position="1.5035,-8.9493,3.7368" scale="0.01102" clusterMaxTriangles="0" clusterMaxExtent="0" basisX="0.010029,-0.0041933,4.3839e-05" basisY="0.0042877,0.010252,-0.0003048" basisZ="7.5949e-05,0.00029738,0.01107" />
   <Mesh file="meshes/_m_0_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
   <Mesh file="meshes/_m_1_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
+  <!-- Camera path fill lights -->
+  <Rectangle position="-8,-2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,-7,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="4,-4,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="6,2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,6,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <!-- End camera path fill lights -->
   <Rectangle position="0.5,1.2,6.4" u="1.8,0,0" v="0,1.2,0" />
   <Rectangle position="-3.2,-4.5,6.2" u="1.4,0,0" v="0,1.4,0" />
   <Sphere position="2.8,-1.0,5.9" radius="0.18" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_probabilistic.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_probabilistic.xml
@@ -1600,6 +1600,13 @@
   <Mesh file="meshes/_m_5_Mesh.1294.obj" position="1.5035,-8.9493,3.7368" scale="0.01102" clusterMaxTriangles="0" clusterMaxExtent="0" basisX="0.010029,-0.0041933,4.3839e-05" basisY="0.0042877,0.010252,-0.0003048" basisZ="7.5949e-05,0.00029738,0.01107" />
   <Mesh file="meshes/_m_0_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
   <Mesh file="meshes/_m_1_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
+  <!-- Camera path fill lights -->
+  <Rectangle position="-8,-2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,-7,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="4,-4,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="6,2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,6,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <!-- End camera path fill lights -->
   <Rectangle position="0.5,1.2,6.4" u="1.8,0,0" v="0,1.2,0" />
   <Rectangle position="-3.2,-4.5,6.2" u="1.4,0,0" v="0,1.4,0" />
   <Sphere position="2.8,-1.0,5.9" radius="0.18" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_rayhit.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_rayhit.xml
@@ -1600,6 +1600,13 @@
   <Mesh file="meshes/_m_5_Mesh.1294.obj" position="1.5035,-8.9493,3.7368" scale="0.01102" clusterMaxTriangles="0" clusterMaxExtent="0" basisX="0.010029,-0.0041933,4.3839e-05" basisY="0.0042877,0.010252,-0.0003048" basisZ="7.5949e-05,0.00029738,0.01107" />
   <Mesh file="meshes/_m_0_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
   <Mesh file="meshes/_m_1_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
+  <!-- Camera path fill lights -->
+  <Rectangle position="-8,-2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,-7,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="4,-4,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="6,2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,6,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <!-- End camera path fill lights -->
   <Rectangle position="0.5,1.2,6.4" u="1.8,0,0" v="0,1.2,0" />
   <Rectangle position="-3.2,-4.5,6.2" u="1.4,0,0" v="0,1.4,0" />
   <Sphere position="2.8,-1.0,5.9" radius="0.18" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_restir.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_restir.xml
@@ -1600,6 +1600,13 @@
   <Mesh file="meshes/_m_5_Mesh.1294.obj" position="1.5035,-8.9493,3.7368" scale="0.01102" clusterMaxTriangles="0" clusterMaxExtent="0" basisX="0.010029,-0.0041933,4.3839e-05" basisY="0.0042877,0.010252,-0.0003048" basisZ="7.5949e-05,0.00029738,0.01107" />
   <Mesh file="meshes/_m_0_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
   <Mesh file="meshes/_m_1_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
+  <!-- Camera path fill lights -->
+  <Rectangle position="-8,-2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,-7,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="4,-4,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="6,2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,6,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <!-- End camera path fill lights -->
   <Rectangle position="0.5,1.2,6.4" u="1.8,0,0" v="0,1.2,0" />
   <Rectangle position="-3.2,-4.5,6.2" u="1.4,0,0" v="0,1.4,0" />
   <Sphere position="2.8,-1.0,5.9" radius="0.18" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_screenspace.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_screenspace.xml
@@ -1600,6 +1600,13 @@
   <Mesh file="meshes/_m_5_Mesh.1294.obj" position="1.5035,-8.9493,3.7368" scale="0.01102" clusterMaxTriangles="0" clusterMaxExtent="0" basisX="0.010029,-0.0041933,4.3839e-05" basisY="0.0042877,0.010252,-0.0003048" basisZ="7.5949e-05,0.00029738,0.01107" />
   <Mesh file="meshes/_m_0_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
   <Mesh file="meshes/_m_1_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
+  <!-- Camera path fill lights -->
+  <Rectangle position="-8,-2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,-7,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="4,-4,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="6,2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,6,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <!-- End camera path fill lights -->
   <Rectangle position="0.5,1.2,6.4" u="1.8,0,0" v="0,1.2,0" />
   <Rectangle position="-3.2,-4.5,6.2" u="1.4,0,0" v="0,1.4,0" />
   <Sphere position="2.8,-1.0,5.9" radius="0.18" />

--- a/Nomad Path Tracer/scene_bistro_test_v2_unified.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_unified.xml
@@ -1600,6 +1600,13 @@
   <Mesh file="meshes/_m_5_Mesh.1294.obj" position="1.5035,-8.9493,3.7368" scale="0.01102" clusterMaxTriangles="0" clusterMaxExtent="0" basisX="0.010029,-0.0041933,4.3839e-05" basisY="0.0042877,0.010252,-0.0003048" basisZ="7.5949e-05,0.00029738,0.01107" />
   <Mesh file="meshes/_m_0_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
   <Mesh file="meshes/_m_1_Mesh.1295.obj" position="7.2615,-4.1579,3.1682" scale="0.01" clusterMaxTriangles="0" clusterMaxExtent="0" rotation="-0.013722,-5.1674,-22.01" />
+  <!-- Camera path fill lights -->
+  <Rectangle position="-8,-2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,-7,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="4,-4,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="6,2,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <Rectangle position="-3,6,6" u="2,0,0" v="0,2,0" rotation="0,0,0" albedo="0,0,0" emission="1,1,1" materialType="0" emissionPower="20" />
+  <!-- End camera path fill lights -->
   <Rectangle position="0.5,1.2,6.4" u="1.8,0,0" v="0,1.2,0" />
   <Rectangle position="-3.2,-4.5,6.2" u="1.4,0,0" v="0,1.4,0" />
   <Sphere position="2.8,-1.0,5.9" radius="0.18" />


### PR DESCRIPTION
### Motivation

- Reduce render noise along the camera trajectory by adding additional area lights that fill the camera path.
- Ensure consistent placement of those fill lights relative to existing area-light geometry so lighting is stable across variants.

### Description

- Inserted a block of five emissive `<Rectangle>` area lights (with `emission="1,1,1"` and `emissionPower="20"`) into the bistro v2 base scene and all v2 variant scene files. 
- The new `<!-- Camera path fill lights -->` block is placed before the existing area-light geometry marker (the rectangle at `position="0.5,1.2,6.4"`) to keep positioning consistent across files. 
- Files modified are all under `Nomad Path Tracer/` and include `scene_bistro_test_v2.xml` plus the `_distance`, `_energy`, `_environment`, `_predictive`, `_probabilistic`, `_rayhit`, `_restir`, `_screenspace`, and `_unified` variants. 

### Testing

- No automated tests were run because the change is limited to scene XML data only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69678b604538832da170294dde6dde09)