### PR TITLE
Add configurable soft total GPU memory cap and benchmark metrics

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -689,6 +689,7 @@ size_t alignTo(size_t value, size_t alignment) {
 constexpr size_t kTextureResidencyPrimitiveBudget = 1;
 constexpr double kDefaultTextureResidencyMemoryCapMB = 2048.0;
 constexpr double kDefaultGeometryResidencyMemoryCapMB = 2048.0;
+constexpr double kDefaultTotalGpuMemoryCapMB = 4096.0;
 constexpr size_t kMaxTextureHistoryBytes = 16ull * 1024ull * 1024ull;
 constexpr float kFrustumDebugNear = 0.1f;
 constexpr float kFrustumDebugFarMultiplier = 5.0f;
@@ -1587,7 +1588,8 @@ void Renderer::writeBenchmarkHeader() {
          "object_probabilities,probabilistic_toggles,"
          "gpu_memory_mb,scratch_memory_mb,resident_geometry_memory_mb,"
          "residency_memory_mb,texture_memory_cap_mb,geometry_memory_cap_mb,"
-         "over_memory_cap,geometry_over_memory_cap,geometry_cap_hits,"
+         "total_memory_cap_mb,over_memory_cap,geometry_over_memory_cap,"
+         "total_over_memory_cap,total_memory_overage_warnings,geometry_cap_hits,"
          "geometry_hard_cap_denials,residency_compacted,"
          "accumulation_reset,ray_hit_decay,state_cooldown_frames,lod_toggle_budget,"
          "energy_toggle_budget,screen_toggle_budget,rayhit_toggle_budget,"
@@ -1683,8 +1685,11 @@ void Renderer::writeBenchmarkRow(const BenchmarkSample &sample) {
       << formatFixed(sample.residencyMemoryMB, 3) << ','
       << formatFixed(sample.textureMemoryCapMB, 3) << ','
       << formatFixed(sample.geometryMemoryCapMB, 3) << ','
+      << formatFixed(sample.totalMemoryCapMB, 3) << ','
       << boolToInt(sample.overMemoryCap) << ','
       << boolToInt(sample.geometryOverMemoryCap) << ','
+      << boolToInt(sample.totalOverMemoryCap) << ','
+      << sample.totalMemoryOverageWarnings << ','
       << sample.geometryCapHitCount << ','
       << sample.geometryHardCapDeniedCount << ','
       << boolToInt(sample.residentCompacted) << ','
@@ -2545,6 +2550,10 @@ void Renderer::updateVisibleScene() {
     _geometryResidencyMemoryCapMB = kDefaultGeometryResidencyMemoryCapMB;
   printf("Geometry residency memory cap: %.1f MB\n",
          _geometryResidencyMemoryCapMB);
+  _totalGpuMemoryCapMB = std::max(_pScene->getTotalGpuMemoryCapMB(), 0.0);
+  if (_totalGpuMemoryCapMB <= 0.0)
+    _totalGpuMemoryCapMB = kDefaultTotalGpuMemoryCapMB;
+  printf("Total GPU memory soft cap: %.1f MB\n", _totalGpuMemoryCapMB);
   _residentCompacted = _pScene->getStartCompacted();
   _compactionCooldown = 0;
 
@@ -7253,11 +7262,23 @@ void Renderer::draw(MTK::View *pView) {
   bool geometryOverCap = geometryMemory > _geometryResidencyMemoryCapMB;
   double contentMemory = residencyMemoryMB();
   bool overCap = contentMemory > _textureResidencyMemoryCapMB;
+  double totalMemoryMB = currentGPUMemoryMB();
+  bool totalOverCap = _totalGpuMemoryCapMB > 0.0 &&
+                      totalMemoryMB > _totalGpuMemoryCapMB;
 
-  if (geometryOverCap || _pendingGeometryResidencyOverageBytes > 0)
+  if (totalOverCap) {
+    ++_frameTotalMemoryOverageWarnings;
+    std::printf(
+        "[MemoryBudget] Total GPU memory over soft cap: total=%.3f MB "
+        "cap=%.3f MB (residency=%.3f MB, scratch=%.3f MB)\n",
+        totalMemoryMB, _totalGpuMemoryCapMB, contentMemory, scratchMemoryMB());
+  }
+
+  if (geometryOverCap || _pendingGeometryResidencyOverageBytes > 0 ||
+      totalOverCap)
     updateGeometryResidency(prepCmd);
 
-  if (!_needsAccumulationReset && (belowBudget || overCap))
+  if (!_needsAccumulationReset && (belowBudget || overCap || totalOverCap))
     updateTextureResidency(prepCmd);
 
   bool allowResidency =
@@ -7788,6 +7809,7 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   _frameEnvironmentActivationFloor = 0;
   _frameGeometryResidencyCapHitCount = 0;
   _frameGeometryResidencyHardCapDeniedCount = 0;
+  _frameTotalMemoryOverageWarnings = 0;
   _frameRestirReuseRate = 0.0;
   _frameRestirCandidateAcceptance = 0.0;
   ResidencyStrategy strategy = _pScene->getResidencyStrategy();
@@ -12598,6 +12620,7 @@ void Renderer::beginFrameMetrics() {
         std::max(0.0, sample.gpuMemoryMB - sample.scratchMemoryMB);
     sample.textureMemoryCapMB = _textureResidencyMemoryCapMB;
     sample.geometryMemoryCapMB = _geometryResidencyMemoryCapMB;
+    sample.totalMemoryCapMB = _totalGpuMemoryCapMB;
     double geometryResidentMB = residentGeometryMemoryMB();
     sample.residentGeometryMemoryMB = geometryResidentMB;
     sample.avgHitProbability = 0.0;
@@ -12732,9 +12755,12 @@ void Renderer::beginFrameMetrics() {
         sample.residencyMemoryMB > _textureResidencyMemoryCapMB;
     sample.geometryOverMemoryCap =
         geometryResidentMB > _geometryResidencyMemoryCapMB;
+    sample.totalOverMemoryCap =
+        _totalGpuMemoryCapMB > 0.0 && sample.gpuMemoryMB > _totalGpuMemoryCapMB;
     sample.geometryCapHitCount = _frameGeometryResidencyCapHitCount;
     sample.geometryHardCapDeniedCount =
         _frameGeometryResidencyHardCapDeniedCount;
+    sample.totalMemoryOverageWarnings = _frameTotalMemoryOverageWarnings;
     _pendingBenchmarkSamples.push_back(std::move(sample));
   }
 }

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -418,6 +418,7 @@ private:
     double residencyMemoryMB = 0.0;
     double textureMemoryCapMB = 0.0;
     double geometryMemoryCapMB = 0.0;
+    double totalMemoryCapMB = 0.0;
     double deltaTimeSeconds = 0.0;
     double wallSeconds = 0.0;
     double cpuTimeSeconds = 0.0;
@@ -455,8 +456,10 @@ private:
     bool residentCompacted = false;
     bool overMemoryCap = false;
     bool geometryOverMemoryCap = false;
+    bool totalOverMemoryCap = false;
     size_t geometryCapHitCount = 0;
     size_t geometryHardCapDeniedCount = 0;
+    size_t totalMemoryOverageWarnings = 0;
   };
 
   struct FrameCaptureRequest {
@@ -553,6 +556,7 @@ private:
   float _totalPrimitiveImportance = 0.0f;
   double _textureResidencyMemoryCapMB = 2048.0;
   double _geometryResidencyMemoryCapMB = 2048.0;
+  double _totalGpuMemoryCapMB = 4096.0;
 
   std::vector<BlasInstanceRecord> _instanceRecords;
   std::vector<Primitive> _residentPrimitives;
@@ -681,6 +685,7 @@ private:
   size_t _frameEnvironmentActivationFloor = 0;
   size_t _frameGeometryResidencyCapHitCount = 0;
   size_t _frameGeometryResidencyHardCapDeniedCount = 0;
+  size_t _frameTotalMemoryOverageWarnings = 0;
   size_t _geometryResidencyCapHitCount = 0;
   size_t _geometryResidencyHardCapDeniedCount = 0;
   size_t _pendingGeometryResidencyOverageBytes = 0;

--- a/Nomad Path Tracer/Scene/Scene.cpp
+++ b/Nomad Path Tracer/Scene/Scene.cpp
@@ -89,6 +89,7 @@ void Scene::clear() {
   startCompacted = false;
   textureResidencyMemoryCapMB = 2048.0;
   geometryResidencyMemoryCapMB = 2048.0;
+  totalGpuMemoryCapMB = 4096.0;
   maxTileSampleWorkPerCommand = kDefaultMaxTileSampleWorkPerCommand;
   maxTileSampleWorkPerCommandSet = false;
   observerCameraValid = false;
@@ -289,6 +290,12 @@ double Scene::getGeometryResidencyMemoryCapMB() const {
 
 void Scene::setGeometryResidencyMemoryCapMB(double capMB) {
   geometryResidencyMemoryCapMB = capMB;
+}
+
+double Scene::getTotalGpuMemoryCapMB() const { return totalGpuMemoryCapMB; }
+
+void Scene::setTotalGpuMemoryCapMB(double capMB) {
+  totalGpuMemoryCapMB = capMB;
 }
 
 void Scene::setObserverCamera(const ObserverCamera &camera) {

--- a/Nomad Path Tracer/Scene/Scene.h
+++ b/Nomad Path Tracer/Scene/Scene.h
@@ -219,6 +219,8 @@ public:
   void setTextureResidencyMemoryCapMB(double capMB);
   double getGeometryResidencyMemoryCapMB() const;
   void setGeometryResidencyMemoryCapMB(double capMB);
+  double getTotalGpuMemoryCapMB() const;
+  void setTotalGpuMemoryCapMB(double capMB);
 
   void buildBVH();
   size_t getBVHNodeCount() const;
@@ -282,6 +284,7 @@ private:
   bool startCompacted;
   double textureResidencyMemoryCapMB;
   double geometryResidencyMemoryCapMB;
+  double totalGpuMemoryCapMB;
   size_t maxTileSampleWorkPerCommand;
   bool maxTileSampleWorkPerCommandSet;
   bool observerCameraValid;

--- a/Nomad Path Tracer/Scene/SceneLoader.cpp
+++ b/Nomad Path Tracer/Scene/SceneLoader.cpp
@@ -895,6 +895,10 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         "geometryResidencyMemoryCapMB", scene->getGeometryResidencyMemoryCapMB());
     scene->setGeometryResidencyMemoryCapMB(geometryCap);
 
+    double totalGpuCap = root->DoubleAttribute(
+        "totalGpuMemoryCapMB", scene->getTotalGpuMemoryCapMB());
+    scene->setTotalGpuMemoryCapMB(totalGpuCap);
+
     const char *environmentAttr = root->Attribute("environmentTexture");
     if (environmentAttr && environmentAttr[0]) {
         std::filesystem::path envPath(environmentAttr);


### PR DESCRIPTION
### Motivation
- Provide a single soft cap for total GPU memory usage so residency systems can detect overall pressure and bias evictions before hard geometry caps are hit.  
- Expose the cap from scene settings and record it in benchmark output to help tune residency behavior and observe how often the soft cap is exceeded.

### Description
- Add `totalGpuMemoryCapMB` to `Scene` with getters/setters and initialize it with a default (4096 MB) in `Scene::clear`, and load it from scene XML in `SceneLoader.cpp`.  
- Add `_totalGpuMemoryCapMB` and `_frameTotalMemoryOverageWarnings` to `Renderer` and introduce `kDefaultTotalGpuMemoryCapMB`.  
- Extend `BenchmarkSample` with `totalMemoryCapMB`, `totalOverMemoryCap` and `totalMemoryOverageWarnings`, populate them in `beginFrameMetrics`, and include these fields in `writeBenchmarkHeader`/`writeBenchmarkRow` CSV output.  
- In the frame loop (around `Renderer::draw`) compute `totalMemoryMB = currentGPUMemoryMB()` and, when above the soft cap, log a `[MemoryBudget] Total GPU memory over soft cap...` warning, increment the per-frame warning counter, and trigger existing eviction pathways by treating the soft cap as a signal (it now influences `updateGeometryResidency`/`updateTextureResidency`) without changing the existing geometry hard-cap denial logic.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975895da5bc832d8cf86ab184a3daf8)