### PR TITLE
Add ReSTIR baseline mode to disable texture history eviction

### DIFF
--- a/Nomad Path Tracer/README.md
+++ b/Nomad Path Tracer/README.md
@@ -9,3 +9,10 @@ Long-running path tracing commands can trigger GPU timeout errors when the pixel
 - **Default:** when unset, the renderer uses a conservative default budget. For `AlwaysResident` residency, the default budget is halved to keep command buffers short while more geometry remains resident.
 
 The renderer clamps the budget so each command can still process at least one full tile, based on the current tile dimensions and sample count.
+
+## ReSTIR baseline mode
+
+To keep ReSTIR temporal reuse stable for baseline comparisons, you can disable texture history eviction:
+
+- **Scene XML:** add `restirBaselineMode="true"` (or `restirBaseline="true"`) to the `<Scene>` root.
+- **Behavior:** no history eviction; maintains stable ReSTIR temporal reuse for baseline comparisons.

--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -6135,6 +6135,10 @@ bool Renderer::evictTextureSlot(ManagedTextureSlot &slot,
 void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
   if (!cmd || _needsAccumulationReset)
     return;
+  if (_residencyConfig.restirBaselineMode) {
+    std::printf("[TextureResidency] Skipping eviction: ReSTIR baseline mode enabled.\n");
+    return;
+  }
 
   bool belowBudget = _residentPrimitiveCount < kTextureResidencyPrimitiveBudget;
   double totalMemoryMB = currentGPUMemoryMB();

--- a/Nomad Path Tracer/Scene/Scene.h
+++ b/Nomad Path Tracer/Scene/Scene.h
@@ -96,6 +96,7 @@ struct ResidencyParameters {
   float restirReuseWeight = 0.85f;
   size_t restirCandidateCount = 4;
   size_t restirMaxTogglesPerFrame = 16;
+  bool restirBaselineMode = false;
 
   float screenFootprintTargetFraction = 0.65f;
   float screenFootprintMinPixelCoverage = 32.0f;

--- a/Nomad Path Tracer/Scene/SceneLoader.cpp
+++ b/Nomad Path Tracer/Scene/SceneLoader.cpp
@@ -797,6 +797,10 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         "restirCandidateCount", static_cast<uint64_t>(params.restirCandidateCount)));
     params.restirMaxTogglesPerFrame = static_cast<size_t>(root->Unsigned64Attribute(
         "restirToggleBudget", static_cast<uint64_t>(params.restirMaxTogglesPerFrame)));
+    params.restirBaselineMode = root->BoolAttribute(
+        "restirBaselineMode", params.restirBaselineMode);
+    params.restirBaselineMode = root->BoolAttribute(
+        "restirBaseline", params.restirBaselineMode);
     params.probabilityIdleCooldownFrames = root->UnsignedAttribute(
         "probabilityIdleCooldownFrames", params.probabilityIdleCooldownFrames);
     params.probabilityIdleCooldownFrames = root->UnsignedAttribute(


### PR DESCRIPTION
### Motivation
- Provide a toggleable mode to preserve ReSTIR temporal reuse by preventing texture/history eviction for baseline comparisons.

### Description
- Add a `bool restirBaselineMode` field to `ResidencyParameters` in `Scene/Scene.h` to track the mode via runtime/scene settings.
- Parse `restirBaselineMode` (and the alias `restirBaseline`) from scene XML in `Scene/SceneLoader.cpp` and populate the residency parameters.
- Short-circuit `Renderer::updateTextureResidency()` to skip all eviction when `_residencyConfig.restirBaselineMode` is true, preserving accumulation and ReSTIR history (`Renderer/Renderer.cpp`).
- Document the new scene XML flags `restirBaselineMode` / `restirBaseline` and the behavior in `README.md` under runtime controls.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968dae553a4832d9df832fa8270edab)