### PR TITLE
Screen-space footprint: skip low-coverage groups and add skip metric

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -1478,7 +1478,8 @@ void Renderer::writeBenchmarkHeader() {
          "lod_enter_distance,lod_exit_distance,lod_enter_view_margin,"
          "lod_exit_view_margin,energy_target_fraction,"
          "energy_min_active,energy_visibility_boost,screen_target_fraction,"
-         "screen_min_pixels,screen_min_active,environment_target_fraction,"
+         "screen_min_pixels,screen_min_active,screen_min_pixel_skips,"
+         "environment_target_fraction,"
          "environment_escape_threshold,env_high_escape,env_low_escape,global_env_escape,"
          "environment_activation_floor,environment_min_active,environment_toggle_budget,"
          "unified_offscreen_decay,unified_offscreen_floor,environment_depth_weights,"
@@ -1590,6 +1591,7 @@ void Renderer::writeBenchmarkRow(const BenchmarkSample &sample) {
       << formatFixed(_residencyConfig.screenFootprintTargetFraction, 3) << ','
       << formatFixed(_residencyConfig.screenFootprintMinPixelCoverage, 3) << ','
       << _residencyConfig.screenFootprintMinActivePrimitives << ','
+      << sample.screenMinPixelCoverageSkips << ','
       << formatFixed(sample.environmentTargetActiveFraction, 3) << ','
       << formatFixed(sample.environmentEscapeThreshold, 3) << ','
       << formatFixed(sample.envHighEscapeThreshold, 3) << ','
@@ -7214,6 +7216,7 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   _frameObjectActivations = 0;
   _frameObjectDeactivations = 0;
   _frameProbabilisticToggles = 0;
+  _frameScreenMinPixelCoverageSkips = 0;
   _frameEnvironmentActivationFloor = 0;
   _frameRestirReuseRate = 0.0;
   _frameRestirCandidateAcceptance = 0.0;
@@ -10515,10 +10518,12 @@ bool Renderer::updateScreenSpaceFootprint(bool forceAllToggles) {
     if (minPrimitivesSatisfied && coverageSatisfied)
       break;
     if (minPrimitivesSatisfied &&
-        coverage < _residencyConfig.screenFootprintMinPixelCoverage)
-      break;
+        coverage < _residencyConfig.screenFootprintMinPixelCoverage) {
+      ++_frameScreenMinPixelCoverageSkips;
+      continue;
+    }
     if (minPrimitivesSatisfied && coverage <= 0.0f)
-      break;
+      continue;
 
     desiredGroupState[groupIndex] = true;
     primitivesEnabled += declaredPrimitiveCount;
@@ -12449,6 +12454,7 @@ void Renderer::beginFrameMetrics() {
         _frameProbabilityFinalDesiredPrimitives;
     sample.probabilityTrimmedPrimitives = _frameProbabilityTrimmedPrimitives;
     sample.probabilityBudgetHit = _frameProbabilityBudgetHit;
+    sample.screenMinPixelCoverageSkips = _frameScreenMinPixelCoverageSkips;
     sample.deltaTimeSeconds = _deltaTimeSeconds;
     sample.wallSeconds = std::chrono::duration<double>(
                             std::chrono::steady_clock::now() - _benchmarkStartTime)

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -415,6 +415,7 @@ private:
     size_t probabilityFinalDesiredPrimitives = 0;
     size_t probabilityTrimmedPrimitives = 0;
     bool probabilityBudgetHit = false;
+    size_t screenMinPixelCoverageSkips = 0;
     double environmentTargetActiveFraction = 0.0;
     double environmentEscapeThreshold = 0.0;
     std::string environmentDepthWeights;
@@ -653,6 +654,7 @@ private:
   size_t _frameProbabilityFinalDesiredPrimitives = 0;
   size_t _frameProbabilityTrimmedPrimitives = 0;
   bool _frameProbabilityBudgetHit = false;
+  size_t _frameScreenMinPixelCoverageSkips = 0;
   size_t _frameEnvironmentActivationFloor = 0;
   ResidencyStrategy _frameStrategy = ResidencyStrategy::DistanceLOD;
   ResidencyStrategy _lastResidencyStrategy = ResidencyStrategy::DistanceLOD;


### PR DESCRIPTION
### Motivation
- Prevent a single low-coverage mesh group from stopping selection once the minimum active primitives requirement is reached, so later groups can still be considered for activation. 
- Preserve the early exit when both `minActive` and `targetCoverage` are satisfied while avoiding premature termination due to one low-coverage group. 
- Add a debug metric to measure how often groups are skipped due to the minimum pixel coverage threshold to aid diagnosing selection behavior on large meshes.

### Description
- In `Renderer::updateScreenSpaceFootprint` replaced the unconditional `break` for low coverage with a counter increment and `continue`, keeping the `break` when both `minActive` and `targetCoverage` are satisfied, and also changed the `coverage <= 0.0f` case to `continue` instead of breaking. (modified `Nomad Path Tracer/Renderer/Renderer.cpp`)
- Introduced a per-frame counter `_frameScreenMinPixelCoverageSkips` and added it to the `BenchmarkSample` struct as `screenMinPixelCoverageSkips`. (modified `Nomad Path Tracer/Renderer/Renderer.h`)
- Reset `_frameScreenMinPixelCoverageSkips` at the start of `updateResidency` and populate `sample.screenMinPixelCoverageSkips` in `beginFrameMetrics`, and include the value in CSV output via `writeBenchmarkRow` and the benchmark header. (modified `Nomad Path Tracer/Renderer/Renderer.cpp`)
- Updated CSV header order to expose the new `screen_min_pixel_skips` column for benchmark logs. (modified `Nomad Path Tracer/Renderer/Renderer.cpp`)

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a1c7ff594832db18ac3efe5c54a89)