### PR TITLE
Add ReSTIR sampling toggle flag

### DIFF
--- a/Nomad Path Tracer/README.md
+++ b/Nomad Path Tracer/README.md
@@ -16,3 +16,11 @@ To keep ReSTIR temporal reuse stable for baseline comparisons, you can disable t
 
 - **Scene XML:** add `restirBaselineMode="true"` (or `restirBaseline="true"`) to the `<Scene>` root.
 - **Behavior:** no history eviction; maintains stable ReSTIR temporal reuse for baseline comparisons.
+
+## ReSTIR sampling toggle
+
+ReSTIR sampling can be enabled without changing the residency strategy, which is useful for A/B comparisons.
+
+- **Scene XML:** add `restirSampling="true"` (or `restirSamplingEnabled="true"`) to the `<Scene>` root.
+- **Behavior:** when enabled, ReSTIR sampling runs regardless of the configured residency strategy.
+- **Legacy scenes:** `residencyStrategy="restir"` still enables ReSTIR sampling automatically.

--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -2419,6 +2419,11 @@ void Renderer::updateVisibleScene() {
 
   _residencyConfig = _pScene->getResidencyParameters();
   _residencyConfig.normalizeEnvironmentDepthSettings();
+  if (_pScene->getResidencyStrategy() == ResidencyStrategy::ReSTIR &&
+      !_residencyConfig.restirSamplingEnabled) {
+    _residencyConfig.restirSamplingEnabled = true;
+    _pScene->setResidencyParameters(_residencyConfig);
+  }
   bool requiresCachedBlas =
       _pScene->getResidencyStrategy() != ResidencyStrategy::AlwaysResident;
   if (_residencyConfig.buildCachedBlas != requiresCachedBlas) {
@@ -7467,6 +7472,9 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   _frameRestirReuseRate = 0.0;
   _frameRestirCandidateAcceptance = 0.0;
   ResidencyStrategy strategy = _pScene->getResidencyStrategy();
+  bool restirSamplingActive = _residencyConfig.restirSamplingEnabled;
+  if (strategy == ResidencyStrategy::ReSTIR)
+    restirSamplingActive = true;
   if (strategy != _lastResidencyStrategy) {
     if (strategy == ResidencyStrategy::AlwaysResident) {
       _alwaysResidentCache.markDirty();
@@ -7475,7 +7483,7 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
     }
     _lastResidencyStrategy = strategy;
   }
-  _frameStrategy = strategy;
+  _frameStrategy = restirSamplingActive ? ResidencyStrategy::ReSTIR : strategy;
 
   for (uint32_t &cooldown : _primitiveCooldown)
     if (cooldown > 0)
@@ -7501,7 +7509,6 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
     changed = updateProbabilisticResidency(forceAllToggles);
     break;
   case ResidencyStrategy::ReSTIR:
-    changed = updateReSTIRResidency(forceAllToggles);
     break;
   case ResidencyStrategy::ScreenSpaceFootprint:
     changed = updateScreenSpaceFootprint(forceAllToggles);
@@ -7520,6 +7527,9 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
     changed = updateLODByDistance(forceAllToggles);
     break;
   }
+
+  if (restirSamplingActive)
+    changed |= updateReSTIRResidency(forceAllToggles);
 
   if (changed || forceFullRebuild)
     flushResidencyChanges(forceFullRebuild);

--- a/Nomad Path Tracer/Scene/Scene.h
+++ b/Nomad Path Tracer/Scene/Scene.h
@@ -99,6 +99,7 @@ struct ResidencyParameters {
   size_t restirCandidateCount = 4;
   size_t restirMaxTogglesPerFrame = 16;
   bool restirBaselineMode = false;
+  bool restirSamplingEnabled = false;
 
   float screenFootprintTargetFraction = 0.65f;
   float screenFootprintMinPixelCoverage = 32.0f;

--- a/Nomad Path Tracer/Scene/SceneLoader.cpp
+++ b/Nomad Path Tracer/Scene/SceneLoader.cpp
@@ -806,6 +806,10 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         "restirBaselineMode", params.restirBaselineMode);
     params.restirBaselineMode = root->BoolAttribute(
         "restirBaseline", params.restirBaselineMode);
+    params.restirSamplingEnabled = root->BoolAttribute(
+        "restirSampling", params.restirSamplingEnabled);
+    params.restirSamplingEnabled = root->BoolAttribute(
+        "restirSamplingEnabled", params.restirSamplingEnabled);
     params.probabilityIdleCooldownFrames = root->UnsignedAttribute(
         "probabilityIdleCooldownFrames", params.probabilityIdleCooldownFrames);
     params.probabilityIdleCooldownFrames = root->UnsignedAttribute(
@@ -879,6 +883,10 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         "bufferShrinkActiveRatio", params.bufferShrinkActiveRatio);
     params.buildCachedBlas = root->BoolAttribute(
         "buildCachedBlas", params.buildCachedBlas);
+
+    if (scene->getResidencyStrategy() == ResidencyStrategy::ReSTIR) {
+        params.restirSamplingEnabled = true;
+    }
 
     scene->setResidencyParameters(params);
 


### PR DESCRIPTION
### Motivation
- Make ReSTIR sampling configurable independently of the residency strategy so users can A/B compare sampling behavior without switching residency modes.
- Preserve legacy behavior where `residencyStrategy="restir"` still enables ReSTIR sampling automatically.

### Description
- Added a new flag `restirSamplingEnabled` to `ResidencyParameters` in `Scene/Scene.h` with a default of `false` and added XML parsing for `restirSampling` and `restirSamplingEnabled` in `Scene/SceneLoader.cpp`.
- Auto-enable `restirSamplingEnabled` when a scene uses `residencyStrategy="restir"` to keep backward compatibility with legacy scenes.
- Moved ReSTIR sampling execution out of the hard `ResidencyStrategy::ReSTIR` branch in `Renderer::updateResidency` so ReSTIR sampling is invoked when the new flag is set, and kept the legacy strategy path such that `ResidencyStrategy::ReSTIR` still results in ReSTIR sampling being active.
- Updated `README.md` to document the new `restirSampling`/`restirSamplingEnabled` scene XML attributes and clarify independent enabling and legacy behavior.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975412a7368832dac54f627039ebf7e)