### PR TITLE
Allow eviction in ReSTIR baseline mode when GPU or residency caps are exceeded

### DIFF
--- a/Nomad Path Tracer/README.md
+++ b/Nomad Path Tracer/README.md
@@ -26,7 +26,8 @@ ReSTIR is now strictly a sampling feature in the path tracing stage. The residen
 To keep ReSTIR temporal reuse stable for baseline comparisons, you can disable texture history eviction:
 
 - **Scene XML:** add `restirBaselineMode="true"` (or `restirBaseline="true"`) to the `<Scene>` root.
-- **Behavior:** no history eviction; maintains stable ReSTIR temporal reuse for baseline comparisons.
+- **Behavior:** no history eviction unless GPU or texture residency caps are exceeded; maintains stable ReSTIR temporal reuse for baseline comparisons.
+- **Warning:** do not use `restirBaselineMode` to compare residency strategies unless caps are still enforced to keep eviction behavior consistent.
 
 ## Geometry residency memory cap
 

--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -6667,10 +6667,6 @@ bool Renderer::evictTextureSlot(ManagedTextureSlot &slot,
 void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
   if (!cmd || _needsAccumulationReset)
     return;
-  if (_residencyConfig.restirBaselineMode) {
-    std::printf("[TextureResidency] Skipping eviction: ReSTIR baseline mode enabled.\n");
-    return;
-  }
 
   bool belowBudget = _residentPrimitiveCount < kTextureResidencyPrimitiveBudget;
   double totalMemoryMB = currentGPUMemoryMB();
@@ -6679,6 +6675,15 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
   bool overMemory = residencyMB > _textureResidencyMemoryCapMB;
   bool totalOverCap =
       _totalGpuMemoryCapMB > 0.0 && totalMemoryMB > _totalGpuMemoryCapMB;
+  if (_residencyConfig.restirBaselineMode) {
+    if (!overMemory && !totalOverCap) {
+      std::printf("[TextureResidency] Baseline mode: skipping eviction; caps not exceeded.\n");
+      return;
+    }
+    std::printf("[TextureResidency] Baseline mode: caps exceeded, allowing eviction "
+                "(residency=%.2f MB, total=%.2f MB, cap=%.2f MB, total cap=%.2f MB).\n",
+                residencyMB, totalMemoryMB, _textureResidencyMemoryCapMB, _totalGpuMemoryCapMB);
+  }
 
   if (!overMemory && totalMemoryMB > _textureResidencyMemoryCapMB &&
       scratchMB > 0.0) {


### PR DESCRIPTION
### Motivation
- Ensure `restirBaselineMode` still prevents history eviction for baseline ReSTIR comparisons while avoiding uncontrolled memory growth when GPU or texture residency caps are exceeded.
- Improve observability and documentation so users can distinguish the baseline bypass from cap-enforced eviction behavior.

### Description
- Update `Renderer::updateTextureResidency` in `Renderer/Renderer.cpp` to replace the unconditional early return on `restirBaselineMode` with a guard that only skips eviction when neither `overMemory` nor `totalOverCap` are true, allowing eviction when caps are exceeded.
- Add explicit log lines to `updateTextureResidency` to indicate when baseline mode is skipping eviction and when caps force eviction (including residency/total/cap values in the message).
- Update `Nomad Path Tracer/README.md` to clarify that `restirBaselineMode` does not evict history unless caps are exceeded and to warn that `restirBaselineMode` should not be used to compare residency strategies unless caps remain enforced.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69762ba90b38832d80e44bd7c0d61130)