### PR TITLE
Unify residency caps under total GPU budget

### DIFF
--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -27,6 +27,18 @@ Residency memory reporting now splits the working set into the actual budget com
 - `restir_memory_mb` – ReSTIR buffers that scale with resolution when sampling is enabled.
 - `residency_memory_mb` – sum of the above resident components, which is the budget that the residency strategies and caps are meant to manage. Geometry strategy tweaks primarily affect the geometry slice, while texture eviction and ReSTIR toggles influence the other two components.
 
+## Residency cap configuration for the study
+
+The renderer now enforces a **single** residency budget using `totalGpuMemoryCapMB`. Geometry allocations and texture evictions both reference this unified cap (which includes resident content + scratch), and the legacy per-pool caps are synced to the same value for reporting/compatibility.
+
+For the study runs reported in the paper/appendix, we fixed the caps to a single value to avoid ambiguity:
+
+- `totalGpuMemoryCapMB = 4096` MB (authoritative)
+- `textureResidencyMemoryCapMB = 4096` MB (synced)
+- `geometryResidencyMemoryCapMB = 4096` MB (synced)
+
+If you override the cap in a scene XML, report `totalGpuMemoryCapMB` explicitly; the renderer will align the texture and geometry caps to that value.
+
 ## Environment-hit scene attributes
 
 Scenes that opt into the `environment` residency strategy can now tune how aggressively the renderer combats environment-map leaks. The `<Scene>` root accepts the following optional attributes:

--- a/Nomad Path Tracer/README.md
+++ b/Nomad Path Tracer/README.md
@@ -29,11 +29,11 @@ To keep ReSTIR temporal reuse stable for baseline comparisons, you can disable t
 - **Behavior:** no history eviction unless GPU or texture residency caps are exceeded; maintains stable ReSTIR temporal reuse for baseline comparisons.
 - **Warning:** do not use `restirBaselineMode` to compare residency strategies unless caps are still enforced to keep eviction behavior consistent.
 
-## Geometry residency memory cap
+## Unified residency memory cap
 
-The `geometryResidencyMemoryCapMB` scene parameter is now treated as a hard ceiling. Geometry residency allocations (including streaming uploads, prewarm passes, and rebuilds) are rejected if the next allocation would exceed the cap; the renderer queues the request and triggers eviction until enough space is available to retry.
+The renderer now treats `totalGpuMemoryCapMB` as the single residency budget for both geometry and textures. Geometry uploads (including streaming/prewarm passes and rebuilds) are deferred if the next allocation would exceed the total cap, and eviction is scheduled before retrying. Texture/accumulation eviction uses the same total cap to decide when to release history.
 
-When `totalGpuMemoryCapMB` is set, the renderer also treats the total GPU memory budget (resident content + scratch) as a soft cap. Total memory overages pause new residency allocations and trigger texture eviction, even if the texture residency pool itself is still under `textureResidencyMemoryCapMB`.
+The legacy per-pool caps (`geometryResidencyMemoryCapMB` and `textureResidencyMemoryCapMB`) are still accepted on the `<Scene>` root, but the renderer syncs them to `totalGpuMemoryCapMB` for compatibility and reporting.
 
 ## Bistro test scenes with ReSTIR sampling enabled
 

--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -568,7 +568,9 @@ size_t Renderer::residentGeometryMemoryBytes() const {
 }
 
 size_t Renderer::geometryResidencyCapBytes() const {
-  double capMB = std::max(0.0, _geometryResidencyMemoryCapMB);
+  double capMB = std::max(
+      0.0, _useUnifiedResidencyCap ? _totalGpuMemoryCapMB
+                                   : _geometryResidencyMemoryCapMB);
   return static_cast<size_t>(capMB * 1024.0 * 1024.0);
 }
 
@@ -592,14 +594,24 @@ bool Renderer::checkGeometryResidencyCap(size_t objectIndex,
                                          size_t requestedBytes,
                                          size_t existingBytes,
                                          const char *context) {
-  if (_geometryResidencyMemoryCapMB <= 0.0)
+  double effectiveCapMB =
+      _useUnifiedResidencyCap ? _totalGpuMemoryCapMB
+                              : _geometryResidencyMemoryCapMB;
+  if (effectiveCapMB <= 0.0)
     return true;
 
-  size_t capBytes = geometryResidencyCapBytes();
+  size_t capBytes =
+      static_cast<size_t>(effectiveCapMB * 1024.0 * 1024.0);
   if (capBytes == 0)
     return true;
 
-  size_t residentBytes = residentGeometryMemoryBytes();
+  size_t residentBytes = 0;
+  if (_useUnifiedResidencyCap) {
+    residentBytes = static_cast<size_t>(
+        std::max(0.0, currentGPUMemoryMB()) * 1024.0 * 1024.0);
+  } else {
+    residentBytes = residentGeometryMemoryBytes();
+  }
   size_t nextBytes = residentBytes >= existingBytes
                          ? residentBytes - existingBytes + requestedBytes
                          : residentBytes + requestedBytes;
@@ -2639,22 +2651,32 @@ void Renderer::updateVisibleScene() {
     _residencyConfig.buildCachedBlas = requiresCachedBlas;
     _pScene->setResidencyParameters(_residencyConfig);
   }
+  _totalGpuMemoryCapMB = std::max(_pScene->getTotalGpuMemoryCapMB(), 0.0);
+  if (_totalGpuMemoryCapMB <= 0.0)
+    _totalGpuMemoryCapMB = kDefaultTotalGpuMemoryCapMB;
+  _useUnifiedResidencyCap = _totalGpuMemoryCapMB > 0.0;
+
   _textureResidencyMemoryCapMB =
       std::max(_pScene->getTextureResidencyMemoryCapMB(), 0.0);
   if (_textureResidencyMemoryCapMB <= 0.0)
     _textureResidencyMemoryCapMB = kDefaultTextureResidencyMemoryCapMB;
-  printf("Texture residency memory cap: %.1f MB\n",
-         _textureResidencyMemoryCapMB);
   _geometryResidencyMemoryCapMB =
       std::max(_pScene->getGeometryResidencyMemoryCapMB(), 0.0);
   if (_geometryResidencyMemoryCapMB <= 0.0)
     _geometryResidencyMemoryCapMB = kDefaultGeometryResidencyMemoryCapMB;
-  printf("Geometry residency memory cap: %.1f MB\n",
-         _geometryResidencyMemoryCapMB);
-  _totalGpuMemoryCapMB = std::max(_pScene->getTotalGpuMemoryCapMB(), 0.0);
-  if (_totalGpuMemoryCapMB <= 0.0)
-    _totalGpuMemoryCapMB = kDefaultTotalGpuMemoryCapMB;
-  printf("Total GPU memory soft cap: %.1f MB\n", _totalGpuMemoryCapMB);
+
+  if (_useUnifiedResidencyCap) {
+    _textureResidencyMemoryCapMB = _totalGpuMemoryCapMB;
+    _geometryResidencyMemoryCapMB = _totalGpuMemoryCapMB;
+    printf("Unified GPU residency cap: %.1f MB (texture/geometry caps synced)\n",
+           _totalGpuMemoryCapMB);
+  } else {
+    printf("Texture residency memory cap: %.1f MB\n",
+           _textureResidencyMemoryCapMB);
+    printf("Geometry residency memory cap: %.1f MB\n",
+           _geometryResidencyMemoryCapMB);
+    printf("Total GPU memory soft cap: %.1f MB\n", _totalGpuMemoryCapMB);
+  }
   _residentCompacted = _pScene->getStartCompacted();
   _compactionCooldown = 0;
 
@@ -5381,10 +5403,24 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
     }
   }
 
-  size_t geometryCapBytes = geometryResidencyCapBytes();
+  double effectiveGeometryCapMB =
+      _useUnifiedResidencyCap ? _totalGpuMemoryCapMB
+                              : _geometryResidencyMemoryCapMB;
+  size_t geometryCapBytes = static_cast<size_t>(
+      std::max(0.0, effectiveGeometryCapMB) * 1024.0 * 1024.0);
   size_t projectedResidentBytes = residentGeometryMemoryBytes();
+  if (_useUnifiedResidencyCap) {
+    size_t totalBytes = static_cast<size_t>(
+        std::max(0.0, currentGPUMemoryMB()) * 1024.0 * 1024.0);
+    size_t nonGeometryBytes =
+        totalBytes > projectedResidentBytes ? totalBytes - projectedResidentBytes
+                                            : 0;
+    geometryCapBytes =
+        geometryCapBytes > nonGeometryBytes ? geometryCapBytes - nonGeometryBytes
+                                            : 0;
+  }
   bool geometryHardCapEnabled =
-      _geometryResidencyMemoryCapMB > 0.0 && geometryCapBytes > 0;
+      effectiveGeometryCapMB > 0.0 && geometryCapBytes > 0;
   bool geometryHardCapReached = _pendingGeometryResidencyOverageBytes > 0;
 
   for (size_t objectIndex = 0; objectIndex < sceneObjects.size(); ++objectIndex) {
@@ -6672,9 +6708,15 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
   double totalMemoryMB = currentGPUMemoryMB();
   double scratchMB = scratchMemoryMB();
   double residencyMB = std::max(0.0, totalMemoryMB - scratchMB);
-  bool overMemory = residencyMB > _textureResidencyMemoryCapMB;
+  double effectiveCapMB =
+      _useUnifiedResidencyCap ? _totalGpuMemoryCapMB
+                              : _textureResidencyMemoryCapMB;
+  bool overMemory = _useUnifiedResidencyCap
+                        ? totalMemoryMB > effectiveCapMB
+                        : residencyMB > effectiveCapMB;
   bool totalOverCap =
-      _totalGpuMemoryCapMB > 0.0 && totalMemoryMB > _totalGpuMemoryCapMB;
+      !_useUnifiedResidencyCap && _totalGpuMemoryCapMB > 0.0 &&
+      totalMemoryMB > _totalGpuMemoryCapMB;
   if (_residencyConfig.restirBaselineMode) {
     if (!overMemory && !totalOverCap) {
       std::printf("[TextureResidency] Baseline mode: skipping eviction; caps not exceeded.\n");
@@ -6682,14 +6724,14 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
     }
     std::printf("[TextureResidency] Baseline mode: caps exceeded, allowing eviction "
                 "(residency=%.2f MB, total=%.2f MB, cap=%.2f MB, total cap=%.2f MB).\n",
-                residencyMB, totalMemoryMB, _textureResidencyMemoryCapMB, _totalGpuMemoryCapMB);
+                residencyMB, totalMemoryMB, effectiveCapMB, _totalGpuMemoryCapMB);
   }
 
-  if (!overMemory && totalMemoryMB > _textureResidencyMemoryCapMB &&
+  if (!overMemory && totalMemoryMB > effectiveCapMB &&
       scratchMB > 0.0) {
     std::printf("[TextureResidency] Skipping eviction: total=%.2f MB, scratch=%.2f MB, "
                 "residency=%.2f MB (cap=%.2f MB).\n",
-                totalMemoryMB, scratchMB, residencyMB, _textureResidencyMemoryCapMB);
+                totalMemoryMB, scratchMB, residencyMB, effectiveCapMB);
   }
   if (!belowBudget && !overMemory && !totalOverCap)
     return;
@@ -6697,7 +6739,7 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
   if (overMemory) {
     std::printf("[TextureResidency] Triggering eviction: residency=%.2f MB (total=%.2f MB, "
                 "scratch=%.2f MB, cap=%.2f MB).\n",
-                residencyMB, totalMemoryMB, scratchMB, _textureResidencyMemoryCapMB);
+                residencyMB, totalMemoryMB, scratchMB, effectiveCapMB);
   } else if (totalOverCap) {
     std::printf("[TextureResidency] Triggering eviction: total=%.2f MB "
                 "(residency=%.2f MB, scratch=%.2f MB, cap=%.2f MB).\n",
@@ -6761,8 +6803,9 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
     residencyMB = std::max(0.0, residencyMB - candidate.bytesMB);
     totalMemoryMB = std::max(0.0, totalMemoryMB - candidate.bytesMB);
     needMemoryEviction =
-        residencyMB > _textureResidencyMemoryCapMB ||
-        (_totalGpuMemoryCapMB > 0.0 && totalMemoryMB > _totalGpuMemoryCapMB);
+        residencyMB > effectiveCapMB ||
+        (!_useUnifiedResidencyCap && _totalGpuMemoryCapMB > 0.0 &&
+         totalMemoryMB > _totalGpuMemoryCapMB);
     primitiveBudgetSatisfied =
         _residentPrimitiveCount < kTextureResidencyPrimitiveBudget;
   }
@@ -6773,15 +6816,27 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
 void Renderer::updateGeometryResidency(MTL::CommandBuffer *cmd) {
   if (!cmd)
     return;
-  if (_geometryResidencyMemoryCapMB <= 0.0)
+  double effectiveCapMB =
+      _useUnifiedResidencyCap ? _totalGpuMemoryCapMB
+                              : _geometryResidencyMemoryCapMB;
+  if (effectiveCapMB <= 0.0)
     return;
 
-  size_t capBytes = geometryResidencyCapBytes();
+  size_t capBytes =
+      static_cast<size_t>(effectiveCapMB * 1024.0 * 1024.0);
   size_t residentBytes = residentGeometryMemoryBytes();
   size_t targetBytes = capBytes;
+  if (_useUnifiedResidencyCap) {
+    size_t totalBytes = static_cast<size_t>(
+        std::max(0.0, currentGPUMemoryMB()) * 1024.0 * 1024.0);
+    size_t nonGeometryBytes =
+        totalBytes > residentBytes ? totalBytes - residentBytes : 0;
+    targetBytes =
+        capBytes > nonGeometryBytes ? capBytes - nonGeometryBytes : 0;
+  }
   if (_pendingGeometryResidencyOverageBytes > 0) {
-    if (capBytes > _pendingGeometryResidencyOverageBytes)
-      targetBytes = capBytes - _pendingGeometryResidencyOverageBytes;
+    if (targetBytes > _pendingGeometryResidencyOverageBytes)
+      targetBytes = targetBytes - _pendingGeometryResidencyOverageBytes;
     else
       targetBytes = 0;
   }

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -578,6 +578,7 @@ private:
   double _textureResidencyMemoryCapMB = 2048.0;
   double _geometryResidencyMemoryCapMB = 2048.0;
   double _totalGpuMemoryCapMB = 4096.0;
+  bool _useUnifiedResidencyCap = false;
 
   std::vector<BlasInstanceRecord> _instanceRecords;
   std::vector<Primitive> _residentPrimitives;


### PR DESCRIPTION
### Motivation

- Align renderer behavior with the study by treating `totalGpuMemoryCapMB` as the authoritative residency budget for both geometry and textures.
- Reduce ambiguity in reporting and experiments by syncing legacy per-pool caps to a single, testable parameter.
- Keep backward compatibility with existing scene XML parameters while making the unified-cap semantics explicit in logs and docs.

### Description

- Add a `_useUnifiedResidencyCap` flag to `Renderer` and set it during initialization when `totalGpuMemoryCapMB > 0.0`, syncing `textureResidencyMemoryCapMB` and `geometryResidencyMemoryCapMB` to `totalGpuMemoryCapMB` and emitting a unified-cap log line.
- Make `geometryResidencyCapBytes()` and `checkGeometryResidencyCap()` use the effective cap when unified, and when unified estimate resident usage from `currentGPUMemoryMB()` to gate geometry uploads and schedule eviction.
- Update `updateGeometryResidency()` to derive a geometry target that reserves space for non-geometry allocations when the unified cap is active, and adjust pending-overage logic accordingly.
- Change `updateTextureResidency()` to use an `effectiveCapMB` and, when unified, compare against `totalMemoryMB` (resident + scratch) for eviction decisions; also update eviction loop checks and logging to use the effective cap.
- Document the new behavior and the study configuration in `Nomad Path Tracer/README.md` and `Benchmarks/README.md`, recording the study values as `totalGpuMemoryCapMB = 4096` MB with per-pool caps synced to that value.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69762d4a4a18832d8e855e62c632a489)