### PR TITLE
Add forward declarations for BVH helper functions

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -196,6 +196,27 @@ struct RestirEvaluation {
   bool valid;
 };
 
+inline bool intersectAABB(thread const Ray &r, float3 bmin, float3 bmax,
+                          float tMin, float tMax);
+inline intersection firstHitBVH(thread const Ray &r,
+                                device const float4 *bvhNodes,
+                                device const float4 *primitives,
+                                device const int *primitiveIndices,
+                                device const uchar *activeMask,
+                                device const uint *primitiveRemap,
+                                uint residentPrimitiveCount,
+                                uint totalPrimitiveCount,
+                                device atomic_uint *primitiveRayStats,
+                                int startNode);
+inline intersection firstHitTLAS(
+    thread const Ray &r, device const float4 *tlasNodes, uint tlasNodeCount,
+    device const float4 *bvhNodes, device const float4 *primitives,
+    device const int *primitiveIndices, device const uchar *activeMask,
+    device const InstanceRecord *instanceRecords,
+    device const uint *primitiveRemap, uint residentPrimitiveCount,
+    uint totalPrimitiveCount, device atomic_uint *primitiveRayStats,
+    thread TlasLeafCache *cache);
+
 inline RestirEvaluation evaluateLightCandidate(
     uint lightOffset, uint lightPrimIndex, float3 lightPoint,
     float3 lightNormal, float area, float3 offsetNormal,


### PR DESCRIPTION
### Motivation
- Resolve a usage-before-definition ordering problem by making the BVH/TLAS helper signatures visible at their first call site. 
- Ensure the declarations exactly match the later definitions so the compiler sees correct signatures and to avoid potential compilation errors.

### Description
- Added a forward declaration for `intersectAABB` in `Nomad Path Tracer/Renderer/Shaders/PathTracing.h` above the first call site. 
- Added a forward declaration for `firstHitBVH` with the exact signature used by its later definition. 
- Added a forward declaration for `firstHitTLAS` with the exact signature used by its later definition and placed the three declarations above `evaluateLightCandidate`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69757a3580a4832db4d22a5f670ab366)