### PR TITLE
Handle persistent GPU memory cap overruns

### DIFF
--- a/Nomad Path Tracer/README.md
+++ b/Nomad Path Tracer/README.md
@@ -35,6 +35,8 @@ The renderer now treats `totalGpuMemoryCapMB` as the single residency budget for
 
 The legacy per-pool caps (`geometryResidencyMemoryCapMB` and `textureResidencyMemoryCapMB`) are still accepted on the `<Scene>` root, but the renderer syncs them to `totalGpuMemoryCapMB` for compatibility and reporting.
 
+When the total GPU memory soft cap is exceeded, residency updates can pause to avoid allocating additional history buffers. If the renderer stays over the cap for 120 consecutive frames, it forces an accumulation reset and allows a minimal residency refresh (accumulation + sample count/importance) so rendering can recover. Benchmark runs should note that exceeding the soft cap can temporarily stall residency updates before this fallback kicks in.
+
 ## Bistro test scenes with ReSTIR sampling enabled
 
 The `scene_bistro_test_v2_*_restir_on.xml` variants mirror their corresponding bistro test scenes but explicitly enable ReSTIR sampling via `restirSampling="true"` on the `<Scene>` root. Use these for A/B comparisons that isolate the sampling toggle from other settings.

--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -87,6 +87,7 @@ TaskLimiter &sceneBvhTaskLimiter() {
 
 namespace {
 constexpr float kIdleVisibleExploreSeed = 1.0f;
+constexpr size_t kTotalOverCapResidencyResetFrames = 120;
 }
 
 namespace NomadPathTracer {
@@ -7484,11 +7485,27 @@ void Renderer::draw(MTK::View *pView) {
                       totalMemoryMB > _totalGpuMemoryCapMB;
 
   if (totalOverCap) {
+    ++_totalOverCapFrameStreak;
     ++_frameTotalMemoryOverageWarnings;
     std::printf(
         "[MemoryBudget] Total GPU memory over soft cap: total=%.3f MB "
         "cap=%.3f MB (residency=%.3f MB, scratch=%.3f MB)\n",
         totalMemoryMB, _totalGpuMemoryCapMB, contentMemory, scratchMemoryMB());
+  } else {
+    _totalOverCapFrameStreak = 0;
+  }
+
+  bool totalOverCapPersisted =
+      totalOverCap &&
+      _totalOverCapFrameStreak >= kTotalOverCapResidencyResetFrames;
+  if (totalOverCap &&
+      _totalOverCapFrameStreak == kTotalOverCapResidencyResetFrames) {
+    std::printf(
+        "[MemoryBudget] Total GPU memory over soft cap for %zu frames; "
+        "forcing accumulation reset and minimal residency updates.\n",
+        _totalOverCapFrameStreak);
+    _needsAccumulationReset = true;
+    _accumulationTargetsNeedClear = true;
   }
 
   if (geometryOverCap || _pendingGeometryResidencyOverageBytes > 0 ||
@@ -7498,8 +7515,12 @@ void Renderer::draw(MTK::View *pView) {
   if (!_needsAccumulationReset && (belowBudget || overCap || totalOverCap))
     updateTextureResidency(prepCmd);
 
-  bool allowResidency =
-      _needsAccumulationReset || (!belowBudget && !overCap && !totalOverCap);
+  enum class ResidencyRequestMode { None, Minimal, Full };
+  ResidencyRequestMode residencyMode = ResidencyRequestMode::None;
+  if (_needsAccumulationReset || (!belowBudget && !overCap && !totalOverCap))
+    residencyMode = ResidencyRequestMode::Full;
+  if (totalOverCapPersisted)
+    residencyMode = ResidencyRequestMode::Minimal;
 
   MTL::BlitCommandEncoder *restoreBlit = nullptr;
   MTL::Texture *accum0 = _accumulationSlots[0].texture;
@@ -7515,7 +7536,7 @@ void Renderer::draw(MTK::View *pView) {
   MTL::Texture *restirOutSample = _restirSampleSlots[1].texture;
   MTL::Texture *restirOutNormal = _restirNormalSlots[1].texture;
   MTL::Texture *restirOutState = _restirStateSlots[1].texture;
-  if (allowResidency) {
+  if (residencyMode == ResidencyRequestMode::Full) {
     accum0 = requestResidentTexture(_accumulationSlots[0], prepCmd, restoreBlit);
     accum1 = requestResidentTexture(_accumulationSlots[1], prepCmd, restoreBlit);
     sampleCount = requestResidentTexture(_sampleCountSlot, prepCmd, restoreBlit);
@@ -7537,6 +7558,17 @@ void Renderer::draw(MTK::View *pView) {
         requestResidentTexture(_restirNormalSlots[1], prepCmd, restoreBlit);
     restirOutState =
         requestResidentTexture(_restirStateSlots[1], prepCmd, restoreBlit);
+  } else if (residencyMode == ResidencyRequestMode::Minimal) {
+    accum0 = requestResidentTexture(_accumulationSlots[0], prepCmd, restoreBlit);
+    accum1 = requestResidentTexture(_accumulationSlots[1], prepCmd, restoreBlit);
+    sampleCount = requestResidentTexture(_sampleCountSlot, prepCmd, restoreBlit);
+    sampleImportance =
+        requestResidentTexture(_sampleImportanceSlot, prepCmd, restoreBlit);
+  } else if (totalOverCap) {
+    std::printf(
+        "[MemoryBudget] Residency updates paused: total=%.3f MB "
+        "cap=%.3f MB.\n",
+        totalMemoryMB, _totalGpuMemoryCapMB);
   }
 
   auto ensureSlotReady = [&](ManagedTextureSlot &slot, MTL::Texture *&handle) {

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -708,6 +708,7 @@ private:
   size_t _frameGeometryResidencyCapHitCount = 0;
   size_t _frameGeometryResidencyHardCapDeniedCount = 0;
   size_t _frameTotalMemoryOverageWarnings = 0;
+  size_t _totalOverCapFrameStreak = 0;
   size_t _geometryResidencyCapHitCount = 0;
   size_t _geometryResidencyHardCapDeniedCount = 0;
   size_t _pendingGeometryResidencyOverageBytes = 0;


### PR DESCRIPTION
### Motivation

- Prevent uncontrolled allocation or stalled recovery when the renderer stays above the `totalGpuMemoryCapMB` soft cap for many frames by tracking sustained over-cap conditions.  
- Provide clearer logging when residency updates are paused due to total GPU memory overage so benchmarks and debugging can see cap vs current usage.  
- Provide a deterministic fallback that forces an accumulation reset and allows a minimal residency refresh after N frames so rendering can recover without fully re-enabling large history uploads.  

### Description

- Added a new constant `kTotalOverCapResidencyResetFrames` (120) and a renderer state counter `_totalOverCapFrameStreak` to track consecutive frames over the soft total GPU cap.  
- Increment and log on each `totalOverCap` detection and reset the streak when the condition clears, and emit a special log when the streak reaches the threshold.  
- When the over-cap streak persists for the threshold, force `_needsAccumulationReset = true` and `_accumulationTargetsNeedClear = true` to trigger a controlled reset and recovery path.  
- Introduced an internal `ResidencyRequestMode` with `Full`/`Minimal`/`None` to select between the normal full residency requests and a minimal fallback which only requests accumulation, sample count and importance textures; added a log message when residency updates are paused.  
- Documented this behavior in `Nomad Path Tracer/README.md` so benchmark results note that exceeding the soft cap can pause residency updates for up to 120 frames before the fallback triggers.  

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69763ca8b100832d9ce14dc43d6fe7ec)