### PR TITLE
Do not reset _lastFrameGlobalEnvEscape before ray-hit readback completes

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -11537,8 +11537,6 @@ bool Renderer::flushRayHitCopy() {
 }
 
 void Renderer::processRayHitCounters() {
-  _lastFrameGlobalEnvEscape = 0.0f;
-
   if (!flushRayHitCopy())
     return;
 


### PR DESCRIPTION
### Motivation
- Prevent `global_env_escape` being forced to zero when a ray-hit readback is not yet available by avoiding premature reset of `_lastFrameGlobalEnvEscape`.

### Description
- Remove the early assignment of `_lastFrameGlobalEnvEscape = 0.0f` from `Renderer::processRayHitCounters()` so the value is only updated when the readback is processed (gated by `flushRayHitCopy()` and the later readback handling in the same function). The change is in `Nomad Path Tracer/Renderer/Renderer.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69693958f6e0832da6991a2b8e7b2b8f)