### PR TITLE
Add residency diagnostics for non-evictable resources

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -6754,6 +6754,11 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
       &_restirNormalSlots[0], &_restirNormalSlots[1],
       &_restirStateSlots[0], &_restirStateSlots[1]};
 
+  size_t nonEvictableBytes = 0;
+  for (MTL::Texture *texture : _materialTextures)
+    nonEvictableBytes += textureByteSize(texture);
+  nonEvictableBytes += textureByteSize(_environmentTexture);
+
   struct ResidencyCandidate {
     ManagedTextureSlot *slot = nullptr;
     double score = 0.0;
@@ -6779,6 +6784,26 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
     if (!slot->texture)
       continue;
     candidates.push_back(scoreSlot(slot));
+  }
+
+  if (overMemory || totalOverCap) {
+    double nonEvictableMB =
+        static_cast<double>(nonEvictableBytes) / (1024.0 * 1024.0);
+    size_t effectiveCapBytes =
+        static_cast<size_t>(std::max(0.0, effectiveCapMB) * 1024.0 * 1024.0);
+    std::printf(
+        "[TextureResidency] Non-evictable resident bytes this frame: %zu (%.2f "
+        "MB).\n",
+        nonEvictableBytes, nonEvictableMB);
+    if (effectiveCapBytes > 0 && effectiveCapBytes < nonEvictableBytes) {
+      double capMB =
+          static_cast<double>(effectiveCapBytes) / (1024.0 * 1024.0);
+      std::printf(
+          "[TextureResidency][Warning] Eviction cannot resolve over-cap "
+          "condition: cap=%.2f MB below minimum resident footprint of %.2f "
+          "MB (non-evictable=%zu bytes).\n",
+          capMB, nonEvictableMB, nonEvictableBytes);
+    }
   }
 
   std::sort(candidates.begin(), candidates.end(),
@@ -6872,6 +6897,7 @@ void Renderer::updateGeometryResidency(MTL::CommandBuffer *cmd) {
 
   std::vector<GeometryCandidate> candidates;
   candidates.reserve(_residentObjectGpuResources.size());
+  size_t evictableBytes = 0;
   for (size_t objectIndex = 0; objectIndex < _residentObjectGpuResources.size();
        ++objectIndex) {
     const auto &resident = _residentObjectGpuResources[objectIndex];
@@ -6885,6 +6911,7 @@ void Renderer::updateGeometryResidency(MTL::CommandBuffer *cmd) {
     if (bytesMB <= 0.0)
       continue;
 
+    evictableBytes += resident.byteSize;
     uint64_t lastHitFrame = 0;
     if (objectIndex < _objectHitLastFrame.size())
       lastHitFrame = _objectHitLastFrame[objectIndex];
@@ -6899,6 +6926,22 @@ void Renderer::updateGeometryResidency(MTL::CommandBuffer *cmd) {
       score += 1.0;
 
     candidates.push_back({objectIndex, score, bytesMB});
+  }
+
+  size_t nonEvictableBytes =
+      residentBytes > evictableBytes ? residentBytes - evictableBytes : 0;
+  double nonEvictableMB =
+      static_cast<double>(nonEvictableBytes) / (1024.0 * 1024.0);
+  std::printf(
+      "[GeometryResidency] Non-evictable resident bytes this frame: %zu (%.2f "
+      "MB).\n",
+      nonEvictableBytes, nonEvictableMB);
+  if (targetBytes < nonEvictableBytes) {
+    std::printf(
+        "[GeometryResidency][Warning] Eviction cannot resolve over-cap "
+        "condition: target=%.2f MB below minimum resident footprint of %.2f "
+        "MB (non-evictable=%zu bytes).\n",
+        targetMB, nonEvictableMB, nonEvictableBytes);
   }
 
   std::sort(candidates.begin(), candidates.end(),


### PR DESCRIPTION
### Motivation
- Improve observability when residency eviction cannot bring GPU memory under configured caps by reporting the portion of resident resources that cannot be evicted this frame.
- Make it explicit in logs when the configured cap/target is below the minimum resident footprint so operators understand eviction alone cannot resolve over-cap conditions.

### Description
- In `Nomad Path Tracer/Renderer/Renderer.cpp` added diagnostics to `updateTextureResidency` to compute non-evictable texture bytes (material textures + environment texture) and log the total along with a warning when the effective cap is below that footprint, using `std::printf`.
- In `updateGeometryResidency` accumulated `evictableBytes` for resident geometry and computed `nonEvictableBytes = residentBytes - evictableBytes`, logging the non-evictable geometry bytes and emitting a warning when the computed `target` is below that footprint.
- Kept changes local to the two residency update functions and used existing helpers like `textureByteSize` and `residentGeometryMemoryBytes` to produce MB-formatted diagnostics.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69763dfd1c18832d833ac2f567520d42)