### PR TITLE
Expose renderer GPU memory breakdown accessors

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -126,6 +126,10 @@ public:
   void dumpAccelerationStructure(const std::string &path);
 
   double currentGPUMemoryMB() const;
+  double scratchMemoryMB() const;
+  double residentGeometryMemoryMB() const;
+  double residentTextureMemoryMB() const;
+  double restirMemoryMB() const;
 
   double lastCPUTime() const;
   double lastGPUTime() const;
@@ -198,7 +202,6 @@ private:
   void flushResidencyChanges(bool forceFullRebuild);
   void beginFrameMetrics();
   void completeFrameMetrics(MTL::CommandBuffer *pCmd);
-  double residentGeometryMemoryMB() const;
   size_t residentGeometryMemoryBytes() const;
   size_t geometryResidencyCapBytes() const;
   void recordGeometryResidencyHardCapDenied(size_t objectIndex,
@@ -286,10 +289,7 @@ private:
   void recycleBlasScratchBuffer(MTL::Buffer *buffer, NS::UInteger size);
   void releaseBlasScratchPool();
   void updateBlasScratchResidencyBudget();
-  double scratchMemoryMB() const;
   double residencyMemoryMB() const;
-  double residentTextureMemoryMB() const;
-  double restirMemoryMB() const;
   size_t textureByteSize(MTL::Texture *texture) const;
   
   MTL::Device *_pDevice = nullptr;


### PR DESCRIPTION
### Motivation
- Fix compilation errors in `ViewDelegate.cpp` caused by access to `Renderer` memory fields by providing public getters for those values.
- Allow higher-level code (e.g. view delegate logging) to read detailed GPU memory breakdowns from the `Renderer` API.

### Description
- Promote the following memory accessor declarations to the public section of `Renderer` by adding `double scratchMemoryMB() const;`, `double residentGeometryMemoryMB() const;`, `double residentTextureMemoryMB() const;`, and `double restirMemoryMB() const;` to `Renderer.h`.
- Remove duplicate/private declarations of those accessors from the private section so the header exposes a single public API for these values.
- No other functional changes were made; this is a header-only API visibility adjustment.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697630601dd0832daa9f1006c6150d6b)