### PR TITLE
Add spatial ReSTIR reuse pass

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -1489,6 +1489,8 @@ Renderer::~Renderer() {
 
   if (_pPathTracePSO)
     _pPathTracePSO->release();
+  if (_pRestirSpatialPSO)
+    _pRestirSpatialPSO->release();
   if (_pAdaptiveSamplingPSO)
     _pAdaptiveSamplingPSO->release();
   if (_pOverlayPSO)
@@ -2368,6 +2370,10 @@ void Renderer::buildShaders() {
     _pPathTracePSO->release();
     _pPathTracePSO = nullptr;
   }
+  if (_pRestirSpatialPSO) {
+    _pRestirSpatialPSO->release();
+    _pRestirSpatialPSO = nullptr;
+  }
   if (_pAdaptiveSamplingPSO) {
     _pAdaptiveSamplingPSO->release();
     _pAdaptiveSamplingPSO = nullptr;
@@ -2468,6 +2474,18 @@ void Renderer::buildShaders() {
       }
     }
     pPathTraceFn->release();
+  }
+
+  pError = nullptr;
+  MTL::Function *pRestirSpatialFn = pLibrary->newFunction(
+      NS::String::string("restirSpatialKernel", UTF8StringEncoding));
+  if (pRestirSpatialFn) {
+    _pRestirSpatialPSO =
+        _pDevice->newComputePipelineState(pRestirSpatialFn, &pError);
+    if (!_pRestirSpatialPSO && pError) {
+      __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
+    }
+    pRestirSpatialFn->release();
   }
 
   pError = nullptr;
@@ -7776,6 +7794,55 @@ void Renderer::draw(MTK::View *pView) {
       trackFrameCommandBuffer(computeCmd);
       computeCmd->commit();
     }
+  }
+
+  bool restirSpatialDispatched = false;
+  if (_pRestirSpatialPSO && _residencyConfig.restirSamplingEnabled &&
+      restirPrevSample && restirPrevNormal && restirPrevState &&
+      restirOutSample && restirOutNormal && restirOutState) {
+    MTL::CommandBuffer *restirCmd = _pCommandQueue->commandBuffer();
+    if (restirCmd) {
+      MTL::ComputeCommandEncoder *pCompute = restirCmd->computeCommandEncoder();
+      if (pCompute) {
+        pCompute->setComputePipelineState(_pRestirSpatialPSO);
+        pCompute->setBuffer(_pUniformsBuffer, 0, 0);
+        pCompute->setTexture(restirOutSample, 0);
+        pCompute->setTexture(restirOutNormal, 1);
+        pCompute->setTexture(restirOutState, 2);
+        pCompute->setTexture(restirPrevSample, 3);
+        pCompute->setTexture(restirPrevNormal, 4);
+        pCompute->setTexture(restirPrevState, 5);
+
+        NS::UInteger width = restirOutSample->width();
+        NS::UInteger height = restirOutSample->height();
+        if (width > 0 && height > 0) {
+          NS::UInteger tgWidth = std::max<NS::UInteger>(
+              1, _pRestirSpatialPSO->threadExecutionWidth());
+          NS::UInteger maxThreads = std::max<NS::UInteger>(
+              tgWidth, _pRestirSpatialPSO->maxTotalThreadsPerThreadgroup());
+          NS::UInteger tgHeight =
+              std::max<NS::UInteger>(1, maxThreads / tgWidth);
+          MTL::Size threadsPerThreadgroup =
+              MTL::Size::Make(tgWidth, tgHeight, 1);
+          MTL::Size threadgroups = MTL::Size::Make(
+              (width + threadsPerThreadgroup.width - 1) /
+                  threadsPerThreadgroup.width,
+              (height + threadsPerThreadgroup.height - 1) /
+                  threadsPerThreadgroup.height,
+              1);
+          pCompute->dispatchThreadgroups(threadgroups, threadsPerThreadgroup);
+          restirSpatialDispatched = true;
+        }
+        pCompute->endEncoding();
+      }
+      trackFrameCommandBuffer(restirCmd);
+      restirCmd->commit();
+    }
+  }
+  if (restirSpatialDispatched) {
+    std::swap(_restirSampleSlots[0], _restirSampleSlots[1]);
+    std::swap(_restirNormalSlots[0], _restirNormalSlots[1]);
+    std::swap(_restirStateSlots[0], _restirStateSlots[1]);
   }
 
   MTL::CommandBuffer *presentCmd = _pCommandQueue->commandBuffer();

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -297,6 +297,7 @@ private:
   MTL::RenderPipelineState *_pPSO = nullptr;
   MTL::RenderPipelineState *_pOverlayPSO = nullptr;
   MTL::ComputePipelineState *_pPathTracePSO = nullptr;
+  MTL::ComputePipelineState *_pRestirSpatialPSO = nullptr;
   MTL::ComputePipelineState *_pAdaptiveSamplingPSO = nullptr;
 
   // Core scene and geometry data

--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -4,6 +4,112 @@ using namespace metal;
 
 #include "PathTracing.h"
 
+inline bool loadRestirReservoir(texture2d<float, access::read> restirSample,
+                                texture2d<float, access::read> restirNormal,
+                                texture2d<float, access::read> restirState,
+                                uint2 pixel,
+                                thread RestirReservoir &reservoir) {
+  float4 state = restirState.read(pixel);
+  float4 sample = restirSample.read(pixel);
+  float4 normal = restirNormal.read(pixel);
+  if (isfinite(state.x) && isfinite(state.y) && state.x > 0.0f &&
+      state.y > 0.0f && isfinite(sample.w) && sample.w >= 0.0f) {
+    reservoir.valid = 1u;
+    reservoir.W = state.x;
+    reservoir.M = state.y;
+    reservoir.sample.position = sample.xyz;
+    reservoir.sample.normal = normal.xyz;
+    reservoir.sample.area = normal.w;
+    reservoir.sample.lightIndex = uint(sample.w);
+    reservoir.selectedFromTemporal = 0u;
+    return true;
+  }
+  return false;
+}
+
+inline void writeRestirReservoir(texture2d<float, access::write> restirSample,
+                                 texture2d<float, access::write> restirNormal,
+                                 texture2d<float, access::write> restirState,
+                                 uint2 pixel,
+                                 thread const RestirReservoir &reservoir) {
+  float4 outSample = float4(0.0f);
+  float4 outNormal = float4(0.0f);
+  float4 outState = float4(0.0f);
+  if (reservoir.valid != 0u && reservoir.W > 0.0f && reservoir.M > 0.0f) {
+    outSample = float4(reservoir.sample.position,
+                       float(reservoir.sample.lightIndex));
+    outNormal = float4(reservoir.sample.normal, reservoir.sample.area);
+    outState = float4(reservoir.W, reservoir.M, 0.0f, 1.0f);
+  }
+  restirSample.write(outSample, pixel);
+  restirNormal.write(outNormal, pixel);
+  restirState.write(outState, pixel);
+}
+
+kernel void restirSpatialKernel(
+    device const UniformsData *uniforms [[buffer(0)]],
+    texture2d<float, access::read> restirInSample [[texture(0)]],
+    texture2d<float, access::read> restirInNormal [[texture(1)]],
+    texture2d<float, access::read> restirInState [[texture(2)]],
+    texture2d<float, access::write> restirOutSample [[texture(3)]],
+    texture2d<float, access::write> restirOutNormal [[texture(4)]],
+    texture2d<float, access::write> restirOutState [[texture(5)]],
+    uint2 gid [[thread_position_in_grid]]) {
+  if (!uniforms)
+    return;
+
+  uint width = restirInSample.get_width();
+  uint height = restirInSample.get_height();
+  if (gid.x >= width || gid.y >= height)
+    return;
+
+  const device UniformsData &u = *uniforms;
+  float2 screenSize = float2(u.screenSize);
+  if (screenSize.x <= 0.0f || screenSize.y <= 0.0f)
+    return;
+
+  float2 uv = (float2(gid) + 0.5f) / screenSize;
+  uint32_t seed = random(uv, u.randomSeed.xyz) * ((uint32_t)-1);
+  seed ^= uint32_t(u.frameCount + gid.x * 1973u + gid.y * 9277u);
+
+  RestirReservoir combined{};
+  combined.valid = 0u;
+  combined.W = 0.0f;
+  combined.M = 0.0f;
+
+  constexpr int kSpatialTapCount = 5;
+  const int2 offsets[kSpatialTapCount] = {
+      int2(0, 0), int2(1, 0), int2(-1, 0), int2(0, 1), int2(0, -1)};
+
+  for (int tap = 0; tap < kSpatialTapCount; ++tap) {
+    int2 offset = offsets[tap];
+    int2 sampleCoord = int2(gid) + offset;
+    sampleCoord.x = clamp(sampleCoord.x, 0, int(width) - 1);
+    sampleCoord.y = clamp(sampleCoord.y, 0, int(height) - 1);
+    uint2 pixel = uint2(sampleCoord);
+
+    RestirReservoir candidate{};
+    if (!loadRestirReservoir(restirInSample, restirInNormal, restirInState,
+                             pixel, candidate))
+      continue;
+    if (candidate.W <= 0.0f || candidate.M <= 0.0f)
+      continue;
+
+    float weight = candidate.W;
+    combined.M += candidate.M;
+    combined.W += weight;
+    float select = randomFloat(seed);
+    seed = random(seed);
+    if (combined.W > 0.0f && select < (weight / combined.W)) {
+      combined.sample = candidate.sample;
+      combined.valid = 1u;
+    }
+  }
+
+  writeRestirReservoir(restirOutSample, restirOutNormal, restirOutState, gid,
+                       combined);
+}
+
 kernel void pathTraceKernel(
     device const float4 *bvhNodes [[buffer(0)]],
     device const float4 *primitives [[buffer(1)]],


### PR DESCRIPTION
### Motivation
- Implement a spatial reuse stage for the ReSTIR pipeline so per-pixel reservoirs can be combined with nearby pixels to increase candidate reuse and improve direct lighting estimates.
- Wire the spatial pass into the existing renderer flow so it reuses the existing ReSTIR history textures (`_restirSampleSlots`, `_restirNormalSlots`, `_restirStateSlots`) and preserves per-pixel reservoir state (sample, normal, `W`, `M`).

### Description
- Added a compute pipeline member `MTL::ComputePipelineState *_pRestirSpatialPSO` to `Renderer` and initialized/released it in `buildShaders()` and the destructor.
- Implemented `restirSpatialKernel` (and helpers `loadRestirReservoir` / `writeRestirReservoir`) in `PathTraceKernel.metal`, which samples a small neighborhood (`kSpatialTapCount = 5`) and merges reservoirs using canonical ReSTIR reservoir-update logic (accumulate `M`, `W` and perform weighted reservoir sampling), and preserves/writes sample position, normal, light index, `W`, and `M` into the ReSTIR textures.
- Created the compute PSO for `restirSpatialKernel` in `Renderer::buildShaders()` via `newFunction("restirSpatialKernel")` and added error handling similar to other compute pipelines.
- Dispatched the spatial pass in `Renderer::draw` after the path-trace dispatch, bound `_pUniformsBuffer` and the six ReSTIR textures (prev/out samples/normals/states), dispatched threadgroups over the full texture size, and on successful dispatch swapped the `_restirSampleSlots`, `_restirNormalSlots`, and `_restirStateSlots` so the updated reservoirs are used as history on subsequent frames.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69761bbf1c58832da26f4d05a35d365a)