### PR TITLE
Increase CSV field size limit in compare_runs.py

### DIFF
--- a/compare_runs.py
+++ b/compare_runs.py
@@ -14,10 +14,13 @@ from __future__ import annotations
 
 import argparse
 import csv
+import sys
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
+
+csv.field_size_limit(sys.maxsize)
 
 Frames = List[int]
 Series = Dict[str, List[float]]


### PR DESCRIPTION
### Motivation
- Prevent `_csv.Error: field larger than field limit` when reading benchmark CSVs that contain very large metric fields by increasing the CSV parser field size limit.

### Description
- Import `sys` and call `csv.field_size_limit(sys.maxsize)` in `compare_runs.py` near the top (before `_load_csv` uses `csv.DictReader`) to allow parsing very large fields.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969231e5d40832d9ce0f2d1c1f4a0c1)