### PR TITLE
Use constant address space for ReSTIR candidate count

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -20,7 +20,7 @@ struct PathTraceSample {
   float3 normal;
 };
 
-constexpr uint kRestirCandidateCount = 4;
+constant uint kRestirCandidateCount = 4;
 
 struct RestirSampleData {
   float3 position;


### PR DESCRIPTION
### Motivation
- Ensure the ReSTIR candidate count uses the Metal constant address space consistent with nearby shader constants by replacing the C++-style `constexpr` with the shader `constant` qualifier.

### Description
- Replace the declaration in `Nomad Path Tracer/Renderer/Shaders/PathTracing.h` from `constexpr uint kRestirCandidateCount = 4;` to `constant uint kRestirCandidateCount = 4;`.

### Testing
- No automated tests or CI were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69757b767e40832d8585297fccdf38f8)