### PR TITLE
Gate AlwaysResident tile work halving behind env opt-in

### DIFF
--- a/Nomad Path Tracer/README.md
+++ b/Nomad Path Tracer/README.md
@@ -6,7 +6,9 @@ Long-running path tracing commands can trigger GPU timeout errors when the pixel
 
 - **Environment variable:** set `MPT_MAX_TILE_WORK` to the maximum number of pixel/sample operations per command buffer. Example: `MPT_MAX_TILE_WORK=20000`.
 - **Scene XML:** add `maxTileWorkPerCommand="<value>"` (or the alias `maxTileWork`) to the `<Scene>` root to bake a limit into a scene file.
-- **Default:** when unset, the renderer uses a conservative default budget. For `AlwaysResident` residency, the default budget is halved to keep command buffers short while more geometry remains resident.
+- **Default:** when unset, the renderer uses a conservative default budget.
+- **AlwaysResident override (opt-in):** set `MPT_ALWAYS_RESIDENT_TILE_WORK_HALF=1` to halve the default budget when the `AlwaysResident` residency strategy is active.
+- **Benchmarking tip:** set `MPT_MAX_TILE_WORK` (or `maxTileWorkPerCommand` in the scene) to lock the same budget across residency strategies and avoid `MPT_ALWAYS_RESIDENT_TILE_WORK_HALF`.
 
 The renderer clamps the budget so each command can still process at least one full tile, based on the current tile dimensions and sample count.
 

--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -7659,12 +7659,24 @@ void Renderer::draw(MTK::View *pView) {
       return static_cast<size_t>(parsed);
     };
 
+    auto parseAlwaysResidentHalfTileWorkEnv = []() -> bool {
+      const char *env = std::getenv("MPT_ALWAYS_RESIDENT_TILE_WORK_HALF");
+      if (!env)
+        return false;
+      char *end = nullptr;
+      unsigned long parsed = std::strtoul(env, &end, 10);
+      if (end == env)
+        return false;
+      return parsed > 0;
+    };
+
     size_t tileIndex = 0;
     const size_t effectiveMaxSamples = std::max<size_t>(maxSamples, 1);
     const size_t envTileWork = parseMaxTileWorkEnv();
     const bool envTileWorkValid = envTileWork > 0;
     size_t tileWorkBudget = envTileWorkValid ? envTileWork
                                              : kDefaultMaxTileSampleWorkPerCommand;
+    const bool alwaysResidentHalfTileWork = parseAlwaysResidentHalfTileWorkEnv();
     const size_t envMaxTilesPerCommand = parseMaxTilesPerCommandEnv();
     size_t maxTilesPerCommand = envMaxTilesPerCommand > 0
                                     ? envMaxTilesPerCommand
@@ -7679,7 +7691,8 @@ void Renderer::draw(MTK::View *pView) {
     if (!envTileWorkValid && _pScene) {
       if (_pScene->hasCustomMaxTileSampleWorkPerCommand()) {
         tileWorkBudget = _pScene->getMaxTileSampleWorkPerCommand();
-      } else if (_frameStrategy == ResidencyStrategy::AlwaysResident) {
+      } else if (_frameStrategy == ResidencyStrategy::AlwaysResident &&
+                 alwaysResidentHalfTileWork) {
         tileWorkBudget = std::max<size_t>(kDefaultMaxTileSampleWorkPerCommand / 2, 1);
       }
     }


### PR DESCRIPTION
### Motivation
- Prevent implicit halving of the default tile work budget for the `AlwaysResident` strategy so residency strategy does not change runtime work without user consent.
- Provide a clear, documented way to opt into the halved budget and to lock budgets across strategies for fair benchmarking.

### Description
- Add a new environment parser and opt-in flag `MPT_ALWAYS_RESIDENT_TILE_WORK_HALF` in `Renderer::draw` to control AlwaysResident halving behavior.
- Only apply the `kDefaultMaxTileSampleWorkPerCommand / 2` reduction when `_frameStrategy == ResidencyStrategy::AlwaysResident` and `MPT_ALWAYS_RESIDENT_TILE_WORK_HALF` is set.
- Update `Nomad Path Tracer/README.md` to document the new opt-in environment variable and add a benchmarking tip to use `MPT_MAX_TILE_WORK` or `maxTileWorkPerCommand` to lock budgets across strategies.
- Modified files: `Nomad Path Tracer/Renderer/Renderer.cpp` and `Nomad Path Tracer/README.md`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69762b1d6f88832d9f41869bfccd1112)