### PR TITLE
Per-frame normalization for unified residency signals

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -7725,6 +7725,28 @@ std::vector<float> Renderer::computeUnifiedImportance(float &outTotalScore) {
       std::clamp(_residencyConfig.unifiedOffscreenDecay, 0.0f, 1.0f);
   const float offscreenFloor =
       std::max(_residencyConfig.unifiedOffscreenFloor, 0.0f);
+  const bool normalizeUnified = _residencyConfig.unifiedNormalize;
+  constexpr float normalizationEpsilon = 1e-6f;
+
+  std::vector<float> adjustedEnergy(primCount, 0.0f);
+  std::vector<float> adjustedHit(primCount, 0.0f);
+  std::vector<float> adjustedCoverage(primCount, 0.0f);
+  std::vector<float> adjustedDistance(primCount, 0.0f);
+  std::vector<uint8_t> skipScore(primCount, 0);
+
+  float minEnergy = std::numeric_limits<float>::max();
+  float maxEnergy = std::numeric_limits<float>::lowest();
+  float minHit = std::numeric_limits<float>::max();
+  float maxHit = std::numeric_limits<float>::lowest();
+  float minCoverage = std::numeric_limits<float>::max();
+  float maxCoverage = std::numeric_limits<float>::lowest();
+  float minDistance = std::numeric_limits<float>::max();
+  float maxDistance = std::numeric_limits<float>::lowest();
+
+  auto updateMinMax = [](float value, float &minValue, float &maxValue) {
+    minValue = std::min(minValue, value);
+    maxValue = std::max(maxValue, value);
+  };
 
   for (size_t i = 0; i < primCount; ++i) {
     uint64_t boundsVersion = boundsVersionForPrimitive(i);
@@ -7803,6 +7825,15 @@ std::vector<float> Renderer::computeUnifiedImportance(float &outTotalScore) {
     if (hit == 0.0f && energy == 0.0f && coverage == 0.0f &&
         distanceScore == 0.0f && !visible) {
       _primitiveUnifiedPrevVisible[i] = visible ? 1 : 0;
+      adjustedEnergy[i] = energy;
+      adjustedHit[i] = hit;
+      adjustedCoverage[i] = coverage;
+      adjustedDistance[i] = distanceScore;
+      skipScore[i] = 1;
+      updateMinMax(adjustedEnergy[i], minEnergy, maxEnergy);
+      updateMinMax(adjustedHit[i], minHit, maxHit);
+      updateMinMax(adjustedCoverage[i], minCoverage, maxCoverage);
+      updateMinMax(adjustedDistance[i], minDistance, maxDistance);
       continue;
     }
 
@@ -7830,6 +7861,39 @@ std::vector<float> Renderer::computeUnifiedImportance(float &outTotalScore) {
 
     if (i < _primitiveUnifiedPrevVisible.size())
       _primitiveUnifiedPrevVisible[i] = visible ? 1 : 0;
+
+    adjustedEnergy[i] = energy;
+    adjustedHit[i] = hit;
+    adjustedCoverage[i] = coverage;
+    adjustedDistance[i] = distanceScore;
+    updateMinMax(adjustedEnergy[i], minEnergy, maxEnergy);
+    updateMinMax(adjustedHit[i], minHit, maxHit);
+    updateMinMax(adjustedCoverage[i], minCoverage, maxCoverage);
+    updateMinMax(adjustedDistance[i], minDistance, maxDistance);
+  }
+
+  auto normalizeValue = [&](float value, float minValue, float maxValue) {
+    float range = maxValue - minValue;
+    if (range <= normalizationEpsilon)
+      return 0.0f;
+    return (value - minValue) / (range + normalizationEpsilon);
+  };
+
+  for (size_t i = 0; i < primCount; ++i) {
+    if (skipScore[i] != 0)
+      continue;
+
+    float energy = adjustedEnergy[i];
+    float hit = adjustedHit[i];
+    float coverage = adjustedCoverage[i];
+    float distanceScore = adjustedDistance[i];
+
+    if (normalizeUnified) {
+      energy = normalizeValue(energy, minEnergy, maxEnergy);
+      hit = normalizeValue(hit, minHit, maxHit);
+      coverage = normalizeValue(coverage, minCoverage, maxCoverage);
+      distanceScore = normalizeValue(distanceScore, minDistance, maxDistance);
+    }
 
     float score = alpha * energy + beta * hit + gamma * coverage +
                   delta * distanceScore;

--- a/Nomad Path Tracer/Scene/Scene.h
+++ b/Nomad Path Tracer/Scene/Scene.h
@@ -66,6 +66,7 @@ struct ResidencyParameters {
   float unifiedOffscreenDecay = 0.05f;
   float unifiedOffscreenFloor = 0.02f;
   float unifiedReentryBoost = 3.0f;
+  bool unifiedNormalize = true;
 
   float rayHitDecay = 0.85f;
   float rayHitTargetFraction = 0.6f;

--- a/Nomad Path Tracer/Scene/SceneLoader.cpp
+++ b/Nomad Path Tracer/Scene/SceneLoader.cpp
@@ -747,6 +747,8 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         "unifiedOffscreenFloor", params.unifiedOffscreenFloor);
     params.unifiedReentryBoost =
         root->FloatAttribute("unifiedReentryBoost", params.unifiedReentryBoost);
+    params.unifiedNormalize =
+        root->BoolAttribute("unifiedNormalize", params.unifiedNormalize);
 
     params.rayHitDecay = root->FloatAttribute("rayHitDecay", params.rayHitDecay);
     params.rayHitTargetFraction =


### PR DESCRIPTION
### Motivation
- Make the unified residency score components (`energy`, `hit`, `coverage`, `distance`) comparable on a per-frame basis so that no single raw signal magnitude overwhelms the unified score across varying scenes or camera configurations.
- Provide a runtime toggle to enable/disable normalization so scenes can opt into the normalized mode or keep previous behavior for comparisons and tuning.

### Description
- Added a new residency parameter `unifiedNormalize` (default `true`) to `ResidencyParameters` in `Scene.h` and wired XML parsing in `SceneLoader.cpp` to read `unifiedNormalize` via `root->BoolAttribute`.
- In `Renderer::computeUnifiedImportance` the pass now gathers per-frame min/max statistics for `energy`, `hit`, `coverage`, and `distance` into temporary arrays and min/max accumulators while preserving existing visibility/offscreen and reentry boost logic.
- When `unifiedNormalize` is enabled the code normalizes each signal with a guarded min/max normalization `(value - min) / (max - min + epsilon)` using `normalizationEpsilon`, and then computes the unified score as the weighted sum `alpha*energy + beta*hit + gamma*coverage + delta*distance`.
- Added local temporaries (`adjustedEnergy`, `adjustedHit`, `adjustedCoverage`, `adjustedDistance`, and `skipScore`) and a small helper `updateMinMax` to collect stats and avoid changing existing persisted arrays or other control flow.

### Testing
- No automated tests were run on this change.
- The change compiles locally as part of the commit cycle (no runtime/behavioral automated verification was executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968eec8b038832dbbb998596c7aeb5f)