### PR TITLE
Honor total GPU memory cap in texture/geometry residency logic

### DIFF
--- a/Nomad Path Tracer/README.md
+++ b/Nomad Path Tracer/README.md
@@ -30,6 +30,8 @@ To keep ReSTIR temporal reuse stable for baseline comparisons, you can disable t
 
 The `geometryResidencyMemoryCapMB` scene parameter is now treated as a hard ceiling. Geometry residency allocations (including streaming uploads, prewarm passes, and rebuilds) are rejected if the next allocation would exceed the cap; the renderer queues the request and triggers eviction until enough space is available to retry.
 
+When `totalGpuMemoryCapMB` is set, the renderer also treats the total GPU memory budget (resident content + scratch) as a soft cap. Total memory overages pause new residency allocations and trigger texture eviction, even if the texture residency pool itself is still under `textureResidencyMemoryCapMB`.
+
 ## Bistro test scenes with ReSTIR sampling enabled
 
 The `scene_bistro_test_v2_*_restir_on.xml` variants mirror their corresponding bistro test scenes but explicitly enable ReSTIR sampling via `restirSampling="true"` on the `<Scene>` root. Use these for A/B comparisons that isolate the sampling toggle from other settings.

--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -6674,6 +6674,8 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
   double scratchMB = scratchMemoryMB();
   double residencyMB = std::max(0.0, totalMemoryMB - scratchMB);
   bool overMemory = residencyMB > _textureResidencyMemoryCapMB;
+  bool totalOverCap =
+      _totalGpuMemoryCapMB > 0.0 && totalMemoryMB > _totalGpuMemoryCapMB;
 
   if (!overMemory && totalMemoryMB > _textureResidencyMemoryCapMB &&
       scratchMB > 0.0) {
@@ -6681,13 +6683,17 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
                 "residency=%.2f MB (cap=%.2f MB).\n",
                 totalMemoryMB, scratchMB, residencyMB, _textureResidencyMemoryCapMB);
   }
-  if (!belowBudget && !overMemory)
+  if (!belowBudget && !overMemory && !totalOverCap)
     return;
 
   if (overMemory) {
     std::printf("[TextureResidency] Triggering eviction: residency=%.2f MB (total=%.2f MB, "
                 "scratch=%.2f MB, cap=%.2f MB).\n",
                 residencyMB, totalMemoryMB, scratchMB, _textureResidencyMemoryCapMB);
+  } else if (totalOverCap) {
+    std::printf("[TextureResidency] Triggering eviction: total=%.2f MB "
+                "(residency=%.2f MB, scratch=%.2f MB, cap=%.2f MB).\n",
+                totalMemoryMB, residencyMB, scratchMB, _totalGpuMemoryCapMB);
   }
 
   std::array<ManagedTextureSlot *, 13> slots = {
@@ -6731,9 +6737,9 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
               return a.score < b.score;
             });
 
-  bool stopOnMemory = overMemory;
+  bool stopOnMemory = overMemory || totalOverCap;
   bool stopOnBudget = !belowBudget;
-  bool needMemoryEviction = overMemory;
+  bool needMemoryEviction = overMemory || totalOverCap;
   bool primitiveBudgetSatisfied = belowBudget;
   MTL::BlitCommandEncoder *blit = nullptr;
   for (const ResidencyCandidate &candidate : candidates) {
@@ -6745,7 +6751,10 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
     if (!evictTextureSlot(*candidate.slot, cmd, blit))
       continue;
     residencyMB = std::max(0.0, residencyMB - candidate.bytesMB);
-    needMemoryEviction = residencyMB > _textureResidencyMemoryCapMB;
+    totalMemoryMB = std::max(0.0, totalMemoryMB - candidate.bytesMB);
+    needMemoryEviction =
+        residencyMB > _textureResidencyMemoryCapMB ||
+        (_totalGpuMemoryCapMB > 0.0 && totalMemoryMB > _totalGpuMemoryCapMB);
     primitiveBudgetSatisfied =
         _residentPrimitiveCount < kTextureResidencyPrimitiveBudget;
   }
@@ -7427,7 +7436,7 @@ void Renderer::draw(MTK::View *pView) {
     updateTextureResidency(prepCmd);
 
   bool allowResidency =
-      _needsAccumulationReset || (!belowBudget && !overCap);
+      _needsAccumulationReset || (!belowBudget && !overCap && !totalOverCap);
 
   MTL::BlitCommandEncoder *restoreBlit = nullptr;
   MTL::Texture *accum0 = _accumulationSlots[0].texture;


### PR DESCRIPTION
### Motivation
- Ensure the renderer explicitly enforces the configured total GPU memory soft cap when making texture residency decisions so total memory overages trigger eviction and block new allocations.

### Description
- In `Renderer::updateTextureResidency` introduced a `totalOverCap` check computed from `currentGPUMemoryMB()` and `_totalGpuMemoryCapMB` and use it to trigger eviction even when `residencyMB <= _textureResidencyMemoryCapMB`.
- Extended the eviction loop to decrement `totalMemoryMB` as slots are evicted and to recompute `needMemoryEviction` using the total-cap condition; also updated `stopOnMemory` and `needMemoryEviction` flags to include `totalOverCap`.
- In the per-frame residency gate (draw loop) included `totalOverCap` in the `allowResidency` condition so new `requestResidentTexture` calls are blocked when the total GPU memory is already over the cap; also added a warning print when total is over cap.
- Documented the behavior in `Nomad Path Tracer/README.md` under the “Geometry residency memory cap” section to describe the total GPU memory soft-cap semantics.

### Testing
- No automated tests were executed against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697629249cdc832dbf049355f8f1513b)