### PR TITLE
Enforce geometry residency hard cap

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -520,6 +520,22 @@ size_t Renderer::geometryResidencyCapBytes() const {
   return static_cast<size_t>(capMB * 1024.0 * 1024.0);
 }
 
+void Renderer::recordGeometryResidencyHardCapDenied(
+    size_t objectIndex, size_t requestedBytes, size_t existingBytes,
+    size_t residentBytes, size_t capBytes, const char *context) {
+  ++_geometryResidencyHardCapDeniedCount;
+  ++_frameGeometryResidencyHardCapDeniedCount;
+
+  std::printf(
+      "[GeometryResidency] Hard cap deny for object %zu (%s): requested %.2f MB "
+      "(existing %.2f MB), resident %.2f MB, cap %.2f MB.\n",
+      objectIndex, context ? context : "unspecified",
+      static_cast<double>(requestedBytes) / (1024.0 * 1024.0),
+      static_cast<double>(existingBytes) / (1024.0 * 1024.0),
+      static_cast<double>(residentBytes) / (1024.0 * 1024.0),
+      static_cast<double>(capBytes) / (1024.0 * 1024.0));
+}
+
 bool Renderer::checkGeometryResidencyCap(size_t objectIndex,
                                          size_t requestedBytes,
                                          size_t existingBytes,
@@ -545,16 +561,12 @@ bool Renderer::checkGeometryResidencyCap(size_t objectIndex,
   ++_geometryResidencyCapHitCount;
   ++_frameGeometryResidencyCapHitCount;
 
-  std::printf(
-      "[GeometryResidency] Cap hit for object %zu (%s): requested %.2f MB "
-      "(existing %.2f MB), resident %.2f MB, cap %.2f MB (over %.2f MB). "
-      "Deferring allocation and scheduling eviction.\n",
-      objectIndex, context ? context : "unspecified",
-      static_cast<double>(requestedBytes) / (1024.0 * 1024.0),
-      static_cast<double>(existingBytes) / (1024.0 * 1024.0),
-      static_cast<double>(residentBytes) / (1024.0 * 1024.0),
-      static_cast<double>(capBytes) / (1024.0 * 1024.0),
-      static_cast<double>(overageBytes) / (1024.0 * 1024.0));
+  recordGeometryResidencyHardCapDenied(objectIndex, requestedBytes,
+                                       existingBytes, residentBytes, capBytes,
+                                       context);
+  std::printf("  [GeometryResidency] Over cap by %.2f MB; deferring allocation "
+              "and scheduling eviction.\n",
+              static_cast<double>(overageBytes) / (1024.0 * 1024.0));
   return false;
 }
 
@@ -1531,7 +1543,8 @@ void Renderer::writeBenchmarkHeader() {
          "object_probabilities,probabilistic_toggles,"
          "gpu_memory_mb,scratch_memory_mb,"
          "residency_memory_mb,texture_memory_cap_mb,geometry_memory_cap_mb,"
-         "over_memory_cap,geometry_over_memory_cap,geometry_cap_hits,residency_compacted,"
+         "over_memory_cap,geometry_over_memory_cap,geometry_cap_hits,"
+         "geometry_hard_cap_denials,residency_compacted,"
          "accumulation_reset,ray_hit_decay,state_cooldown_frames,lod_toggle_budget,"
          "energy_toggle_budget,screen_toggle_budget,rayhit_toggle_budget,"
          "rayhit_target_fraction,rayhit_min_active,rayhit_rebuild_cooldown,"
@@ -1628,6 +1641,7 @@ void Renderer::writeBenchmarkRow(const BenchmarkSample &sample) {
       << boolToInt(sample.overMemoryCap) << ','
       << boolToInt(sample.geometryOverMemoryCap) << ','
       << sample.geometryCapHitCount << ','
+      << sample.geometryHardCapDeniedCount << ','
       << boolToInt(sample.residentCompacted) << ','
       << boolToInt(sample.accumulationReset) << ','
       << formatFixed(_residencyConfig.rayHitDecay, 3) << ','
@@ -5191,10 +5205,34 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     }
   }
 
+  size_t geometryCapBytes = geometryResidencyCapBytes();
+  size_t projectedResidentBytes = residentGeometryMemoryBytes();
+  bool geometryHardCapEnabled =
+      _geometryResidencyMemoryCapMB > 0.0 && geometryCapBytes > 0;
+  bool geometryHardCapReached = _pendingGeometryResidencyOverageBytes > 0;
+
   for (size_t objectIndex = 0; objectIndex < sceneObjects.size(); ++objectIndex) {
     bool shouldBeResident = objectShouldBeResident[objectIndex];
     auto &gpuResident = _residentObjectGpuResources[objectIndex];
     auto &instanceRecord = _instanceRecords[objectIndex];
+
+    if (geometryHardCapEnabled && shouldBeResident &&
+        gpuResident.state ==
+            ResidentObjectGpuResources::ResidencyState::Cold) {
+      bool projectedOverCap = geometryHardCapReached ||
+                              projectedResidentBytes >= geometryCapBytes ||
+                              _pendingGeometryResidencyOverageBytes > 0;
+      if (projectedOverCap) {
+        recordGeometryResidencyHardCapDenied(objectIndex, 0, 0,
+                                             projectedResidentBytes,
+                                             geometryCapBytes,
+                                             "residency update");
+        shouldBeResident = false;
+        objectShouldBeResident[objectIndex] = false;
+        instanceRecord.blasRootIndex = -1;
+        geometryHardCapReached = true;
+      }
+    }
 
     if (shouldBeResident) {
       bool built = gpuResident.ensureResident(
@@ -6540,11 +6578,11 @@ void Renderer::updateGeometryResidency(MTL::CommandBuffer *cmd) {
 
   if (_pendingGeometryResidencyOverageBytes > 0) {
     std::printf(
-        "[GeometryResidency] Triggering eviction: residency=%.2f MB (cap=%.2f "
+        "[GeometryResidency] Over budget eviction: residency=%.2f MB (cap=%.2f "
         "MB, target=%.2f MB) to satisfy pending allocation.\n",
         residentMB, capMB, targetMB);
   } else {
-    std::printf("[GeometryResidency] Triggering eviction: residency=%.2f MB "
+    std::printf("[GeometryResidency] Over budget eviction: residency=%.2f MB "
                 "(cap=%.2f MB).\n",
                 residentMB, capMB);
   }
@@ -7691,6 +7729,7 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   _frameScreenMinPixelCoverageSkips = 0;
   _frameEnvironmentActivationFloor = 0;
   _frameGeometryResidencyCapHitCount = 0;
+  _frameGeometryResidencyHardCapDeniedCount = 0;
   _frameRestirReuseRate = 0.0;
   _frameRestirCandidateAcceptance = 0.0;
   ResidencyStrategy strategy = _pScene->getResidencyStrategy();
@@ -12635,6 +12674,8 @@ void Renderer::beginFrameMetrics() {
     sample.geometryOverMemoryCap =
         geometryResidentMB > _geometryResidencyMemoryCapMB;
     sample.geometryCapHitCount = _frameGeometryResidencyCapHitCount;
+    sample.geometryHardCapDeniedCount =
+        _frameGeometryResidencyHardCapDeniedCount;
     _pendingBenchmarkSamples.push_back(std::move(sample));
   }
 }

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -185,6 +185,12 @@ private:
   double residentGeometryMemoryMB() const;
   size_t residentGeometryMemoryBytes() const;
   size_t geometryResidencyCapBytes() const;
+  void recordGeometryResidencyHardCapDenied(size_t objectIndex,
+                                            size_t requestedBytes,
+                                            size_t existingBytes,
+                                            size_t residentBytes,
+                                            size_t capBytes,
+                                            const char *context);
   bool checkGeometryResidencyCap(size_t objectIndex, size_t requestedBytes,
                                  size_t existingBytes,
                                  const char *context);
@@ -446,6 +452,7 @@ private:
     bool overMemoryCap = false;
     bool geometryOverMemoryCap = false;
     size_t geometryCapHitCount = 0;
+    size_t geometryHardCapDeniedCount = 0;
   };
 
   struct FrameCaptureRequest {
@@ -669,7 +676,9 @@ private:
   size_t _frameScreenMinPixelCoverageSkips = 0;
   size_t _frameEnvironmentActivationFloor = 0;
   size_t _frameGeometryResidencyCapHitCount = 0;
+  size_t _frameGeometryResidencyHardCapDeniedCount = 0;
   size_t _geometryResidencyCapHitCount = 0;
+  size_t _geometryResidencyHardCapDeniedCount = 0;
   size_t _pendingGeometryResidencyOverageBytes = 0;
   ResidencyStrategy _frameStrategy = ResidencyStrategy::DistanceLOD;
   ResidencyStrategy _lastResidencyStrategy = ResidencyStrategy::DistanceLOD;


### PR DESCRIPTION
### Motivation
- Prevent new geometry residency loads/uploads from being scheduled when projected resident geometry memory would exceed the configured cap and provide clearer metrics/logging for hard denials versus over-budget evictions.

### Description
- Added a new helper `recordGeometryResidencyHardCapDenied` and counters (`_geometryResidencyHardCapDeniedCount`, `_frameGeometryResidencyHardCapDeniedCount`) to track and log hard-cap denials.  The recording function emits a clear message and increments metrics.
- Updated `checkGeometryResidencyCap` to call `recordGeometryResidencyHardCapDenied` on cap hits and to clarify the printf output so that the original message distinguishes the hard-deny vs over-budget behavior. 
- Added a pre-check in `rebuildResidentResources` that prevents scheduling cold objects to become resident when the projected resident geometry memory would exceed the cap, and marks instance state consistent (clears `blasRootIndex` and avoids enqueueing residency). 
- Updated geometry eviction logging in `updateGeometryResidency` to use "Over budget eviction" wording and extended benchmark/CSV output and `BenchmarkSample` to include `geometry_hard_cap_denials` and to reset/report the per-frame hard-denial counter (`_frameGeometryResidencyHardCapDeniedCount`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697581199390832da6fb2163e9711379)