### PR TITLE
Enforce geometry residency cap and defer BLAS allocations on cap hit

### DIFF
--- a/Nomad Path Tracer/README.md
+++ b/Nomad Path Tracer/README.md
@@ -25,6 +25,10 @@ ReSTIR sampling can be enabled without changing the residency strategy, which is
 - **Behavior:** when enabled, ReSTIR sampling runs regardless of the configured residency strategy.
 - **Legacy scenes:** `residencyStrategy="restir"` still enables ReSTIR sampling automatically.
 
+## Geometry residency memory cap
+
+The `geometryResidencyMemoryCapMB` scene parameter is now treated as a hard ceiling. Geometry residency allocations (including streaming uploads, prewarm passes, and rebuilds) are rejected if the next allocation would exceed the cap; the renderer queues the request and triggers eviction until enough space is available to retry.
+
 ## Bistro test scenes with ReSTIR sampling enabled
 
 The `scene_bistro_test_v2_*_restir_on.xml` variants mirror their corresponding bistro test scenes but explicitly enable ReSTIR sampling via `restirSampling="true"` on the `<Scene>` root. Use these for A/B comparisons that isolate the sampling toggle from other settings.

--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -502,12 +502,60 @@ double Renderer::residencyMemoryMB() const {
 }
 
 double Renderer::residentGeometryMemoryMB() const {
+  size_t totalBytes = residentGeometryMemoryBytes();
+  return static_cast<double>(totalBytes) / (1024.0 * 1024.0);
+}
+
+size_t Renderer::residentGeometryMemoryBytes() const {
   size_t totalBytes = 0;
   for (const auto &resident : _residentObjectGpuResources) {
-    if (resident.isResident() && resident.geometryValid)
+    if (resident.state != ResidentObjectGpuResources::ResidencyState::Cold)
       totalBytes += resident.byteSize;
   }
-  return static_cast<double>(totalBytes) / (1024.0 * 1024.0);
+  return totalBytes;
+}
+
+size_t Renderer::geometryResidencyCapBytes() const {
+  double capMB = std::max(0.0, _geometryResidencyMemoryCapMB);
+  return static_cast<size_t>(capMB * 1024.0 * 1024.0);
+}
+
+bool Renderer::checkGeometryResidencyCap(size_t objectIndex,
+                                         size_t requestedBytes,
+                                         size_t existingBytes,
+                                         const char *context) {
+  if (_geometryResidencyMemoryCapMB <= 0.0)
+    return true;
+
+  size_t capBytes = geometryResidencyCapBytes();
+  if (capBytes == 0)
+    return true;
+
+  size_t residentBytes = residentGeometryMemoryBytes();
+  size_t nextBytes = residentBytes >= existingBytes
+                         ? residentBytes - existingBytes + requestedBytes
+                         : residentBytes + requestedBytes;
+
+  if (nextBytes <= capBytes)
+    return true;
+
+  size_t overageBytes = nextBytes - capBytes;
+  _pendingGeometryResidencyOverageBytes =
+      std::max(_pendingGeometryResidencyOverageBytes, overageBytes);
+  ++_geometryResidencyCapHitCount;
+  ++_frameGeometryResidencyCapHitCount;
+
+  std::printf(
+      "[GeometryResidency] Cap hit for object %zu (%s): requested %.2f MB "
+      "(existing %.2f MB), resident %.2f MB, cap %.2f MB (over %.2f MB). "
+      "Deferring allocation and scheduling eviction.\n",
+      objectIndex, context ? context : "unspecified",
+      static_cast<double>(requestedBytes) / (1024.0 * 1024.0),
+      static_cast<double>(existingBytes) / (1024.0 * 1024.0),
+      static_cast<double>(residentBytes) / (1024.0 * 1024.0),
+      static_cast<double>(capBytes) / (1024.0 * 1024.0),
+      static_cast<double>(overageBytes) / (1024.0 * 1024.0));
+  return false;
 }
 
 struct UniformsData {
@@ -1479,7 +1527,7 @@ void Renderer::writeBenchmarkHeader() {
          "object_probabilities,probabilistic_toggles,"
          "gpu_memory_mb,scratch_memory_mb,"
          "residency_memory_mb,texture_memory_cap_mb,geometry_memory_cap_mb,"
-         "over_memory_cap,geometry_over_memory_cap,residency_compacted,"
+         "over_memory_cap,geometry_over_memory_cap,geometry_cap_hits,residency_compacted,"
          "accumulation_reset,ray_hit_decay,state_cooldown_frames,lod_toggle_budget,"
          "energy_toggle_budget,screen_toggle_budget,rayhit_toggle_budget,"
          "rayhit_target_fraction,rayhit_min_active,rayhit_rebuild_cooldown,"
@@ -1579,6 +1627,7 @@ void Renderer::writeBenchmarkRow(const BenchmarkSample &sample) {
       << formatFixed(sample.geometryMemoryCapMB, 3) << ','
       << boolToInt(sample.overMemoryCap) << ','
       << boolToInt(sample.geometryOverMemoryCap) << ','
+      << sample.geometryCapHitCount << ','
       << boolToInt(sample.residentCompacted) << ','
       << boolToInt(sample.accumulationReset) << ','
       << formatFixed(_residencyConfig.rayHitDecay, 3) << ','
@@ -3130,39 +3179,47 @@ void Renderer::processBlasBuildQueue() {
   if (!_pDevice || !_pCommandQueue)
     return;
 
+  size_t queueIterations = _pendingBlasBuilds.size();
   while (!_pendingBlasBuilds.empty() &&
-         _activeBlasBuilds.size() < kMaxBlasBuildsInFlight) {
+         _activeBlasBuilds.size() < kMaxBlasBuildsInFlight &&
+         queueIterations > 0) {
     auto buildRequest = _pendingBlasBuilds.front();
+    _pendingBlasBuilds.pop_front();
+    --queueIterations;
+
     if (buildRequest && buildRequest->resident &&
         buildRequest->resident->hasPendingCommands()) {
       std::printf(
           "[BLAS] Deferred queued build for object %zu: pending command buffer "
           "still in flight.\n",
           buildRequest->objectIndex);
-      _pendingBlasBuilds.pop_front();
       _pendingBlasBuilds.push_back(buildRequest);
-      break;
-    }
-    if (!startBlasBuild(buildRequest)) {
-      _pendingBlasBuilds.pop_front();
-      if (buildRequest && buildRequest->resident &&
-          buildRequest->objectIndex < _instanceRecords.size()) {
-        transitionResidentToCold(buildRequest->objectIndex,
-                                 *buildRequest->resident,
-                                 _instanceRecords[buildRequest->objectIndex]);
-      }
       continue;
     }
 
-    _pendingBlasBuilds.pop_front();
-    _activeBlasBuilds.push_back(buildRequest);
+    BlasBuildStartResult result = startBlasBuild(buildRequest);
+    if (result == BlasBuildStartResult::Started) {
+      _activeBlasBuilds.push_back(buildRequest);
+      continue;
+    }
+    if (result == BlasBuildStartResult::DeferredCap) {
+      _pendingBlasBuilds.push_back(buildRequest);
+      continue;
+    }
+
+    if (buildRequest && buildRequest->resident &&
+        buildRequest->objectIndex < _instanceRecords.size()) {
+      transitionResidentToCold(buildRequest->objectIndex,
+                               *buildRequest->resident,
+                               _instanceRecords[buildRequest->objectIndex]);
+    }
   }
 }
 
-bool Renderer::startBlasBuild(
+Renderer::BlasBuildStartResult Renderer::startBlasBuild(
     const std::shared_ptr<PendingBlasBuild> &buildRequest) {
   if (!buildRequest || !buildRequest->resident || !_pDevice || !_pCommandQueue)
-    return false;
+    return BlasBuildStartResult::Failed;
 
   auto &resident = *buildRequest->resident;
 
@@ -3189,7 +3246,7 @@ bool Renderer::startBlasBuild(
                           ->init();
   if (!geometryDesc) {
     cleanupPool();
-    return false;
+    return BlasBuildStartResult::Failed;
   }
   geometryDesc->setOpaque(true);
 
@@ -3204,7 +3261,7 @@ bool Renderer::startBlasBuild(
     if (accelDesc)
       accelDesc->release();
     cleanupPool();
-    return false;
+    return BlasBuildStartResult::Failed;
   }
 
   accelDesc->setGeometryDescriptors(geometryArray);
@@ -3217,10 +3274,18 @@ bool Renderer::startBlasBuild(
   MTL::Buffer *vertexBuffer = nullptr;
   MTL::Buffer *indexBuffer = nullptr;
 
+  bool capDenied = false;
   auto requestGeometryBuffers = [&]() -> bool {
     NS::UInteger initialHeapBytes = alignedVertexSize + alignedIndexSize;
-    if (initialHeapBytes > 0)
+    if (initialHeapBytes > 0) {
+      if (!checkGeometryResidencyCap(buildRequest->objectIndex,
+                                     static_cast<size_t>(initialHeapBytes),
+                                     resident.byteSize, "initial buffers")) {
+        capDenied = true;
+        return false;
+      }
       resident.resources.ensureHeapCapacity(initialHeapBytes);
+    }
 
     vertexBuffer = resident.resources.ensureVertexBuffer(vertexBytes,
                                                         vertexLabel.c_str());
@@ -3234,7 +3299,8 @@ bool Renderer::startBlasBuild(
     geometryDesc->release();
     accelDesc->release();
     cleanupPool();
-    return false;
+    return capDenied ? BlasBuildStartResult::DeferredCap
+                     : BlasBuildStartResult::Failed;
   }
 
   auto configureGeometryDescriptor = [&]() {
@@ -3272,6 +3338,15 @@ bool Renderer::startBlasBuild(
 
     if (requiredTotal > totalHeapBytes) {
       totalHeapBytes = requiredTotal;
+      if (!checkGeometryResidencyCap(buildRequest->objectIndex,
+                                     static_cast<size_t>(totalHeapBytes),
+                                     resident.byteSize, "heap resize")) {
+        geometryArray->release();
+        geometryDesc->release();
+        accelDesc->release();
+        cleanupPool();
+        return BlasBuildStartResult::DeferredCap;
+      }
       resident.resources.ensureHeapCapacity(totalHeapBytes);
 
       if (!requestGeometryBuffers()) {
@@ -3279,7 +3354,8 @@ bool Renderer::startBlasBuild(
         geometryDesc->release();
         accelDesc->release();
         cleanupPool();
-        return false;
+        return capDenied ? BlasBuildStartResult::DeferredCap
+                         : BlasBuildStartResult::Failed;
       }
       continue;
     }
@@ -3298,7 +3374,7 @@ bool Renderer::startBlasBuild(
     geometryDesc->release();
     accelDesc->release();
     cleanupPool();
-    return false;
+    return BlasBuildStartResult::Failed;
   }
 
   MTL::Buffer *vertexStaging = nullptr;
@@ -3332,7 +3408,7 @@ bool Renderer::startBlasBuild(
     geometryDesc->release();
     accelDesc->release();
     cleanupPool();
-    return false;
+    return BlasBuildStartResult::Failed;
   }
 
   NS::UInteger requestedScratchSize = sizes.buildScratchBufferSize;
@@ -3354,7 +3430,7 @@ bool Renderer::startBlasBuild(
       geometryDesc->release();
       accelDesc->release();
       cleanupPool();
-      return false;
+      return BlasBuildStartResult::Failed;
     }
 
     buildRequest->scratchBuffer = scratchBuffer;
@@ -3377,7 +3453,7 @@ bool Renderer::startBlasBuild(
     geometryDesc->release();
     accelDesc->release();
     cleanupPool();
-    return false;
+    return BlasBuildStartResult::Failed;
   }
 
   MTL::BlitCommandEncoder *blitEncoder = nullptr;
@@ -3412,7 +3488,7 @@ bool Renderer::startBlasBuild(
     geometryDesc->release();
     accelDesc->release();
     cleanupPool();
-    return false;
+    return BlasBuildStartResult::Failed;
   }
 
   asEncoder->buildAccelerationStructure(accelerationStructure, accelDesc,
@@ -3445,11 +3521,11 @@ bool Renderer::startBlasBuild(
     resident.clearPendingCommand();
     buildRequest->releaseResources();
     cleanupPool();
-    return false;
+    return BlasBuildStartResult::Failed;
   }
 
   cleanupPool();
-  return true;
+  return BlasBuildStartResult::Started;
 }
 
 void Renderer::handleCompletedBlasBuild(
@@ -6404,13 +6480,37 @@ void Renderer::updateGeometryResidency(MTL::CommandBuffer *cmd) {
   if (_geometryResidencyMemoryCapMB <= 0.0)
     return;
 
-  double residentMB = residentGeometryMemoryMB();
-  if (residentMB <= _geometryResidencyMemoryCapMB)
-    return;
+  size_t capBytes = geometryResidencyCapBytes();
+  size_t residentBytes = residentGeometryMemoryBytes();
+  size_t targetBytes = capBytes;
+  if (_pendingGeometryResidencyOverageBytes > 0) {
+    if (capBytes > _pendingGeometryResidencyOverageBytes)
+      targetBytes = capBytes - _pendingGeometryResidencyOverageBytes;
+    else
+      targetBytes = 0;
+  }
 
-  std::printf("[GeometryResidency] Triggering eviction: residency=%.2f MB "
-              "(cap=%.2f MB).\n",
-              residentMB, _geometryResidencyMemoryCapMB);
+  if (residentBytes <= targetBytes) {
+    if (_pendingGeometryResidencyOverageBytes > 0)
+      _pendingGeometryResidencyOverageBytes = 0;
+    return;
+  }
+
+  double residentMB =
+      static_cast<double>(residentBytes) / (1024.0 * 1024.0);
+  double capMB = static_cast<double>(capBytes) / (1024.0 * 1024.0);
+  double targetMB = static_cast<double>(targetBytes) / (1024.0 * 1024.0);
+
+  if (_pendingGeometryResidencyOverageBytes > 0) {
+    std::printf(
+        "[GeometryResidency] Triggering eviction: residency=%.2f MB (cap=%.2f "
+        "MB, target=%.2f MB) to satisfy pending allocation.\n",
+        residentMB, capMB, targetMB);
+  } else {
+    std::printf("[GeometryResidency] Triggering eviction: residency=%.2f MB "
+                "(cap=%.2f MB).\n",
+                residentMB, capMB);
+  }
 
   struct GeometryCandidate {
     size_t objectIndex = 0;
@@ -6457,7 +6557,7 @@ void Renderer::updateGeometryResidency(MTL::CommandBuffer *cmd) {
             });
 
   for (const auto &candidate : candidates) {
-    if (residentMB <= _geometryResidencyMemoryCapMB)
+    if (residentBytes <= targetBytes)
       break;
     if (candidate.objectIndex >= _residentObjectGpuResources.size() ||
         candidate.objectIndex >= _instanceRecords.size())
@@ -6465,8 +6565,16 @@ void Renderer::updateGeometryResidency(MTL::CommandBuffer *cmd) {
     auto &resident = _residentObjectGpuResources[candidate.objectIndex];
     requestResidentEviction(candidate.objectIndex, resident,
                             _instanceRecords[candidate.objectIndex]);
-    residentMB = std::max(0.0, residentMB - candidate.bytesMB);
+    double candidateBytes =
+        candidate.bytesMB * (1024.0 * 1024.0);
+    residentBytes =
+        residentBytes > static_cast<size_t>(candidateBytes)
+            ? residentBytes - static_cast<size_t>(candidateBytes)
+            : 0;
   }
+
+  if (residentBytes <= targetBytes)
+    _pendingGeometryResidencyOverageBytes = 0;
 }
 
 void Renderer::clearMaterialTextures() {
@@ -6985,7 +7093,7 @@ void Renderer::draw(MTK::View *pView) {
   double contentMemory = residencyMemoryMB();
   bool overCap = contentMemory > _textureResidencyMemoryCapMB;
 
-  if (geometryOverCap)
+  if (geometryOverCap || _pendingGeometryResidencyOverageBytes > 0)
     updateGeometryResidency(prepCmd);
 
   if (!_needsAccumulationReset && (belowBudget || overCap))
@@ -7469,6 +7577,7 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   _frameProbabilisticToggles = 0;
   _frameScreenMinPixelCoverageSkips = 0;
   _frameEnvironmentActivationFloor = 0;
+  _frameGeometryResidencyCapHitCount = 0;
   _frameRestirReuseRate = 0.0;
   _frameRestirCandidateAcceptance = 0.0;
   ResidencyStrategy strategy = _pScene->getResidencyStrategy();
@@ -12730,6 +12839,7 @@ void Renderer::beginFrameMetrics() {
         sample.residencyMemoryMB > _textureResidencyMemoryCapMB;
     sample.geometryOverMemoryCap =
         geometryResidentMB > _geometryResidencyMemoryCapMB;
+    sample.geometryCapHitCount = _frameGeometryResidencyCapHitCount;
     _pendingBenchmarkSamples.push_back(std::move(sample));
   }
 }

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -184,6 +184,11 @@ private:
   void beginFrameMetrics();
   void completeFrameMetrics(MTL::CommandBuffer *pCmd);
   double residentGeometryMemoryMB() const;
+  size_t residentGeometryMemoryBytes() const;
+  size_t geometryResidencyCapBytes() const;
+  bool checkGeometryResidencyCap(size_t objectIndex, size_t requestedBytes,
+                                 size_t existingBytes,
+                                 const char *context);
   std::vector<bool> buildResidentMaskFromGpuResources() const;
   void trackFrameCommandBuffer(MTL::CommandBuffer *commandBuffer);
   void recordPathTraceCommandTime(double gpuMs, size_t tileCount);
@@ -217,7 +222,9 @@ private:
   struct PendingBlasBuild;
   void enqueueBlasBuild(const std::shared_ptr<PendingBlasBuild> &buildRequest);
   void processBlasBuildQueue();
-  bool startBlasBuild(const std::shared_ptr<PendingBlasBuild> &buildRequest);
+  enum class BlasBuildStartResult { Started, DeferredCap, Failed };
+  BlasBuildStartResult startBlasBuild(
+      const std::shared_ptr<PendingBlasBuild> &buildRequest);
   void handleCompletedBlasBuild(
       const std::shared_ptr<PendingBlasBuild> &buildRequest, bool success);
   void requestResidentEviction(size_t objectIndex,
@@ -435,6 +442,7 @@ private:
     bool residentCompacted = false;
     bool overMemoryCap = false;
     bool geometryOverMemoryCap = false;
+    size_t geometryCapHitCount = 0;
   };
 
   struct FrameCaptureRequest {
@@ -661,6 +669,9 @@ private:
   bool _frameProbabilityBudgetHit = false;
   size_t _frameScreenMinPixelCoverageSkips = 0;
   size_t _frameEnvironmentActivationFloor = 0;
+  size_t _frameGeometryResidencyCapHitCount = 0;
+  size_t _geometryResidencyCapHitCount = 0;
+  size_t _pendingGeometryResidencyOverageBytes = 0;
   ResidencyStrategy _frameStrategy = ResidencyStrategy::DistanceLOD;
   ResidencyStrategy _lastResidencyStrategy = ResidencyStrategy::DistanceLOD;
   AlwaysResidentCache _alwaysResidentCache;


### PR DESCRIPTION
### Motivation
- Prevent geometry residency allocations (BLAS heaps, vertex/index buffers, streaming builds) from exceeding the configured `geometryResidencyMemoryCapMB` hard ceiling.
- Make geometry-related allocations deterministic by routing all BLAS build/heap requests through a single cap check and ensure the renderer evicts or defers work when the cap would be exceeded.
- Expose cap hits in runtime metrics/logging so users can see when allocations are blocked by the hard limit and understand eviction activity.

### Description
- Added a centralized cap guard and helpers: `residentGeometryMemoryBytes()`, `geometryResidencyCapBytes()` and `checkGeometryResidencyCap(...)` in `Renderer` (added to `Renderer.h` and implemented in `Renderer.cpp`) to compute next allocation size and deny allocations that would exceed the cap.
- Made BLAS build startup deterministic: replaced `startBlasBuild` boolean result with `BlasBuildStartResult { Started, DeferredCap, Failed }`, and updated `processBlasBuildQueue` to handle `DeferredCap` by queuing the build for retry instead of proceeding or failing immediately.
- Integrated cap checks into BLAS build paths: initial heap/buffer requests and heap-resize logic in `startBlasBuild` now call `checkGeometryResidencyCap(...)` and return `DeferredCap` when the next allocation would exceed the cap, deferring the build and scheduling eviction.
- Eviction behavior updated: `updateGeometryResidency` now accounts for a pending overage (`_pendingGeometryResidencyOverageBytes`) and computes a target resident footprint to achieve before retrying allocations; cap hits set this pending overage and trigger eviction scheduling.
- Metrics and logging: added cap hit counters (`_frameGeometryResidencyCapHitCount`, `_geometryResidencyCapHitCount`) and a `geometryCapHitCount` column to benchmark samples/CSV output and the metrics header, and added `std::printf` messages when the cap blocks an allocation and when eviction is triggered to satisfy pending allocations.
- Documentation: updated `Nomad Path Tracer/README.md` to clarify that `geometryResidencyMemoryCapMB` is now treated as a hard ceiling and that allocations will be rejected/deferred and eviction will be attempted.
- Files changed: `Nomad Path Tracer/Renderer/Renderer.cpp`, `Nomad Path Tracer/Renderer/Renderer.h`, `Nomad Path Tracer/README.md`.

### Testing
- No automated tests were run as part of this change; manual validation was not requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69755d99bd50832d9ee727f4ce4d44c9)