### PR TITLE
Add spatial reuse validation checks

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -137,6 +137,9 @@ kernel void restirSpatialKernel(
   constexpr int kSpatialTapCount = 5;
   const int2 offsets[kSpatialTapCount] = {
       int2(0, 0), int2(1, 0), int2(-1, 0), int2(0, 1), int2(0, -1)};
+  constexpr float kSpatialNormalThreshold = 0.85f;
+  constexpr float kSpatialDepthThreshold = 0.25f;
+  constexpr float kSpatialPositionThreshold = 0.5f;
 
   for (int tap = 0; tap < kSpatialTapCount; ++tap) {
     int2 offset = offsets[tap];
@@ -144,6 +147,25 @@ kernel void restirSpatialKernel(
     sampleCoord.x = clamp(sampleCoord.x, 0, int(width) - 1);
     sampleCoord.y = clamp(sampleCoord.y, 0, int(height) - 1);
     uint2 pixel = uint2(sampleCoord);
+
+    float3 neighborPosition = positionAccum.read(pixel).xyz;
+    float3 neighborNormal = normalAccum.read(pixel).xyz;
+    if (!all(isfinite(neighborPosition)) || !all(isfinite(neighborNormal)))
+      continue;
+    float neighborNormalLen = length(neighborNormal);
+    if (neighborNormalLen <= 1e-4f)
+      continue;
+    neighborNormal /= neighborNormalLen;
+
+    float normalSimilarity = dot(shadingNormal, neighborNormal);
+    if (normalSimilarity < kSpatialNormalThreshold)
+      continue;
+    float3 delta = neighborPosition - shadingPosition;
+    float depthDelta = abs(dot(delta, shadingNormal));
+    if (depthDelta > kSpatialDepthThreshold)
+      continue;
+    if (length(delta) > kSpatialPositionThreshold)
+      continue;
 
     RestirReservoir candidate{};
     if (!loadRestirReservoir(restirInSample, restirInNormal, restirInState,


### PR DESCRIPTION
### Motivation
- Reduce incorrect spatial ReSTIR neighbor reuse by filtering candidates that are on different surfaces or across depth discontinuities. 
- Reuse existing light evaluation (which contains visibility/shadow checks) to avoid adding occluded or invalid candidates. 
- Keep spatial reuse conservative while preserving the existing visibility logic used for direct-light evaluation.

### Description
- Added constants `kSpatialNormalThreshold`, `kSpatialDepthThreshold`, and `kSpatialPositionThreshold` and early-out validation in `restirSpatialKernel` of `Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal`.
- Load neighbor `position` and `normal` from `positionAccum`/`normalAccum`, normalize the neighbor normal, and test `dot(shadingNormal, neighborNormal)` against `kSpatialNormalThreshold`.
- Compute a depth discontinuity via `depthDelta = abs(dot(delta, shadingNormal))` and an overall spatial distance check, and skip candidates that exceed thresholds before reservoir loading.
- Keep and reuse the existing `evaluateLightCandidate` call (which performs visibility/shadow testing) to validate candidates that pass the spatial checks.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697624e64494832db0ec34d0f7c7085e)