### PR TITLE
Enable ReSTIR baseline mode for bistro test scene

### DIFF
--- a/Nomad Path Tracer/scene_bistro_test_v2_restir.xml
+++ b/Nomad Path Tracer/scene_bistro_test_v2_restir.xml
@@ -1,4 +1,4 @@
-<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="restir" environmentBrightness="0">
+<Scene width="720" height="576" maxRayDepth="4" startCompacted="true" residencyStrategy="restir" restirBaselineMode="true" environmentBrightness="0">
   <CameraPath>
     <Keyframe frame="1" position="-9.8374,-1.4931,3.4163" lookAt="0,0,0" up="0,0,1" />
     <Keyframe frame="60" position="-6.42,-6.18,3.18" lookAt="0,0,0" up="0,0,1" />


### PR DESCRIPTION
### Motivation
- Ensure the Bistro ReSTIR test uses the new baseline ReSTIR behavior so temporal history is preserved for baseline comparisons.

### Description
- Added `restirBaselineMode="true"` to the `<Scene>` root in `Nomad Path Tracer/scene_bistro_test_v2_restir.xml` to enable baseline ReSTIR mode.

### Testing
- No automated tests were run because this is a scene XML change only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968dd22f460832d849866d38992367a)