### PR TITLE
Bind dummy ReSTIR stats buffer when disabled

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -1308,6 +1308,13 @@ Renderer::Renderer(MTL::Device *pDevice)
   _pCommandQueue = _pDevice->newCommandQueue();
   _tlasHeap.initialize(_pDevice);
   _dummyBlasResources.initialize(_pDevice);
+  constexpr size_t kRestirDummyBytes = 16;
+  _pRestirStatsDummyBuffer =
+      _pDevice->newBuffer(kRestirDummyBytes, MTL::ResourceStorageModeShared);
+  if (_pRestirStatsDummyBuffer) {
+    if (void *ptr = _pRestirStatsDummyBuffer->contents())
+      std::memset(ptr, 0, kRestirDummyBytes);
+  }
 
   Camera::reset();
   _primaryCameraState = Camera::captureState();
@@ -1363,6 +1370,8 @@ Renderer::~Renderer() {
     _pLightCdfBuffer->release();
   if (_pRestirStatsBuffer)
     _pRestirStatsBuffer->release();
+  if (_pRestirStatsDummyBuffer)
+    _pRestirStatsDummyBuffer->release();
   if (_pInstanceBuffer)
     _pInstanceBuffer->release();
   if (_pGeometryHandleBuffer)
@@ -2942,7 +2951,8 @@ void Renderer::prewarmAlwaysResidentResources() {
     compute->setBuffer(_pInstanceBuffer, 0, 10);
     compute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
     compute->setBuffer(_pInstanceBuffer, 0, 13);
-    compute->setBuffer(restirEnabled ? _pRestirStatsBuffer : nullptr, 0, 14);
+    compute->setBuffer(
+        restirEnabled ? _pRestirStatsBuffer : _pRestirStatsDummyBuffer, 0, 14);
   } else {
     compute->setBuffer(_pBVHBuffer, 0, 0);
     compute->setBuffer(_pSphereBuffer, 0, 1);
@@ -2958,7 +2968,8 @@ void Renderer::prewarmAlwaysResidentResources() {
     compute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
     compute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
     compute->setBuffer(_pInstanceBuffer, 0, 13);
-    compute->setBuffer(restirEnabled ? _pRestirStatsBuffer : nullptr, 0, 14);
+    compute->setBuffer(
+        restirEnabled ? _pRestirStatsBuffer : _pRestirStatsDummyBuffer, 0, 14);
   }
 
   compute->setTexture(accum0, 0);
@@ -7657,8 +7668,9 @@ void Renderer::draw(MTK::View *pView) {
         pCompute->setBuffer(_pInstanceBuffer, 0, 10);
         pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
         pCompute->setBuffer(_pInstanceBuffer, 0, 13);
-        pCompute->setBuffer(restirEnabled ? _pRestirStatsBuffer : nullptr, 0,
-                            14);
+        pCompute->setBuffer(
+            restirEnabled ? _pRestirStatsBuffer : _pRestirStatsDummyBuffer, 0,
+            14);
       } else {
         pCompute->setBuffer(_pBVHBuffer, 0, 0);
         pCompute->setBuffer(_pSphereBuffer, 0, 1);
@@ -7674,8 +7686,9 @@ void Renderer::draw(MTK::View *pView) {
         pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
         pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
         pCompute->setBuffer(_pInstanceBuffer, 0, 13);
-        pCompute->setBuffer(restirEnabled ? _pRestirStatsBuffer : nullptr, 0,
-                            14);
+        pCompute->setBuffer(
+            restirEnabled ? _pRestirStatsBuffer : _pRestirStatsDummyBuffer, 0,
+            14);
       }
 
       pCompute->setTexture(accum0, 0);

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -315,6 +315,7 @@ private:
   MTL::Buffer *_pLightIndexBuffer = nullptr;
   MTL::Buffer *_pLightCdfBuffer = nullptr;
   MTL::Buffer *_pRestirStatsBuffer = nullptr;
+  MTL::Buffer *_pRestirStatsDummyBuffer = nullptr;
   MTL::Buffer *_pInstanceBuffer = nullptr;
   MTL::Buffer *_pTlasInstanceDescriptorBuffer = nullptr;
   MTL::Buffer *_pGeometryHandleBuffer = nullptr;


### PR DESCRIPTION
### Motivation
- Prevent Metal argument-table validation failures by ensuring buffer slot 14 is always bound even when ReSTIR sampling is disabled.
- Preserve existing shader behavior while avoiding `nullptr` bindings that can trigger runtime/validation errors.

### Description
- Add a persistent dummy buffer member `MTL::Buffer* _pRestirStatsDummyBuffer` to `Renderer` in `Renderer.h`.
- Allocate a 16-byte shared zero-initialized buffer for `_pRestirStatsDummyBuffer` in the `Renderer` constructor and release it in the destructor in `Renderer.cpp`.
- Replace conditional `setBuffer(..., nullptr, 14)` calls with `setBuffer(restirEnabled ? _pRestirStatsBuffer : _pRestirStatsDummyBuffer, 0, 14)` in the prewarm dispatch and the tiled path-trace dispatch paths so index 14 is always bound.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69759730e244832d99c48c8a983f405c)