### PR TITLE
Account for total cap pressure in geometry eviction

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -6852,13 +6852,22 @@ void Renderer::updateGeometryResidency(MTL::CommandBuffer *cmd) {
       static_cast<size_t>(effectiveCapMB * 1024.0 * 1024.0);
   size_t residentBytes = residentGeometryMemoryBytes();
   size_t targetBytes = capBytes;
+  size_t totalBytes = static_cast<size_t>(
+      std::max(0.0, currentGPUMemoryMB()) * 1024.0 * 1024.0);
+  size_t nonGeometryBytes =
+      totalBytes > residentBytes ? totalBytes - residentBytes : 0;
   if (_useUnifiedResidencyCap) {
-    size_t totalBytes = static_cast<size_t>(
-        std::max(0.0, currentGPUMemoryMB()) * 1024.0 * 1024.0);
-    size_t nonGeometryBytes =
-        totalBytes > residentBytes ? totalBytes - residentBytes : 0;
     targetBytes =
         capBytes > nonGeometryBytes ? capBytes - nonGeometryBytes : 0;
+  } else if (_totalGpuMemoryCapMB > 0.0 &&
+             totalBytes >
+                 static_cast<size_t>(_totalGpuMemoryCapMB * 1024.0 * 1024.0)) {
+    size_t totalCapBytes =
+        static_cast<size_t>(_totalGpuMemoryCapMB * 1024.0 * 1024.0);
+    size_t totalTargetBytes =
+        totalCapBytes > nonGeometryBytes ? totalCapBytes - nonGeometryBytes : 0;
+    if (totalTargetBytes < targetBytes)
+      targetBytes = totalTargetBytes;
   }
   if (_pendingGeometryResidencyOverageBytes > 0) {
     if (targetBytes > _pendingGeometryResidencyOverageBytes)


### PR DESCRIPTION
### Motivation
- Geometry eviction previously only reduced residency to satisfy the geometry-specific cap or the unified cap, which could allow total GPU memory to exceed `totalGpuMemoryCapMB` when per-pool caps were active.
- This change makes geometry eviction aware of overall GPU cap pressure so geometry can be released to help bring total memory under `totalGpuMemoryCapMB` even when `geometryResidencyMemoryCapMB` is not exceeded.

### Description
- Compute `totalBytes` and `nonGeometryBytes` once and reuse them when computing the geometry eviction target.
- Preserve the existing `_useUnifiedResidencyCap` behavior while adding a new branch that, when `_useUnifiedResidencyCap` is false and `_totalGpuMemoryCapMB` is exceeded, computes a `totalTargetBytes` from the total cap and non-geometry usage and lowers `targetBytes` accordingly.
- Apply the change in `Renderer::updateGeometryResidency` in `Renderer.cpp` so pending geometry allocation overage and eviction selection respect total-cap pressure.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697641599364832d9c231b9e1ad3008c)