### PR TITLE
Add geometry residency memory cap and eviction

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -501,6 +501,15 @@ double Renderer::residencyMemoryMB() const {
   return _residencyBudget.residencyMemoryMB(totalMB);
 }
 
+double Renderer::residentGeometryMemoryMB() const {
+  size_t totalBytes = 0;
+  for (const auto &resident : _residentObjectGpuResources) {
+    if (resident.isResident() && resident.geometryValid)
+      totalBytes += resident.byteSize;
+  }
+  return static_cast<double>(totalBytes) / (1024.0 * 1024.0);
+}
+
 struct UniformsData {
   int primitiveIndex;
   simd::float3 cameraPosition;
@@ -574,6 +583,7 @@ size_t alignTo(size_t value, size_t alignment) {
 
 constexpr size_t kTextureResidencyPrimitiveBudget = 1;
 constexpr double kDefaultTextureResidencyMemoryCapMB = 2048.0;
+constexpr double kDefaultGeometryResidencyMemoryCapMB = 2048.0;
 constexpr size_t kMaxTextureHistoryBytes = 16ull * 1024ull * 1024ull;
 constexpr float kFrustumDebugNear = 0.1f;
 constexpr float kFrustumDebugFarMultiplier = 5.0f;
@@ -1468,8 +1478,8 @@ void Renderer::writeBenchmarkHeader() {
         "restir_candidate_acceptance,primitive_probabilities,"
          "object_probabilities,probabilistic_toggles,"
          "gpu_memory_mb,scratch_memory_mb,"
-         "residency_memory_mb,texture_memory_cap_mb,"
-         "over_memory_cap,residency_compacted,"
+         "residency_memory_mb,texture_memory_cap_mb,geometry_memory_cap_mb,"
+         "over_memory_cap,geometry_over_memory_cap,residency_compacted,"
          "accumulation_reset,ray_hit_decay,state_cooldown_frames,lod_toggle_budget,"
          "energy_toggle_budget,screen_toggle_budget,rayhit_toggle_budget,"
          "rayhit_target_fraction,rayhit_min_active,rayhit_rebuild_cooldown,"
@@ -1566,7 +1576,9 @@ void Renderer::writeBenchmarkRow(const BenchmarkSample &sample) {
       << formatFixed(sample.scratchMemoryMB, 3) << ','
       << formatFixed(sample.residencyMemoryMB, 3) << ','
       << formatFixed(sample.textureMemoryCapMB, 3) << ','
+      << formatFixed(sample.geometryMemoryCapMB, 3) << ','
       << boolToInt(sample.overMemoryCap) << ','
+      << boolToInt(sample.geometryOverMemoryCap) << ','
       << boolToInt(sample.residentCompacted) << ','
       << boolToInt(sample.accumulationReset) << ','
       << formatFixed(_residencyConfig.rayHitDecay, 3) << ','
@@ -2419,6 +2431,12 @@ void Renderer::updateVisibleScene() {
     _textureResidencyMemoryCapMB = kDefaultTextureResidencyMemoryCapMB;
   printf("Texture residency memory cap: %.1f MB\n",
          _textureResidencyMemoryCapMB);
+  _geometryResidencyMemoryCapMB =
+      std::max(_pScene->getGeometryResidencyMemoryCapMB(), 0.0);
+  if (_geometryResidencyMemoryCapMB <= 0.0)
+    _geometryResidencyMemoryCapMB = kDefaultGeometryResidencyMemoryCapMB;
+  printf("Geometry residency memory cap: %.1f MB\n",
+         _geometryResidencyMemoryCapMB);
   _residentCompacted = _pScene->getStartCompacted();
   _compactionCooldown = 0;
 
@@ -6223,6 +6241,77 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
     blit->endEncoding();
 }
 
+void Renderer::updateGeometryResidency(MTL::CommandBuffer *cmd) {
+  if (!cmd)
+    return;
+  if (_geometryResidencyMemoryCapMB <= 0.0)
+    return;
+
+  double residentMB = residentGeometryMemoryMB();
+  if (residentMB <= _geometryResidencyMemoryCapMB)
+    return;
+
+  std::printf("[GeometryResidency] Triggering eviction: residency=%.2f MB "
+              "(cap=%.2f MB).\n",
+              residentMB, _geometryResidencyMemoryCapMB);
+
+  struct GeometryCandidate {
+    size_t objectIndex = 0;
+    double score = 0.0;
+    double bytesMB = 0.0;
+  };
+
+  std::vector<GeometryCandidate> candidates;
+  candidates.reserve(_residentObjectGpuResources.size());
+  for (size_t objectIndex = 0; objectIndex < _residentObjectGpuResources.size();
+       ++objectIndex) {
+    const auto &resident = _residentObjectGpuResources[objectIndex];
+    if (!resident.isResident() || !resident.geometryValid)
+      continue;
+    if (objectIndex >= _instanceRecords.size())
+      continue;
+
+    double bytesMB =
+        static_cast<double>(resident.byteSize) / (1024.0 * 1024.0);
+    if (bytesMB <= 0.0)
+      continue;
+
+    uint64_t lastHitFrame = 0;
+    if (objectIndex < _objectHitLastFrame.size())
+      lastHitFrame = _objectHitLastFrame[objectIndex];
+    uint64_t frameAge =
+        _renderedFrameCount > lastHitFrame ? _renderedFrameCount - lastHitFrame
+                                           : 0;
+    double recency = 1.0 / (1.0 + static_cast<double>(frameAge));
+    bool active =
+        objectIndex < _objectActive.size() && _objectActive[objectIndex];
+    double score = recency / (1.0 + bytesMB);
+    if (active)
+      score += 1.0;
+
+    candidates.push_back({objectIndex, score, bytesMB});
+  }
+
+  std::sort(candidates.begin(), candidates.end(),
+            [](const GeometryCandidate &a, const GeometryCandidate &b) {
+              if (a.score == b.score)
+                return a.bytesMB > b.bytesMB;
+              return a.score < b.score;
+            });
+
+  for (const auto &candidate : candidates) {
+    if (residentMB <= _geometryResidencyMemoryCapMB)
+      break;
+    if (candidate.objectIndex >= _residentObjectGpuResources.size() ||
+        candidate.objectIndex >= _instanceRecords.size())
+      continue;
+    auto &resident = _residentObjectGpuResources[candidate.objectIndex];
+    requestResidentEviction(candidate.objectIndex, resident,
+                            _instanceRecords[candidate.objectIndex]);
+    residentMB = std::max(0.0, residentMB - candidate.bytesMB);
+  }
+}
+
 void Renderer::clearMaterialTextures() {
   for (MTL::Texture *texture : _materialTextures) {
     if (texture)
@@ -6734,8 +6823,13 @@ void Renderer::draw(MTK::View *pView) {
 
   bool belowBudget =
       _residentPrimitiveCount < kTextureResidencyPrimitiveBudget;
+  double geometryMemory = residentGeometryMemoryMB();
+  bool geometryOverCap = geometryMemory > _geometryResidencyMemoryCapMB;
   double contentMemory = residencyMemoryMB();
   bool overCap = contentMemory > _textureResidencyMemoryCapMB;
+
+  if (geometryOverCap)
+    updateGeometryResidency(prepCmd);
 
   if (!_needsAccumulationReset && (belowBudget || overCap))
     updateTextureResidency(prepCmd);
@@ -12335,6 +12429,8 @@ void Renderer::beginFrameMetrics() {
     sample.residencyMemoryMB =
         std::max(0.0, sample.gpuMemoryMB - sample.scratchMemoryMB);
     sample.textureMemoryCapMB = _textureResidencyMemoryCapMB;
+    sample.geometryMemoryCapMB = _geometryResidencyMemoryCapMB;
+    double geometryResidentMB = residentGeometryMemoryMB();
     sample.avgHitProbability = 0.0;
     sample.p95HitProbability = 0.0;
     sample.probabilityThreshold = _residencyConfig.probabilityThreshold;
@@ -12465,6 +12561,8 @@ void Renderer::beginFrameMetrics() {
     sample.residentCompacted = _residentCompacted;
     sample.overMemoryCap =
         sample.residencyMemoryMB > _textureResidencyMemoryCapMB;
+    sample.geometryOverMemoryCap =
+        geometryResidentMB > _geometryResidencyMemoryCapMB;
     _pendingBenchmarkSamples.push_back(std::move(sample));
   }
 }

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -182,6 +182,7 @@ private:
   void flushResidencyChanges(bool forceFullRebuild);
   void beginFrameMetrics();
   void completeFrameMetrics(MTL::CommandBuffer *pCmd);
+  double residentGeometryMemoryMB() const;
   std::vector<bool> buildResidentMaskFromGpuResources() const;
   void trackFrameCommandBuffer(MTL::CommandBuffer *commandBuffer);
   void recordPathTraceCommandTime(double gpuMs, size_t tileCount);
@@ -395,6 +396,7 @@ private:
     double scratchMemoryMB = 0.0;
     double residencyMemoryMB = 0.0;
     double textureMemoryCapMB = 0.0;
+    double geometryMemoryCapMB = 0.0;
     double deltaTimeSeconds = 0.0;
     double wallSeconds = 0.0;
     double cpuTimeSeconds = 0.0;
@@ -431,6 +433,7 @@ private:
     bool accumulationReset = false;
     bool residentCompacted = false;
     bool overMemoryCap = false;
+    bool geometryOverMemoryCap = false;
   };
 
   struct FrameCaptureRequest {
@@ -530,6 +533,7 @@ private:
   std::vector<size_t> _screenCoverageSortedIndices;
   float _totalPrimitiveImportance = 0.0f;
   double _textureResidencyMemoryCapMB = 2048.0;
+  double _geometryResidencyMemoryCapMB = 2048.0;
 
   std::vector<BlasInstanceRecord> _instanceRecords;
   std::vector<Primitive> _residentPrimitives;
@@ -694,6 +698,7 @@ private:
   void releaseTextureSlot(ManagedTextureSlot &slot);
   const char *textureSlotLabel(const ManagedTextureSlot &slot) const;
   void updateTextureResidency(MTL::CommandBuffer *cmd);
+  void updateGeometryResidency(MTL::CommandBuffer *cmd);
 };
 
 } // namespace NomadPathTracer

--- a/Nomad Path Tracer/Scene/Scene.cpp
+++ b/Nomad Path Tracer/Scene/Scene.cpp
@@ -88,6 +88,7 @@ void Scene::clear() {
   residencyParams = ResidencyParameters{};
   startCompacted = false;
   textureResidencyMemoryCapMB = 2048.0;
+  geometryResidencyMemoryCapMB = 2048.0;
   maxTileSampleWorkPerCommand = kDefaultMaxTileSampleWorkPerCommand;
   maxTileSampleWorkPerCommandSet = false;
   observerCameraValid = false;
@@ -280,6 +281,14 @@ double Scene::getTextureResidencyMemoryCapMB() const {
 
 void Scene::setTextureResidencyMemoryCapMB(double capMB) {
   textureResidencyMemoryCapMB = capMB;
+}
+
+double Scene::getGeometryResidencyMemoryCapMB() const {
+  return geometryResidencyMemoryCapMB;
+}
+
+void Scene::setGeometryResidencyMemoryCapMB(double capMB) {
+  geometryResidencyMemoryCapMB = capMB;
 }
 
 void Scene::setObserverCamera(const ObserverCamera &camera) {

--- a/Nomad Path Tracer/Scene/Scene.h
+++ b/Nomad Path Tracer/Scene/Scene.h
@@ -220,6 +220,8 @@ public:
 
   double getTextureResidencyMemoryCapMB() const;
   void setTextureResidencyMemoryCapMB(double capMB);
+  double getGeometryResidencyMemoryCapMB() const;
+  void setGeometryResidencyMemoryCapMB(double capMB);
 
   void buildBVH();
   size_t getBVHNodeCount() const;
@@ -282,6 +284,7 @@ private:
   ResidencyParameters residencyParams;
   bool startCompacted;
   double textureResidencyMemoryCapMB;
+  double geometryResidencyMemoryCapMB;
   size_t maxTileSampleWorkPerCommand;
   bool maxTileSampleWorkPerCommandSet;
   bool observerCameraValid;

--- a/Nomad Path Tracer/Scene/SceneLoader.cpp
+++ b/Nomad Path Tracer/Scene/SceneLoader.cpp
@@ -889,6 +889,10 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         "textureResidencyMemoryCapMB", scene->getTextureResidencyMemoryCapMB());
     scene->setTextureResidencyMemoryCapMB(textureCap);
 
+    double geometryCap = root->DoubleAttribute(
+        "geometryResidencyMemoryCapMB", scene->getGeometryResidencyMemoryCapMB());
+    scene->setGeometryResidencyMemoryCapMB(geometryCap);
+
     const char *environmentAttr = root->Attribute("environmentTexture");
     if (environmentAttr && environmentAttr[0]) {
         std::filesystem::path envPath(environmentAttr);

--- a/Nomad Path Tracer/lightwave_blender/exporter.py
+++ b/Nomad Path Tracer/lightwave_blender/exporter.py
@@ -18,6 +18,7 @@ _RESIDENCY_PRESETS: dict[str, dict] = {
         "strategy": "distance",
         "attributes": {
             "textureResidencyMemoryCapMB": 16,
+            "geometryResidencyMemoryCapMB": 16,
             "lodEnterDistance": 50,
             "lodExitDistance": 75,
             "residencyCooldown": 1,
@@ -28,6 +29,7 @@ _RESIDENCY_PRESETS: dict[str, dict] = {
         "strategy": "environment",
         "attributes": {
             "textureResidencyMemoryCapMB": 512,
+            "geometryResidencyMemoryCapMB": 512,
             "envTargetFraction": 0.78,
             "envEscapeThreshold": 0.18,
             "envMinActive": 150,
@@ -40,6 +42,7 @@ _RESIDENCY_PRESETS: dict[str, dict] = {
         "strategy": "predictive",
         "attributes": {
             "textureResidencyMemoryCapMB": 512,
+            "geometryResidencyMemoryCapMB": 512,
             "envTargetFraction": 0.72,
             "envEscapeThreshold": 0.16,
             "envMinActive": 150,
@@ -52,6 +55,7 @@ _RESIDENCY_PRESETS: dict[str, dict] = {
         "strategy": "probabilistic",
         "attributes": {
             "textureResidencyMemoryCapMB": 512,
+            "geometryResidencyMemoryCapMB": 512,
             "probabilityDecay": 0.92,
             "probabilityThreshold": 0.42,
             "probabilityMinActive": 150,
@@ -62,6 +66,7 @@ _RESIDENCY_PRESETS: dict[str, dict] = {
         "strategy": "unified",
         "attributes": {
             "textureResidencyMemoryCapMB": 512,
+            "geometryResidencyMemoryCapMB": 512,
             "unifiedEnergyWeight": 0.85,
             "unifiedHitWeight": 1.95,
             "unifiedCoverageWeight": 1.55,


### PR DESCRIPTION
### Motivation
- Provide a configurable memory cap for resident geometry similar to the existing texture residency cap so geometry BLAS can be pruned when GPU geometry residency grows too large.
- Trigger deterministic eviction of resident geometry objects when their summed resident GPU bytes exceed the cap to avoid unbounded geometry memory growth.
- Expose the geometry cap in scene files and exporter presets so user workflows can configure geometry residency limits alongside texture residency.

### Description
- Added scene parameter accessors and storage: `geometryResidencyMemoryCapMB` in `Scene` with initialization in `Scene::clear` and `get`/`set` methods in `Scene/Scene.h` and `Scene/Scene.cpp`, and XML parsing in `SceneLoader.cpp` to read `geometryResidencyMemoryCapMB` from scene files.
- Plumbed the cap into the renderer via a new member `_geometryResidencyMemoryCapMB` (default and printed on scene load) and set from the scene in renderer initialization in `Renderer.cpp`.
- Implemented `residentGeometryMemoryMB()` to compute current resident geometry memory by summing `ResidentObjectGpuResources::byteSize`, and added `updateGeometryResidency()` which scores resident geometry objects and requests eviction via the existing `requestResidentEviction`/`transitionResidentToCold` flow when the geometry cap is exceeded, in `Renderer.cpp` and declared in `Renderer.h`.
- Extended benchmarking and exporter: added `geometryMemoryCapMB` and `geometryOverMemoryCap` to `BenchmarkSample` and benchmark CSV header/row output in `Renderer.cpp`, and updated `lightwave_blender/exporter.py` residency presets to include `geometryResidencyMemoryCapMB` defaults.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4e323960832dab0fae7d2e9200be)