### PR TITLE
Use `constant` address space for material texture sampler

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -12,7 +12,7 @@ constant uint kMaterialFloat4Count = 5;
 constant uint kPrimitiveFloat4Count = 7;
 constant uint kMaxMaterialTextures = 64;
 
-constexpr sampler kMaterialTextureSampler(address::repeat, filter::linear);
+constant sampler kMaterialTextureSampler(address::repeat, filter::linear);
 
 struct PathTraceSample {
   float3 radiance;


### PR DESCRIPTION
### Motivation
- Ensure the program-scope sampler is declared in the `constant` address space to match Metal address-space requirements and avoid invalid `constexpr` usage at global scope.

### Description
- Replace `constexpr sampler kMaterialTextureSampler(address::repeat, filter::linear);` with `constant sampler kMaterialTextureSampler(address::repeat, filter::linear);` in `Nomad Path Tracer/Renderer/Shaders/PathTracing.h` while keeping the sampler symbol unchanged so existing call sites continue to reference `kMaterialTextureSampler`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697579af1c54832d80710ac6602599fa)