### PR TITLE
Add configurable energy importance metric

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -8133,38 +8133,32 @@ bool Renderer::updateEnergyImportance(bool forceAllToggles) {
   float targetImportanceBase = applyVisibilityBoost ? boostedTotalImportance
                                                     : _totalPrimitiveImportance;
 
-  std::vector<float> energyImportancePerPrimitive(objectCount, 0.0f);
-  float totalEnergyImportancePerPrimitive = 0.0f;
+  const bool useAverageImportance =
+      _residencyConfig.energyUseAverageImportance && !anyMeshGroups;
+  std::vector<float> energySelectionImportance(objectCount, 0.0f);
+  float totalEnergySelectionImportance = 0.0f;
   for (size_t objectIndex = 0; objectIndex < objectCount; ++objectIndex) {
     size_t count = objectIndex < objectPrimitiveCounts.size()
                        ? objectPrimitiveCounts[objectIndex]
                        : 0;
-    if (count == 0)
-      continue;
-    float avgImportance = energyImportance[objectIndex] /
-                          static_cast<float>(count);
-    energyImportancePerPrimitive[objectIndex] = avgImportance;
-    totalEnergyImportancePerPrimitive += std::max(avgImportance, 0.0f);
+    float importance = energyImportance[objectIndex];
+    if (useAverageImportance) {
+      if (count == 0)
+        continue;
+      importance /= static_cast<float>(count);
+    }
+    energySelectionImportance[objectIndex] = importance;
+    totalEnergySelectionImportance += std::max(importance, 0.0f);
   }
 
   std::sort(_energySortedIndices.begin(), _energySortedIndices.end(),
             [&](size_t a, size_t b) {
-              auto scoreFor = [&](size_t idx) {
-                float score = 0.0f;
-                if (idx < _objectImportanceHistory.size())
-                  score = sanitizeSortValue(_objectImportanceHistory[idx]);
-                if (!anyMeshGroups) {
-                  size_t count = idx < objectPrimitiveCounts.size()
-                                     ? objectPrimitiveCounts[idx]
-                                     : 0;
-                  if (count == 0)
-                    return 0.0f;
-                  score /= static_cast<float>(count);
-                }
-                return score;
-              };
-              float scoreA = scoreFor(a);
-              float scoreB = scoreFor(b);
+              float scoreA = (a < energySelectionImportance.size())
+                                 ? sanitizeSortValue(energySelectionImportance[a])
+                                 : 0.0f;
+              float scoreB = (b < energySelectionImportance.size())
+                                 ? sanitizeSortValue(energySelectionImportance[b])
+                                 : 0.0f;
               if (scoreA == scoreB)
                 return a < b;
               return scoreA > scoreB;
@@ -8197,8 +8191,8 @@ bool Renderer::updateEnergyImportance(bool forceAllToggles) {
     std::vector<bool> desiredObjectState(objectCount, false);
     size_t primitivesEnabled = 0;
     float targetImportanceBaseSelection =
-        totalEnergyImportancePerPrimitive > 0.0f
-            ? totalEnergyImportancePerPrimitive
+        totalEnergySelectionImportance > 0.0f
+            ? totalEnergySelectionImportance
             : targetImportanceBase;
 
     if (_totalPrimitiveImportance <= 0.0f) {
@@ -8222,8 +8216,8 @@ bool Renderer::updateEnergyImportance(bool forceAllToggles) {
         if (idx >= objectPrimitiveCounts.size())
           continue;
         size_t count = objectPrimitiveCounts[idx];
-        float importance = (idx < energyImportancePerPrimitive.size())
-                               ? energyImportancePerPrimitive[idx]
+        float importance = (idx < energySelectionImportance.size())
+                               ? energySelectionImportance[idx]
                                : 0.0f;
         if (count == 0 && importance <= 0.0f)
           continue;

--- a/Nomad Path Tracer/Scene/Scene.h
+++ b/Nomad Path Tracer/Scene/Scene.h
@@ -55,6 +55,7 @@ struct ResidencyParameters {
   size_t energyMaxTogglesPerFrame = 32;
   float energyVisibilityBoost = 1.75f;
   float energyImportanceSmoothing = 0.85f;
+  bool energyUseAverageImportance = true;
 
   // Favor immediate view cues over historical hit data so residency reacts
   // quickly to camera motion.

--- a/Nomad Path Tracer/Scene/SceneLoader.cpp
+++ b/Nomad Path Tracer/Scene/SceneLoader.cpp
@@ -730,6 +730,9 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         root->FloatAttribute("energyVisibilityBoost", params.energyVisibilityBoost);
     params.energyImportanceSmoothing = root->FloatAttribute(
         "energyImportanceSmoothing", params.energyImportanceSmoothing);
+    params.energyUseAverageImportance =
+        root->BoolAttribute("energyUseAverageImportance",
+                            params.energyUseAverageImportance);
 
     params.unifiedEnergyWeight =
         root->FloatAttribute("unifiedEnergyWeight", params.unifiedEnergyWeight);


### PR DESCRIPTION
### Motivation
- Allow choosing whether energy-based residency uses per-object total importance or average-per-primitive importance to avoid biasing selection against large objects with many primitives.
- Make the behavior configurable so scenes can opt into the metric that best matches their workload.
- Preserve existing minimum-active constraints and mesh-group behavior while exposing the selection as a residency parameter.

### Description
- Added `energyUseAverageImportance` to `ResidencyParameters` with a default of `true` and wired it into scene XML parsing in `SceneLoader` (`Scene/Scene.h`, `Scene/SceneLoader.cpp`).
- Reworked the energy selection path in `Renderer::updateEnergyImportance` to compute an `energySelectionImportance` per-object that is either the smoothed total object importance or the average-per-primitive importance depending on the new flag and mesh-group state, and use that vector for sorting and target selection (`Renderer/Renderer.cpp`).
- Kept the existing fallback and minimum-active enforcement logic intact so `energyMinActivePrimitives` and related cooldown/toggle limits still apply unchanged.
- Left mesh-group aggregation logic unchanged and only apply the average-per-primitive option when `anyMeshGroups` is false.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a26634610832da9100cd23dbf4b07)