### PR TITLE
Fix lambda capture for view check in Renderer

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -9031,7 +9031,7 @@ bool Renderer::updatePrimitiveScreenCoverageForFrame() {
   float horizontalHalfFov = std::atan(tanHalfFov * aspect);
 
   const auto coverageForSphere =
-      [screenArea, forward, right, horizontalHalfFov,
+      [this, screenArea, forward, right, horizontalHalfFov,
        tanHalfFov](const BoundingSphere &b) -> float {
     if (!isInView(b))
       return 0.0f;


### PR DESCRIPTION
### Motivation
- The sphere coverage lambda called the member `isInView` but did not capture `this`, which caused a compilation error.

### Description
- Capture `this` in the `coverageForSphere` lambda inside `Renderer::updatePrimitiveScreenCoverageForFrame` by changing the capture to `[this, screenArea, forward, right, horizontalHalfFov, tanHalfFov]` in `Nomad Path Tracer/Renderer/Renderer.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69754fbd1cd8832dbf35a9f9f2afc5d1)