### PR TITLE
Evaluate ReSTIR spatial neighbors at current shading point and weight by target/pdf

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -522,6 +522,7 @@ double Renderer::residentTextureMemoryMB() const {
   addSlot(_sampleImportanceSlot);
   addSlot(_albedoSlot);
   addSlot(_normalSlot);
+  addSlot(_positionSlot);
 
   for (MTL::Texture *texture : _materialTextures) {
     totalBytes += textureByteSize(texture);
@@ -1477,6 +1478,7 @@ Renderer::~Renderer() {
   releaseTextureSlot(_sampleImportanceSlot);
   releaseTextureSlot(_albedoSlot);
   releaseTextureSlot(_normalSlot);
+  releaseTextureSlot(_positionSlot);
   for (auto &slot : _restirSampleSlots)
     releaseTextureSlot(slot);
   for (auto &slot : _restirNormalSlots)
@@ -2954,6 +2956,7 @@ void Renderer::prewarmAlwaysResidentResources() {
   MTL::Texture *sampleImportance = ensureSlotReady(_sampleImportanceSlot);
   MTL::Texture *albedoTexture = ensureSlotReady(_albedoSlot);
   MTL::Texture *normalTexture = ensureSlotReady(_normalSlot);
+  MTL::Texture *positionTexture = ensureSlotReady(_positionSlot);
   MTL::Texture *restirPrevSample = ensureSlotReady(_restirSampleSlots[0]);
   MTL::Texture *restirPrevNormal = ensureSlotReady(_restirNormalSlots[0]);
   MTL::Texture *restirPrevState = ensureSlotReady(_restirStateSlots[0]);
@@ -2966,8 +2969,8 @@ void Renderer::prewarmAlwaysResidentResources() {
 
   bool haveAllTextures =
       accum0 && accum1 && sampleCount && sampleImportance && albedoTexture &&
-      normalTexture && restirPrevSample && restirPrevNormal && restirPrevState &&
-      restirOutSample && restirOutNormal && restirOutState;
+      normalTexture && positionTexture && restirPrevSample && restirPrevNormal &&
+      restirPrevState && restirOutSample && restirOutNormal && restirOutState;
 
   bool useAccelerationStructureLayout =
       _useAccelerationStructureBindings && _pTlasStructure &&
@@ -3049,21 +3052,22 @@ void Renderer::prewarmAlwaysResidentResources() {
   compute->setTexture(sampleImportance, 3);
   compute->setTexture(albedoTexture, 4);
   compute->setTexture(normalTexture, 5);
-  compute->setTexture(restirPrevSample, 6);
-  compute->setTexture(restirPrevNormal, 7);
-  compute->setTexture(restirPrevState, 8);
-  compute->setTexture(restirOutSample, 9);
-  compute->setTexture(restirOutNormal, 10);
-  compute->setTexture(restirOutState, 11);
+  compute->setTexture(positionTexture, 6);
+  compute->setTexture(restirPrevSample, 7);
+  compute->setTexture(restirPrevNormal, 8);
+  compute->setTexture(restirPrevState, 9);
+  compute->setTexture(restirOutSample, 10);
+  compute->setTexture(restirOutNormal, 11);
+  compute->setTexture(restirOutState, 12);
 
   for (uint32_t texIdx = 0; texIdx < kMaxMaterialTextureSlots; ++texIdx) {
     MTL::Texture *materialTex =
         (texIdx < _materialTextures.size()) ? _materialTextures[texIdx]
                                             : nullptr;
-    compute->setTexture(materialTex, 12 + texIdx);
+    compute->setTexture(materialTex, 13 + texIdx);
   }
 
-  compute->setTexture(_environmentTexture, 12 + kMaxMaterialTextureSlots);
+  compute->setTexture(_environmentTexture, 13 + kMaxMaterialTextureSlots);
   if (_environmentSampler)
     compute->setSamplerState(_environmentSampler, 0);
 
@@ -6200,6 +6204,8 @@ const char *Renderer::textureSlotLabel(const ManagedTextureSlot &slot) const {
     return "_albedoSlot";
   if (&slot == &_normalSlot)
     return "_normalSlot";
+  if (&slot == &_positionSlot)
+    return "_positionSlot";
   if (&slot == &_restirSampleSlots[0])
     return "_restirSampleSlots[0]";
   if (&slot == &_restirSampleSlots[1])
@@ -6534,7 +6540,8 @@ MTL::Texture *Renderer::requestResidentTexture(ManagedTextureSlot &slot,
                 label);
     if (&slot == &_accumulationSlots[0] || &slot == &_accumulationSlots[1] ||
         &slot == &_sampleCountSlot || &slot == &_albedoSlot ||
-        &slot == &_normalSlot || &slot == &_restirSampleSlots[0] ||
+        &slot == &_normalSlot || &slot == &_positionSlot ||
+        &slot == &_restirSampleSlots[0] ||
         &slot == &_restirSampleSlots[1] || &slot == &_restirNormalSlots[0] ||
         &slot == &_restirNormalSlots[1] || &slot == &_restirStateSlots[0] ||
         &slot == &_restirStateSlots[1]) {
@@ -6683,9 +6690,9 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
                 residencyMB, totalMemoryMB, scratchMB, _textureResidencyMemoryCapMB);
   }
 
-  std::array<ManagedTextureSlot *, 12> slots = {
+  std::array<ManagedTextureSlot *, 13> slots = {
       &_accumulationSlots[0], &_accumulationSlots[1], &_sampleCountSlot,
-      &_sampleImportanceSlot, &_albedoSlot, &_normalSlot,
+      &_sampleImportanceSlot, &_albedoSlot, &_normalSlot, &_positionSlot,
       &_restirSampleSlots[0], &_restirSampleSlots[1],
       &_restirNormalSlots[0], &_restirNormalSlots[1],
       &_restirStateSlots[0], &_restirStateSlots[1]};
@@ -7015,6 +7022,8 @@ void Renderer::buildTextures() {
                        MTL::PixelFormat::PixelFormatRGBA32Float, usage);
   configureTextureSlot(_normalSlot, width, height,
                        MTL::PixelFormat::PixelFormatRGBA32Float, usage);
+  configureTextureSlot(_positionSlot, width, height,
+                       MTL::PixelFormat::PixelFormatRGBA32Float, usage);
   for (auto &slot : _restirSampleSlots)
     configureTextureSlot(slot, width, height,
                          MTL::PixelFormat::PixelFormatRGBA32Float, usage);
@@ -7033,9 +7042,9 @@ bool Renderer::resetAccumulationTargets(MTL::CommandBuffer *cmd) {
   if (!cmd)
     return false;
 
-  std::array<ManagedTextureSlot *, 12> slots = {
+  std::array<ManagedTextureSlot *, 13> slots = {
       &_accumulationSlots[0], &_accumulationSlots[1], &_sampleCountSlot,
-      &_sampleImportanceSlot, &_albedoSlot, &_normalSlot,
+      &_sampleImportanceSlot, &_albedoSlot, &_normalSlot, &_positionSlot,
       &_restirSampleSlots[0], &_restirSampleSlots[1],
       &_restirNormalSlots[0], &_restirNormalSlots[1],
       &_restirStateSlots[0], &_restirStateSlots[1]};
@@ -7427,6 +7436,7 @@ void Renderer::draw(MTK::View *pView) {
   MTL::Texture *sampleImportance = _sampleImportanceSlot.texture;
   MTL::Texture *albedoTexture = _albedoSlot.texture;
   MTL::Texture *normalTexture = _normalSlot.texture;
+  MTL::Texture *positionTexture = _positionSlot.texture;
   MTL::Texture *restirPrevSample = _restirSampleSlots[0].texture;
   MTL::Texture *restirPrevNormal = _restirNormalSlots[0].texture;
   MTL::Texture *restirPrevState = _restirStateSlots[0].texture;
@@ -7441,6 +7451,8 @@ void Renderer::draw(MTK::View *pView) {
         requestResidentTexture(_sampleImportanceSlot, prepCmd, restoreBlit);
     albedoTexture = requestResidentTexture(_albedoSlot, prepCmd, restoreBlit);
     normalTexture = requestResidentTexture(_normalSlot, prepCmd, restoreBlit);
+    positionTexture =
+        requestResidentTexture(_positionSlot, prepCmd, restoreBlit);
     restirPrevSample =
         requestResidentTexture(_restirSampleSlots[0], prepCmd, restoreBlit);
     restirPrevNormal =
@@ -7471,6 +7483,7 @@ void Renderer::draw(MTK::View *pView) {
   ensureSlotReady(_sampleImportanceSlot, sampleImportance);
   ensureSlotReady(_albedoSlot, albedoTexture);
   ensureSlotReady(_normalSlot, normalTexture);
+  ensureSlotReady(_positionSlot, positionTexture);
   ensureSlotReady(_restirSampleSlots[0], restirPrevSample);
   ensureSlotReady(_restirNormalSlots[0], restirPrevNormal);
   ensureSlotReady(_restirStateSlots[0], restirPrevState);
@@ -7489,6 +7502,7 @@ void Renderer::draw(MTK::View *pView) {
   markSlotUsed(_sampleImportanceSlot, sampleImportance);
   markSlotUsed(_albedoSlot, albedoTexture);
   markSlotUsed(_normalSlot, normalTexture);
+  markSlotUsed(_positionSlot, positionTexture);
   markSlotUsed(_restirSampleSlots[0], restirPrevSample);
   markSlotUsed(_restirNormalSlots[0], restirPrevNormal);
   markSlotUsed(_restirStateSlots[0], restirPrevState);
@@ -7501,8 +7515,8 @@ void Renderer::draw(MTK::View *pView) {
 
   bool haveAllTextures =
       accum0 && accum1 && sampleCount && sampleImportance && albedoTexture &&
-      normalTexture && restirPrevSample && restirPrevNormal && restirPrevState &&
-      restirOutSample && restirOutNormal && restirOutState;
+      normalTexture && positionTexture && restirPrevSample && restirPrevNormal &&
+      restirPrevState && restirOutSample && restirOutNormal && restirOutState;
 
   if (_accumulationTargetsNeedClear && haveAllTextures) {
     if (resetAccumulationTargets(prepCmd)) {
@@ -7745,22 +7759,23 @@ void Renderer::draw(MTK::View *pView) {
       pCompute->setTexture(sampleImportance, 3);
       pCompute->setTexture(albedoTexture, 4);
       pCompute->setTexture(normalTexture, 5);
-      pCompute->setTexture(restirPrevSample, 6);
-      pCompute->setTexture(restirPrevNormal, 7);
-      pCompute->setTexture(restirPrevState, 8);
-      pCompute->setTexture(restirOutSample, 9);
-      pCompute->setTexture(restirOutNormal, 10);
-      pCompute->setTexture(restirOutState, 11);
+      pCompute->setTexture(positionTexture, 6);
+      pCompute->setTexture(restirPrevSample, 7);
+      pCompute->setTexture(restirPrevNormal, 8);
+      pCompute->setTexture(restirPrevState, 9);
+      pCompute->setTexture(restirOutSample, 10);
+      pCompute->setTexture(restirOutNormal, 11);
+      pCompute->setTexture(restirOutState, 12);
 
       for (uint32_t texIdx = 0; texIdx < kMaxMaterialTextureSlots; ++texIdx) {
         MTL::Texture *materialTex =
             (texIdx < _materialTextures.size()) ? _materialTextures[texIdx]
                                                 : nullptr;
-        pCompute->setTexture(materialTex, 12 + texIdx);
+        pCompute->setTexture(materialTex, 13 + texIdx);
       }
 
       pCompute->setTexture(_environmentTexture,
-                            12 + kMaxMaterialTextureSlots);
+                            13 + kMaxMaterialTextureSlots);
       if (_environmentSampler)
         pCompute->setSamplerState(_environmentSampler, 0);
 
@@ -7799,7 +7814,11 @@ void Renderer::draw(MTK::View *pView) {
   bool restirSpatialDispatched = false;
   if (_residencyConfig.restirSamplingEnabled && restirPrevSample &&
       restirPrevNormal && restirPrevState && restirOutSample &&
-      restirOutNormal && restirOutState) {
+      restirOutNormal && restirOutState && albedoTexture && normalTexture &&
+      positionTexture && _pBVHBuffer && _pSphereBuffer &&
+      _pSphereMaterialBuffer && _pPrimitiveIndexBuffer && _pTLASBuffer &&
+      _pActiveBuffer && _pLightIndexBuffer && _pLightCdfBuffer &&
+      _pPrimitiveRemapBuffer && _pPrimitiveHitBufferGPU && _pInstanceBuffer) {
     if (_pRestirSpatialPSO) {
       MTL::CommandBuffer *restirCmd = _pCommandQueue->commandBuffer();
       if (restirCmd) {
@@ -7808,12 +7827,26 @@ void Renderer::draw(MTK::View *pView) {
         if (pCompute) {
           pCompute->setComputePipelineState(_pRestirSpatialPSO);
           pCompute->setBuffer(_pUniformsBuffer, 0, 0);
-          pCompute->setTexture(restirOutSample, 0);
-          pCompute->setTexture(restirOutNormal, 1);
-          pCompute->setTexture(restirOutState, 2);
-          pCompute->setTexture(restirPrevSample, 3);
-          pCompute->setTexture(restirPrevNormal, 4);
-          pCompute->setTexture(restirPrevState, 5);
+          pCompute->setBuffer(_pBVHBuffer, 0, 1);
+          pCompute->setBuffer(_pSphereBuffer, 0, 2);
+          pCompute->setBuffer(_pSphereMaterialBuffer, 0, 3);
+          pCompute->setBuffer(_pPrimitiveIndexBuffer, 0, 4);
+          pCompute->setBuffer(_pTLASBuffer, 0, 5);
+          pCompute->setBuffer(_pActiveBuffer, 0, 6);
+          pCompute->setBuffer(_pLightIndexBuffer, 0, 7);
+          pCompute->setBuffer(_pLightCdfBuffer, 0, 8);
+          pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 9);
+          pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 10);
+          pCompute->setBuffer(_pInstanceBuffer, 0, 11);
+          pCompute->setTexture(albedoTexture, 0);
+          pCompute->setTexture(normalTexture, 1);
+          pCompute->setTexture(positionTexture, 2);
+          pCompute->setTexture(restirOutSample, 3);
+          pCompute->setTexture(restirOutNormal, 4);
+          pCompute->setTexture(restirOutState, 5);
+          pCompute->setTexture(restirPrevSample, 6);
+          pCompute->setTexture(restirPrevNormal, 7);
+          pCompute->setTexture(restirPrevState, 8);
 
           NS::UInteger width = restirOutSample->width();
           NS::UInteger height = restirOutSample->height();

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -377,6 +377,7 @@ private:
   ManagedTextureSlot _sampleImportanceSlot;
   ManagedTextureSlot _albedoSlot;
   ManagedTextureSlot _normalSlot;
+  ManagedTextureSlot _positionSlot;
   ManagedTextureSlot _restirSampleSlots[2];
   ManagedTextureSlot _restirNormalSlots[2];
   ManagedTextureSlot _restirStateSlots[2];

--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -48,14 +48,32 @@ inline void writeRestirReservoir(texture2d<float, access::write> restirSample,
 
 kernel void restirSpatialKernel(
     device const UniformsData *uniforms [[buffer(0)]],
-    texture2d<float, access::read> restirInSample [[texture(0)]],
-    texture2d<float, access::read> restirInNormal [[texture(1)]],
-    texture2d<float, access::read> restirInState [[texture(2)]],
-    texture2d<float, access::write> restirOutSample [[texture(3)]],
-    texture2d<float, access::write> restirOutNormal [[texture(4)]],
-    texture2d<float, access::write> restirOutState [[texture(5)]],
+    device const float4 *bvhNodes [[buffer(1)]],
+    device const float4 *primitives [[buffer(2)]],
+    device const float4 *materials [[buffer(3)]],
+    device const int *primitiveIndices [[buffer(4)]],
+    device const float4 *tlasNodes [[buffer(5)]],
+    device const uchar *activeMask [[buffer(6)]],
+    device const uint *lightIndices [[buffer(7)]],
+    device const float *lightCdf [[buffer(8)]],
+    device const uint *primitiveRemap [[buffer(9)]],
+    device atomic_uint *primitiveRayStats [[buffer(10)]],
+    device const InstanceRecord *instanceRecords [[buffer(11)]],
+    texture2d<float, access::read> albedoAccum [[texture(0)]],
+    texture2d<float, access::read> normalAccum [[texture(1)]],
+    texture2d<float, access::read> positionAccum [[texture(2)]],
+    texture2d<float, access::read> restirInSample [[texture(3)]],
+    texture2d<float, access::read> restirInNormal [[texture(4)]],
+    texture2d<float, access::read> restirInState [[texture(5)]],
+    texture2d<float, access::write> restirOutSample [[texture(6)]],
+    texture2d<float, access::write> restirOutNormal [[texture(7)]],
+    texture2d<float, access::write> restirOutState [[texture(8)]],
     uint2 gid [[thread_position_in_grid]]) {
   if (!uniforms)
+    return;
+  if (!bvhNodes || !primitives || !materials || !primitiveIndices || !tlasNodes ||
+      !activeMask || !lightIndices || !lightCdf || !primitiveRemap ||
+      !instanceRecords)
     return;
 
   uint width = restirInSample.get_width();
@@ -77,6 +95,45 @@ kernel void restirSpatialKernel(
   combined.W = 0.0f;
   combined.M = 0.0f;
 
+  if (u.lightCount == 0 || u.lightTotalWeight <= 0.0f) {
+    writeRestirReservoir(restirOutSample, restirOutNormal, restirOutState, gid,
+                         combined);
+    return;
+  }
+
+  float3 shadingPosition = positionAccum.read(gid).xyz;
+  float3 shadingNormal = normalAccum.read(gid).xyz;
+  float3 diffuseColor = albedoAccum.read(gid).xyz;
+  if (!all(isfinite(shadingPosition)) || !all(isfinite(shadingNormal)) ||
+      !all(isfinite(diffuseColor))) {
+    writeRestirReservoir(restirOutSample, restirOutNormal, restirOutState, gid,
+                         combined);
+    return;
+  }
+
+  float normalLen = length(shadingNormal);
+  if (normalLen <= 1e-4f) {
+    writeRestirReservoir(restirOutSample, restirOutNormal, restirOutState, gid,
+                         combined);
+    return;
+  }
+  shadingNormal = shadingNormal / normalLen;
+
+  float diffuseLum = luminance(diffuseColor);
+  if (diffuseLum <= 0.0f) {
+    writeRestirReservoir(restirOutSample, restirOutNormal, restirOutState, gid,
+                         combined);
+    return;
+  }
+
+  intersection bestHit{};
+  bestHit.point = shadingPosition;
+  bestHit.normal = shadingNormal;
+  bestHit.primitiveId = -1;
+  TlasLeafCache bounceCache;
+  bounceCache.valid = false;
+  float4 absorption = float4(1.0f);
+
   constexpr int kSpatialTapCount = 5;
   const int2 offsets[kSpatialTapCount] = {
       int2(0, 0), int2(1, 0), int2(-1, 0), int2(0, 1), int2(0, -1)};
@@ -94,16 +151,32 @@ kernel void restirSpatialKernel(
       continue;
     if (candidate.W <= 0.0f || candidate.M <= 0.0f)
       continue;
+    uint lightOffset = candidate.sample.lightIndex;
+    if (lightOffset >= u.lightCount)
+      continue;
+    if (!isfinite(candidate.sample.area) || candidate.sample.area <= 0.0f)
+      continue;
+    uint lightPrimIndex = lightIndices[lightOffset];
+    RestirEvaluation eval = evaluateLightCandidate(
+        lightOffset, lightPrimIndex, candidate.sample.position,
+        candidate.sample.normal, candidate.sample.area, shadingNormal,
+        diffuseColor, absorption, bestHit, bounceCache, tlasNodes,
+        uint(u.tlasNodeCount), bvhNodes, primitives, primitiveIndices, activeMask,
+        instanceRecords, primitiveRemap, uint(u.primitiveCount),
+        uint(u.totalPrimitiveCount), primitiveRayStats, materials, lightCdf,
+        u.lightTotalWeight);
+    if (!eval.valid || eval.pdf <= 0.0f)
+      continue;
 
-    float weight = candidate.W;
-    combined.M += candidate.M;
-    combined.W += weight;
-    float select = randomFloat(seed);
-    seed = random(seed);
-    if (combined.W > 0.0f && select < (weight / combined.W)) {
-      combined.sample = candidate.sample;
-      combined.valid = 1u;
-    }
+    float candidateM = candidate.M;
+    if (!isfinite(candidateM) || candidateM <= 0.0f)
+      continue;
+    float weight = (eval.target / eval.pdf) * candidateM;
+    if (weight <= 0.0f || !isfinite(weight))
+      continue;
+    updateRestirReservoir(combined, candidate.sample, weight, false, seed);
+    if (candidateM > 1.0f)
+      combined.M += candidateM - 1.0f;
   }
 
   writeRestirReservoir(restirOutSample, restirOutNormal, restirOutState, gid,
@@ -132,16 +205,17 @@ kernel void pathTraceKernel(
     texture2d<half, access::read> sampleImportance [[texture(3)]],
     texture2d<float, access::read_write> albedoAccum [[texture(4)]],
     texture2d<float, access::read_write> normalAccum [[texture(5)]],
-    texture2d<float, access::read> restirPrevSample [[texture(6)]],
-    texture2d<float, access::read> restirPrevNormal [[texture(7)]],
-    texture2d<float, access::read> restirPrevState [[texture(8)]],
-    texture2d<float, access::write> restirOutSample [[texture(9)]],
-    texture2d<float, access::write> restirOutNormal [[texture(10)]],
-    texture2d<float, access::write> restirOutState [[texture(11)]],
+    texture2d<float, access::read_write> positionAccum [[texture(6)]],
+    texture2d<float, access::read> restirPrevSample [[texture(7)]],
+    texture2d<float, access::read> restirPrevNormal [[texture(8)]],
+    texture2d<float, access::read> restirPrevState [[texture(9)]],
+    texture2d<float, access::write> restirOutSample [[texture(10)]],
+    texture2d<float, access::write> restirOutNormal [[texture(11)]],
+    texture2d<float, access::write> restirOutState [[texture(12)]],
     array<texture2d<float, access::sample>, kMaxMaterialTextures>
-        materialTextures [[texture(12)]],
+        materialTextures [[texture(13)]],
     texture2d<float, access::sample> environmentMap
-        [[texture(12 + kMaxMaterialTextures)]],
+        [[texture(13 + kMaxMaterialTextures)]],
     sampler environmentSampler [[sampler(0)]],
     constant TileRegion &tile [[buffer(16)]],
     uint2 gid [[thread_position_in_grid]]) {
@@ -184,6 +258,7 @@ kernel void pathTraceKernel(
   float3 accumulatedColor = float3(0.0);
   float3 accumulatedAlbedo = float3(0.0);
   float3 accumulatedNormal = float3(0.0);
+  float3 accumulatedPosition = float3(0.0);
 
   float3 rayDx = u.rayDx;
   float3 rayDy = u.rayDy;
@@ -261,6 +336,7 @@ kernel void pathTraceKernel(
     accumulatedColor += sample.radiance;
     accumulatedAlbedo += sample.albedo;
     accumulatedNormal += sample.normal;
+    accumulatedPosition += sample.position;
   }
 
   if (restirEnabled) {
@@ -303,18 +379,25 @@ kernel void pathTraceKernel(
       float3(float4(albedoAccum.read(pixel)).xyz);
   float3 previousNormal =
       float3(float4(normalAccum.read(pixel)).xyz);
+  float3 previousPosition =
+      float3(float4(positionAccum.read(pixel)).xyz);
   float3 albedoSum = previousAlbedo * previousSampleCount + accumulatedAlbedo;
   float3 normalSum = previousNormal * previousSampleCount + accumulatedNormal;
+  float3 positionSum =
+      previousPosition * previousSampleCount + accumulatedPosition;
   float3 averagedAlbedo =
       (totalSamples > 0.0f) ? albedoSum / totalSamples : float3(0.0f);
   averagedAlbedo = clamp(averagedAlbedo, 0.0f, 1.0f);
   float3 averagedNormal =
       (totalSamples > 0.0f) ? normalSum / totalSamples : float3(0.0f);
   averagedNormal = clamp(averagedNormal, -1.0f, 1.0f);
+  float3 averagedPosition =
+      (totalSamples > 0.0f) ? positionSum / totalSamples : float3(0.0f);
 
   float4 result = float4(averaged, 1.0f);
   currentFrame.write(result, pixel);
   albedoAccum.write(float4(averagedAlbedo, 1.0f), pixel);
   normalAccum.write(float4(averagedNormal, 1.0f), pixel);
+  positionAccum.write(float4(averagedPosition, 1.0f), pixel);
   sampleCount.write(float4(totalSamples, 0.0f, 0.0f, 0.0f), pixel);
 }

--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -18,6 +18,7 @@ struct PathTraceSample {
   float3 radiance;
   float3 albedo;
   float3 normal;
+  float3 position;
 };
 
 constant uint kRestirCandidateCount = 4;
@@ -852,6 +853,7 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
   sampleResult.radiance = float3(0.0f);
   sampleResult.albedo = float3(0.0f);
   sampleResult.normal = float3(0.0f);
+  sampleResult.position = float3(0.0f);
   bool recordedFirstHit = false;
 
   float footprint = length(cross(rayDx, rayDy));
@@ -1040,6 +1042,7 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
     if (!recordedFirstHit) {
       sampleResult.albedo = material.diffuseColor;
       sampleResult.normal = offsetNormal;
+      sampleResult.position = bestHit.point;
       recordedFirstHit = true;
     }
 


### PR DESCRIPTION
### Motivation
- Improve ReSTIR spatial resampling correctness by evaluating each neighbor candidate at the current pixel's shading point and using the canonical `target/pdf` weight for canonical reservoir updates.
- Avoid reusing occluded or otherwise invalid candidates by reusing the same visibility checks used for per-sample evaluation.
- Provide the spatial kernel with the shading information (position/normal/albedo) required to compute contribution (`target`) and PDFs for each neighbor.

### Description
- Replaced the simplistic neighbor-merge logic in the spatial kernel with a canonical spatial resampling step in `restirSpatialKernel` that re-evaluates each neighbor using `evaluateLightCandidate` and reweights candidates by `eval.target / eval.pdf` before calling `updateRestirReservoir`.
- Added a per-sample world-space position into the path tracer: extended `PathTraceSample` with a `position` field and assigned `bestHit.point` at first-hit code paths in `PathTracing.h` so shading-position is accumulated.
- Added a `positionAccum` texture and a `_positionSlot` `ManagedTextureSlot`, wired it through `Renderer::buildTextures`, residency code, dispatch bindings and compute pipelines so the spatial kernel can read the current pixel's `position`, `normal`, and `albedo`.
- Updated compute bindings for both the spatial kernel (`PathTraceKernel.metal`) and the renderer (`Renderer.cpp`/`Renderer.h`) to pass scene buffers (`BVH/TLAS/primitive/material/light` buffers) and the new shading buffers to the spatial kernel, and to write out reservoir state via `writeRestirReservoir` as before.
- Preserved and reused the existing `evaluateLightCandidate` visibility checks (shadow ray / TLAS/BVH queries) when scoring spatial neighbors so occluded candidates are discarded.

### Testing
- No automated tests were executed for this change in this patch set (no build/run/test was requested).
- Functional verification is expected by running the renderer to ensure the spatial ReSTIR pass produces valid reservoirs and that path-traced frames remain stable; recommended smoke checks include rendering a scene with direct lighting and toggling ReSTIR spatial sampling to compare results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697621a9e970832d8baf4cb045bdfac3)