### PR TITLE
Refine residency memory reporting and visualization

### DIFF
--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -20,6 +20,13 @@ Benchmark exports now include stochastic residency metrics alongside the existin
 
 These columns complement the existing residency memory statistics in `*_memory_mb` and allow the plotting tools to chart probability-driven residency behavior when comparing runs.
 
+Residency memory reporting now splits the working set into the actual budget components:
+
+- `resident_geometry_memory_mb` – geometry residency tracked by the active strategy (distance, energy, etc.).
+- `resident_texture_memory_mb` – texture and accumulation targets managed by the texture residency pool.
+- `restir_memory_mb` – ReSTIR buffers that scale with resolution when sampling is enabled.
+- `residency_memory_mb` – sum of the above resident components, which is the budget that the residency strategies and caps are meant to manage. Geometry strategy tweaks primarily affect the geometry slice, while texture eviction and ReSTIR toggles influence the other two components.
+
 ## Environment-hit scene attributes
 
 Scenes that opt into the `environment` residency strategy can now tune how aggressively the renderer combats environment-map leaks. The `<Scene>` root accepts the following optional attributes:

--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -1666,7 +1666,8 @@ void Renderer::writeBenchmarkHeader() {
          "primitive_probabilities,"
          "object_probabilities,probabilistic_toggles,"
          "gpu_memory_mb,scratch_memory_mb,resident_geometry_memory_mb,"
-         "residency_memory_mb,texture_memory_cap_mb,geometry_memory_cap_mb,"
+         "resident_texture_memory_mb,restir_memory_mb,residency_memory_mb,"
+         "texture_memory_cap_mb,geometry_memory_cap_mb,"
          "total_memory_cap_mb,over_memory_cap,geometry_over_memory_cap,"
          "total_over_memory_cap,total_memory_overage_warnings,geometry_cap_hits,"
          "geometry_hard_cap_denials,residency_compacted,"
@@ -1761,6 +1762,8 @@ void Renderer::writeBenchmarkRow(const BenchmarkSample &sample) {
       << formatFixed(sample.gpuMemoryMB, 3) << ','
       << formatFixed(sample.scratchMemoryMB, 3) << ','
       << formatFixed(sample.residentGeometryMemoryMB, 3) << ','
+      << formatFixed(sample.residentTextureMemoryMB, 3) << ','
+      << formatFixed(sample.restirMemoryMB, 3) << ','
       << formatFixed(sample.residencyMemoryMB, 3) << ','
       << formatFixed(sample.textureMemoryCapMB, 3) << ','
       << formatFixed(sample.geometryMemoryCapMB, 3) << ','
@@ -12847,13 +12850,17 @@ void Renderer::beginFrameMetrics() {
     sample.residentObjectCount = residentObjects;
     sample.gpuMemoryMB = currentGPUMemoryMB();
     sample.scratchMemoryMB = scratchMemoryMB();
-    sample.residencyMemoryMB =
-        std::max(0.0, sample.gpuMemoryMB - sample.scratchMemoryMB);
     sample.textureMemoryCapMB = _textureResidencyMemoryCapMB;
     sample.geometryMemoryCapMB = _geometryResidencyMemoryCapMB;
     sample.totalMemoryCapMB = _totalGpuMemoryCapMB;
     double geometryResidentMB = residentGeometryMemoryMB();
+    double textureResidentMB = residentTextureMemoryMB();
+    double restirResidentMB = restirMemoryMB();
     sample.residentGeometryMemoryMB = geometryResidentMB;
+    sample.residentTextureMemoryMB = textureResidentMB;
+    sample.restirMemoryMB = restirResidentMB;
+    sample.residencyMemoryMB =
+        std::max(0.0, geometryResidentMB + textureResidentMB + restirResidentMB);
     sample.avgHitProbability = 0.0;
     sample.p95HitProbability = 0.0;
     sample.probabilityThreshold = _residencyConfig.probabilityThreshold;

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -434,6 +434,8 @@ private:
     double gpuMemoryMB = 0.0;
     double scratchMemoryMB = 0.0;
     double residentGeometryMemoryMB = 0.0;
+    double residentTextureMemoryMB = 0.0;
+    double restirMemoryMB = 0.0;
     double residencyMemoryMB = 0.0;
     double textureMemoryCapMB = 0.0;
     double geometryMemoryCapMB = 0.0;

--- a/Nomad Path Tracer/Window/ViewDelegate.cpp
+++ b/Nomad Path Tracer/Window/ViewDelegate.cpp
@@ -32,7 +32,9 @@ ViewDelegate::ViewDelegate(MTL::Device *pDevice)
     std::filesystem::path gpu = base / "gpu_mem.csv";
     _gpuMemLog.open(gpu);
     if (_gpuMemLog.is_open())
-      _gpuMemLog << "frame,gpu_memory_mb\n";
+      _gpuMemLog << "frame,gpu_memory_mb,scratch_memory_mb,"
+                    "resident_geometry_memory_mb,resident_texture_memory_mb,"
+                    "restir_memory_mb,residency_memory_mb\n";
   }
 
   auto parseBoolEnv = [](const char *value) {
@@ -92,8 +94,15 @@ void ViewDelegate::drawInMTKView(MTK::View *pView) {
     _perfLog.flush();
   }
   if (_gpuMemLog.is_open()) {
-    _gpuMemLog << _frameCount << "," << _pRenderer->currentGPUMemoryMB()
-               << "\n";
+    double totalMemory = _pRenderer->currentGPUMemoryMB();
+    double scratchMemory = _pRenderer->scratchMemoryMB();
+    double geometryMemory = _pRenderer->residentGeometryMemoryMB();
+    double textureMemory = _pRenderer->residentTextureMemoryMB();
+    double restirMemory = _pRenderer->restirMemoryMB();
+    double residencyMemory = geometryMemory + textureMemory + restirMemory;
+    _gpuMemLog << _frameCount << "," << totalMemory << "," << scratchMemory
+               << "," << geometryMemory << "," << textureMemory << ","
+               << restirMemory << "," << residencyMemory << "\n";
     _gpuMemLog.flush();
   }
   if (!_dumpPath.empty()) {

--- a/visualize_metrics.py
+++ b/visualize_metrics.py
@@ -67,11 +67,11 @@ def _load_perf_csv(path: Path) -> tuple[List[int], Dict[str, List[float]], Dict[
     return frames, metrics, node_series
 
 
-def _load_gpu_mem_csv(path: Path) -> tuple[List[int], List[float]]:
-    """Return frame numbers and GPU memory usage."""
+def _load_gpu_mem_csv(path: Path) -> tuple[List[int], Dict[str, List[float]]]:
+    """Return frame numbers and GPU memory metrics."""
 
     frames: List[int] = []
-    mem: List[float] = []
+    metrics: Dict[str, List[float]] = {}
 
     if not path.is_file():
         raise FileNotFoundError(path)
@@ -80,12 +80,17 @@ def _load_gpu_mem_csv(path: Path) -> tuple[List[int], List[float]]:
         reader = csv.DictReader(f)
         for row in reader:
             frame_value = row.get("frame")
-            mem_value = row.get("gpu_memory_mb")
-            if frame_value is None or mem_value is None:
-                raise ValueError("gpu_mem.csv must contain 'frame' and 'gpu_memory_mb'")
+            if frame_value is None:
+                raise ValueError("gpu_mem.csv must contain a 'frame' column")
             frames.append(int(frame_value))
-            mem.append(float(mem_value))
-    return frames, mem
+            for key, value in row.items():
+                if key == "frame" or value in (None, ""):
+                    continue
+                try:
+                    metrics.setdefault(key, []).append(float(value))
+                except ValueError:
+                    continue
+    return frames, metrics
 
 
 def _nodes_from_dump(data: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -263,9 +268,10 @@ def _node_figure(frames: Iterable[int], series: Mapping[str, List[int]]) -> go.F
     return fig
 
 
-def _gpu_memory_figure(frames: List[int], mem: List[float]) -> go.Figure:
+def _gpu_memory_figure(frames: List[int], metrics: Mapping[str, List[float]]) -> go.Figure:
     fig = go.Figure()
-    fig.add_trace(go.Scatter(x=frames, y=mem, mode="lines+markers", name="gpu_memory_mb"))
+    for name, values in metrics.items():
+        fig.add_trace(go.Scatter(x=frames, y=values, mode="lines+markers", name=name))
     fig.update_layout(title="GPU memory usage per frame", xaxis_title="Frame", yaxis_title="Memory (MB)")
     return fig
 
@@ -341,13 +347,13 @@ def main() -> None:
 
     gpu_path = args.runs / "gpu_mem.csv"
     try:
-        gpu_frames, gpu_mem = _load_gpu_mem_csv(gpu_path)
+        gpu_frames, gpu_metrics = _load_gpu_mem_csv(gpu_path)
     except FileNotFoundError:
         print(f"Skipping GPU memory plot: {gpu_path} was not found")
     except Exception as exc:  # pragma: no cover - defensive reporting
         print(f"Skipping GPU memory plot: failed to parse {gpu_path}: {exc}")
     else:
-        gpu_fig = _gpu_memory_figure(gpu_frames, gpu_mem)
+        gpu_fig = _gpu_memory_figure(gpu_frames, gpu_metrics)
         gpu_output = args.output_dir / "gpu_memory.html"
         _write_html(gpu_fig, gpu_output, args.auto_open)
         outputs["gpu_memory"] = gpu_output


### PR DESCRIPTION
### Motivation
- Make GPU memory accounting explicit so benchmark logs differentiate scratch versus resident working-set components. 
- Provide separate metrics for geometry, textures, and ReSTIR so residency strategies can be evaluated against the actual budget slices they control. 
- Ensure analysis tooling and documentation reflect the new, more accurate residency breakdown.

### Description
- Added `residentTextureMemoryMB` and `restirMemoryMB` to the `BenchmarkSample` struct and CSV header, and keep `scratchMemoryMB()` unchanged. 
- Compute `residencyMemoryMB` as the sum of resident geometry, resident texture, and ReSTIR buffer footprints instead of inferring it from `gpuMemoryMB - scratchMemoryMB`. 
- Emit the new fields into the per-run GPU CSV (`gpu_mem.csv`) in `ViewDelegate` and log a detailed per-frame memory breakdown (total, scratch, geometry, texture, ReSTIR, residency). 
- Updated `visualize_metrics.py` to parse and plot all GPU memory columns (not just `gpu_memory_mb`) and extended `Benchmarks/README.md` to document the new fields and explain which budget components each residency mechanism affects.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697629b0f118832d96316f6b6c361475)