### PR TITLE
Forward-declare ManagedTextureSlot before use in Renderer.h

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -150,6 +150,7 @@ public:
 private:
   struct BenchmarkSample;
   struct FrameCaptureRequest;
+  struct ManagedTextureSlot;
   void recalculateNodeCounters(const std::vector<bool> &residentMask);
   void rebuildResidentResources(bool forceFullRebuild);
   void ensureBufferCapacity(MTL::Buffer *&buffer, size_t requiredBytes,


### PR DESCRIPTION
### Motivation
- Ensure the declaration order in `Renderer` satisfies the out-of-line definition in `Renderer.cpp` and avoid potential use-before-declaration compile errors by making `ManagedTextureSlot` visible before it is referenced.

### Description
- Add a forward declaration `struct ManagedTextureSlot;` in the private section of `Renderer` before the `textureCategoryForSlot(const ManagedTextureSlot &slot) const` declaration.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975a48d2594832dbd2407bf4914957e)