### PR TITLE
Make total GPU memory cap authoritative for residency and add eviction‑stall fallback

### DIFF
--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -27,6 +27,14 @@ Residency memory reporting now splits the working set into the actual budget com
 - `restir_memory_mb` – ReSTIR buffers that scale with resolution when sampling is enabled.
 - `residency_memory_mb` – sum of the above resident components, which is the budget that the residency strategies and caps are meant to manage. Geometry strategy tweaks primarily affect the geometry slice, while texture eviction and ReSTIR toggles influence the other two components.
 
+Total-cap enforcement now adds memory-budget context to the benchmark exports:
+
+- `total_memory_cap_mb` – effective total GPU memory cap in MB (authoritative budget).
+- `minimum_resident_footprint_mb` – estimated minimum resident footprint (history + mandatory buffers + essential geometry).
+- `total_memory_cap_relaxed_mb` – temporary relaxed cap (0 when inactive) if the configured total cap is below the minimum footprint.
+- `total_memory_cap_denials` – number of allocations denied due to the total cap during the frame.
+- `total_memory_eviction_stall` – 1 when the system is in eviction-stall mode (total cap below footprint or pending overage).
+
 ## Environment-hit scene attributes
 
 Scenes that opt into the `environment` residency strategy can now tune how aggressively the renderer combats environment-map leaks. The `<Scene>` root accepts the following optional attributes:

--- a/Nomad Path Tracer/README.md
+++ b/Nomad Path Tracer/README.md
@@ -31,9 +31,13 @@ To keep ReSTIR temporal reuse stable for baseline comparisons, you can disable t
 
 ## Geometry residency memory cap
 
-The `geometryResidencyMemoryCapMB` scene parameter is now treated as a hard ceiling. Geometry residency allocations (including streaming uploads, prewarm passes, and rebuilds) are rejected if the next allocation would exceed the cap; the renderer queues the request and triggers eviction until enough space is available to retry.
+The `geometryResidencyMemoryCapMB` scene parameter remains a hard ceiling. Geometry residency allocations (including streaming uploads, prewarm passes, and rebuilds) are rejected if the next allocation would exceed the cap; the renderer queues the request and triggers eviction until enough space is available to retry.
 
-When `totalGpuMemoryCapMB` is set, the renderer also treats the total GPU memory budget (resident content + scratch) as a soft cap. Total memory overages pause new residency allocations and trigger texture eviction, even if the texture residency pool itself is still under `textureResidencyMemoryCapMB`.
+For the memory-budget study, `totalGpuMemoryCapMB` is now the single authoritative (hard) budget. Both texture and geometry allocations check the total cap before proceeding; if the next allocation would exceed the cap, the renderer blocks the allocation and evicts residency from textures and geometry until the total budget is satisfied.
+
+To prevent eviction scheduling deadlocks, the renderer estimates a minimum resident footprint (history + mandatory buffers + essential geometry). If the configured total cap remains below this footprint for several frames, it logs a warning, disables history, forces an accumulation reset, and temporarily relaxes the effective total cap to the minimum footprint. Benchmark metrics report the minimum footprint, relaxed cap, and whether the frame is in eviction-stall mode.
+
+See `StudyNotes.md` for the study-specific memory budget notes and recommended interpretation of the new metrics.
 
 ## Bistro test scenes with ReSTIR sampling enabled
 

--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -87,6 +87,7 @@ TaskLimiter &sceneBvhTaskLimiter() {
 
 namespace {
 constexpr float kIdleVisibleExploreSeed = 1.0f;
+constexpr size_t kTotalMemoryCapStallFrames = 8;
 }
 
 namespace NomadPathTracer {
@@ -572,6 +573,98 @@ size_t Renderer::geometryResidencyCapBytes() const {
   return static_cast<size_t>(capMB * 1024.0 * 1024.0);
 }
 
+double Renderer::effectiveTotalGpuMemoryCapMB() const {
+  if (_totalGpuMemoryCapMB <= 0.0)
+    return 0.0;
+  if (_totalMemoryCapRelaxedMB <= 0.0)
+    return _totalGpuMemoryCapMB;
+  return std::max(_totalGpuMemoryCapMB, _totalMemoryCapRelaxedMB);
+}
+
+size_t Renderer::totalGpuMemoryCapBytes() const {
+  double capMB = effectiveTotalGpuMemoryCapMB();
+  if (capMB <= 0.0)
+    return 0;
+  return static_cast<size_t>(capMB * 1024.0 * 1024.0);
+}
+
+size_t Renderer::historyFootprintBytes() const {
+  size_t totalBytes = 0;
+  auto addSlot = [&](const ManagedTextureSlot &slot) {
+    totalBytes += textureByteSize(slot);
+  };
+
+  addSlot(_accumulationSlots[0]);
+  addSlot(_accumulationSlots[1]);
+  addSlot(_sampleCountSlot);
+  addSlot(_sampleImportanceSlot);
+  addSlot(_restirSampleSlots[0]);
+  addSlot(_restirSampleSlots[1]);
+  addSlot(_restirNormalSlots[0]);
+  addSlot(_restirNormalSlots[1]);
+  addSlot(_restirStateSlots[0]);
+  addSlot(_restirStateSlots[1]);
+
+  return totalBytes;
+}
+
+size_t Renderer::essentialGeometryMemoryBytes() const {
+  size_t totalBytes = 0;
+  for (size_t objectIndex = 0; objectIndex < _residentObjectGpuResources.size();
+       ++objectIndex) {
+    const auto &resident = _residentObjectGpuResources[objectIndex];
+    if (resident.state == ResidentObjectGpuResources::ResidencyState::Cold)
+      continue;
+    bool essential = true;
+    if (objectIndex < _objectActive.size())
+      essential = _objectActive[objectIndex];
+    if (essential)
+      totalBytes += resident.byteSize;
+  }
+  return totalBytes;
+}
+
+size_t Renderer::minimumResidentFootprintBytes() const {
+  GpuMemoryTracker::Snapshot snapshot = _gpuMemoryTracker.snapshot();
+  size_t mandatoryBytes =
+      snapshot.bytes[static_cast<size_t>(
+          GpuMemoryTracker::Category::RendererBuffers)] +
+      snapshot.bytes[static_cast<size_t>(GpuMemoryTracker::Category::HeapsAS)];
+  size_t historyBytes = historyFootprintBytes();
+  size_t geometryBytes = essentialGeometryMemoryBytes();
+  return mandatoryBytes + historyBytes + geometryBytes;
+}
+
+bool Renderer::checkTotalMemoryCap(size_t requestedBytes, size_t existingBytes,
+                                   const char *context) {
+  size_t capBytes = totalGpuMemoryCapBytes();
+  if (capBytes == 0 || !_pDevice)
+    return true;
+
+  size_t totalBytes = static_cast<size_t>(_pDevice->currentAllocatedSize());
+  size_t nextBytes = totalBytes >= existingBytes
+                         ? totalBytes - existingBytes + requestedBytes
+                         : totalBytes + requestedBytes;
+  if (nextBytes <= capBytes)
+    return true;
+
+  size_t overageBytes = nextBytes - capBytes;
+  _pendingTotalMemoryOverageBytes =
+      std::max(_pendingTotalMemoryOverageBytes, overageBytes);
+  ++_totalMemoryCapDeniedCount;
+  ++_frameTotalMemoryCapDeniedCount;
+
+  std::printf(
+      "[MemoryBudget] Total memory cap deny (%s): requested %.2f MB "
+      "(existing %.2f MB), total %.2f MB cap %.2f MB.\n",
+      context ? context : "unspecified",
+      static_cast<double>(requestedBytes) / (1024.0 * 1024.0),
+      static_cast<double>(existingBytes) / (1024.0 * 1024.0),
+      static_cast<double>(totalBytes) / (1024.0 * 1024.0),
+      static_cast<double>(capBytes) / (1024.0 * 1024.0));
+  return false;
+}
+
 void Renderer::recordGeometryResidencyHardCapDenied(
     size_t objectIndex, size_t requestedBytes, size_t existingBytes,
     size_t residentBytes, size_t capBytes, const char *context) {
@@ -593,11 +686,13 @@ bool Renderer::checkGeometryResidencyCap(size_t objectIndex,
                                          size_t existingBytes,
                                          const char *context) {
   if (_geometryResidencyMemoryCapMB <= 0.0)
-    return true;
+    return checkTotalMemoryCap(requestedBytes, existingBytes,
+                               context ? context : "geometry");
 
   size_t capBytes = geometryResidencyCapBytes();
   if (capBytes == 0)
-    return true;
+    return checkTotalMemoryCap(requestedBytes, existingBytes,
+                               context ? context : "geometry");
 
   size_t residentBytes = residentGeometryMemoryBytes();
   size_t nextBytes = residentBytes >= existingBytes
@@ -605,7 +700,8 @@ bool Renderer::checkGeometryResidencyCap(size_t objectIndex,
                          : residentBytes + requestedBytes;
 
   if (nextBytes <= capBytes)
-    return true;
+    return checkTotalMemoryCap(requestedBytes, existingBytes,
+                               context ? context : "geometry");
 
   size_t overageBytes = nextBytes - capBytes;
   _pendingGeometryResidencyOverageBytes =
@@ -1307,6 +1403,23 @@ MTL::Texture *Renderer::allocateTexture(MTL::TextureDescriptor *descriptor,
   if (!_pDevice || !descriptor)
     return nullptr;
 
+  if (category == GpuMemoryTracker::Category::Textures ||
+      category == GpuMemoryTracker::Category::Restir) {
+    size_t pixelBytes = bytesPerPixel(descriptor->pixelFormat());
+    if (pixelBytes > 0) {
+      size_t width = static_cast<size_t>(descriptor->width());
+      size_t height = static_cast<size_t>(descriptor->height());
+      size_t depth = std::max<size_t>(1, descriptor->depth());
+      size_t rowBytes = width * pixelBytes;
+      size_t alignedRowBytes = alignTo(rowBytes, 256);
+      size_t sliceBytes = alignedRowBytes * height * depth;
+      size_t arrayLength = std::max<size_t>(1, descriptor->arrayLength());
+      size_t estimatedBytes = sliceBytes * arrayLength;
+      if (!checkTotalMemoryCap(estimatedBytes, 0, label ? label : "texture"))
+        return nullptr;
+    }
+  }
+
   MTL::Texture *texture = _pDevice->newTexture(descriptor);
   if (!texture)
     return nullptr;
@@ -1705,8 +1818,10 @@ void Renderer::writeBenchmarkHeader() {
          "gpu_memory_mb,scratch_memory_mb,resident_geometry_memory_mb,"
          "resident_texture_memory_mb,restir_memory_mb,residency_memory_mb,"
          "texture_memory_cap_mb,geometry_memory_cap_mb,"
-         "total_memory_cap_mb,over_memory_cap,geometry_over_memory_cap,"
-         "total_over_memory_cap,total_memory_overage_warnings,geometry_cap_hits,"
+         "total_memory_cap_mb,minimum_resident_footprint_mb,"
+         "total_memory_cap_relaxed_mb,over_memory_cap,geometry_over_memory_cap,"
+         "total_over_memory_cap,total_memory_overage_warnings,"
+         "total_memory_cap_denials,total_memory_eviction_stall,geometry_cap_hits,"
          "geometry_hard_cap_denials,residency_compacted,"
          "accumulation_reset,ray_hit_decay,state_cooldown_frames,lod_toggle_budget,"
          "energy_toggle_budget,screen_toggle_budget,rayhit_toggle_budget,"
@@ -1807,10 +1922,14 @@ void Renderer::writeBenchmarkRow(const BenchmarkSample &sample) {
       << formatFixed(sample.textureMemoryCapMB, 3) << ','
       << formatFixed(sample.geometryMemoryCapMB, 3) << ','
       << formatFixed(sample.totalMemoryCapMB, 3) << ','
+      << formatFixed(sample.minimumResidentFootprintMB, 3) << ','
+      << formatFixed(sample.totalMemoryCapRelaxedMB, 3) << ','
       << boolToInt(sample.overMemoryCap) << ','
       << boolToInt(sample.geometryOverMemoryCap) << ','
       << boolToInt(sample.totalOverMemoryCap) << ','
       << sample.totalMemoryOverageWarnings << ','
+      << sample.totalMemoryCapDeniedCount << ','
+      << boolToInt(sample.totalMemoryEvictionStall) << ','
       << sample.geometryCapHitCount << ','
       << sample.geometryHardCapDeniedCount << ','
       << boolToInt(sample.residentCompacted) << ','
@@ -2693,7 +2812,8 @@ void Renderer::updateVisibleScene() {
   _totalGpuMemoryCapMB = std::max(_pScene->getTotalGpuMemoryCapMB(), 0.0);
   if (_totalGpuMemoryCapMB <= 0.0)
     _totalGpuMemoryCapMB = kDefaultTotalGpuMemoryCapMB;
-  printf("Total GPU memory soft cap: %.1f MB\n", _totalGpuMemoryCapMB);
+  printf("Total GPU memory hard cap (authoritative budget): %.1f MB\n",
+         _totalGpuMemoryCapMB);
   _residentCompacted = _pScene->getStartCompacted();
   _compactionCooldown = 0;
 
@@ -6337,6 +6457,33 @@ void Renderer::clearTextureHistory(ManagedTextureSlot &slot) {
   slot.needsGpuRefresh = false;
 }
 
+void Renderer::disableHistoryForMemoryCap() {
+  auto disableSlot = [&](ManagedTextureSlot &slot) {
+    clearTextureHistory(slot);
+    slot.stagingValid = false;
+    if (slot.stagingBuffer) {
+      releaseTrackedResource(slot.stagingBuffer);
+      slot.stagingBuffer = nullptr;
+      slot.stagingCapacity = 0;
+    }
+  };
+
+  disableSlot(_accumulationSlots[0]);
+  disableSlot(_accumulationSlots[1]);
+  disableSlot(_sampleCountSlot);
+  disableSlot(_sampleImportanceSlot);
+  disableSlot(_restirSampleSlots[0]);
+  disableSlot(_restirSampleSlots[1]);
+  disableSlot(_restirNormalSlots[0]);
+  disableSlot(_restirNormalSlots[1]);
+  disableSlot(_restirStateSlots[0]);
+  disableSlot(_restirStateSlots[1]);
+
+  _frameRestirHistoryReset = true;
+  _needsAccumulationReset = true;
+  _accumulationTargetsNeedClear = true;
+}
+
 bool Renderer::captureCpuHistoryProxy(ManagedTextureSlot &slot) {
   clearTextureHistory(slot);
 
@@ -6530,6 +6677,15 @@ MTL::Texture *Renderer::requestResidentTexture(ManagedTextureSlot &slot,
   }
 
   const char *label = textureSlotLabel(slot);
+  size_t requestedBytes = textureByteSize(slot);
+  if (!checkTotalMemoryCap(requestedBytes, 0, label)) {
+    std::printf(
+        "[TextureResidency] Deferring slot %s: total memory cap would be exceeded.\n",
+        label);
+    _needsAccumulationReset = true;
+    _accumulationTargetsNeedClear = true;
+    return nullptr;
+  }
   MTL::TextureDescriptor *descriptor =
       MTL::TextureDescriptor::alloc()->init();
   descriptor->setTextureType(slot.textureType);
@@ -6725,8 +6881,10 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
   double scratchMB = scratchMemoryMB();
   double residencyMB = std::max(0.0, totalMemoryMB - scratchMB);
   bool overMemory = residencyMB > _textureResidencyMemoryCapMB;
-  bool totalOverCap =
-      _totalGpuMemoryCapMB > 0.0 && totalMemoryMB > _totalGpuMemoryCapMB;
+  double totalCapMB = effectiveTotalGpuMemoryCapMB();
+  bool totalOverCap = totalCapMB > 0.0 &&
+                      (totalMemoryMB > totalCapMB ||
+                       _pendingTotalMemoryOverageBytes > 0);
   if (_residencyConfig.restirBaselineMode) {
     if (!overMemory && !totalOverCap) {
       std::printf("[TextureResidency] Baseline mode: skipping eviction; caps not exceeded.\n");
@@ -6734,7 +6892,7 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
     }
     std::printf("[TextureResidency] Baseline mode: caps exceeded, allowing eviction "
                 "(residency=%.2f MB, total=%.2f MB, cap=%.2f MB, total cap=%.2f MB).\n",
-                residencyMB, totalMemoryMB, _textureResidencyMemoryCapMB, _totalGpuMemoryCapMB);
+                residencyMB, totalMemoryMB, _textureResidencyMemoryCapMB, totalCapMB);
   }
 
   if (!overMemory && totalMemoryMB > _textureResidencyMemoryCapMB &&
@@ -6753,7 +6911,7 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
   } else if (totalOverCap) {
     std::printf("[TextureResidency] Triggering eviction: total=%.2f MB "
                 "(residency=%.2f MB, scratch=%.2f MB, cap=%.2f MB).\n",
-                totalMemoryMB, residencyMB, scratchMB, _totalGpuMemoryCapMB);
+                totalMemoryMB, residencyMB, scratchMB, totalCapMB);
   }
 
   constexpr double kRestirEvictionOverageFactor = 1.25;
@@ -6828,9 +6986,16 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
       continue;
     residencyMB = std::max(0.0, residencyMB - candidate.bytesMB);
     totalMemoryMB = std::max(0.0, totalMemoryMB - candidate.bytesMB);
+    if (_pendingTotalMemoryOverageBytes > 0) {
+      size_t bytes = static_cast<size_t>(candidate.bytesMB * 1024.0 * 1024.0);
+      _pendingTotalMemoryOverageBytes =
+          _pendingTotalMemoryOverageBytes > bytes
+              ? _pendingTotalMemoryOverageBytes - bytes
+              : 0;
+    }
     needMemoryEviction =
         residencyMB > _textureResidencyMemoryCapMB ||
-        (_totalGpuMemoryCapMB > 0.0 && totalMemoryMB > _totalGpuMemoryCapMB);
+        (totalCapMB > 0.0 && totalMemoryMB > totalCapMB);
     primitiveBudgetSatisfied =
         _residentPrimitiveCount < kTextureResidencyPrimitiveBudget;
   }
@@ -6841,22 +7006,42 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
 void Renderer::updateGeometryResidency(MTL::CommandBuffer *cmd) {
   if (!cmd)
     return;
-  if (_geometryResidencyMemoryCapMB <= 0.0)
+  double totalCapMB = effectiveTotalGpuMemoryCapMB();
+  size_t totalCapBytes = totalGpuMemoryCapBytes();
+  size_t totalBytes =
+      _pDevice ? static_cast<size_t>(_pDevice->currentAllocatedSize()) : 0;
+  size_t totalOverageBytes = 0;
+  if (totalCapBytes > 0) {
+    if (totalBytes > totalCapBytes)
+      totalOverageBytes = totalBytes - totalCapBytes;
+    if (_pendingTotalMemoryOverageBytes > totalOverageBytes)
+      totalOverageBytes = _pendingTotalMemoryOverageBytes;
+  }
+  if (_geometryResidencyMemoryCapMB <= 0.0 && totalOverageBytes == 0)
     return;
 
   size_t capBytes = geometryResidencyCapBytes();
   size_t residentBytes = residentGeometryMemoryBytes();
-  size_t targetBytes = capBytes;
+  size_t targetBytes = residentBytes;
   if (_pendingGeometryResidencyOverageBytes > 0) {
     if (capBytes > _pendingGeometryResidencyOverageBytes)
       targetBytes = capBytes - _pendingGeometryResidencyOverageBytes;
     else
       targetBytes = 0;
+  } else if (_geometryResidencyMemoryCapMB > 0.0) {
+    targetBytes = capBytes;
+  }
+  if (totalOverageBytes > 0) {
+    size_t totalTarget =
+        residentBytes > totalOverageBytes ? residentBytes - totalOverageBytes : 0;
+    targetBytes = std::min(targetBytes, totalTarget);
   }
 
   if (residentBytes <= targetBytes) {
     if (_pendingGeometryResidencyOverageBytes > 0)
       _pendingGeometryResidencyOverageBytes = 0;
+    if (totalOverageBytes == 0)
+      _pendingTotalMemoryOverageBytes = 0;
     return;
   }
 
@@ -6865,7 +7050,13 @@ void Renderer::updateGeometryResidency(MTL::CommandBuffer *cmd) {
   double capMB = static_cast<double>(capBytes) / (1024.0 * 1024.0);
   double targetMB = static_cast<double>(targetBytes) / (1024.0 * 1024.0);
 
-  if (_pendingGeometryResidencyOverageBytes > 0) {
+  if (totalOverageBytes > 0) {
+    std::printf(
+        "[GeometryResidency] Total memory eviction: total=%.2f MB cap=%.2f MB, "
+        "residency=%.2f MB target=%.2f MB.\n",
+        static_cast<double>(totalBytes) / (1024.0 * 1024.0), totalCapMB,
+        residentMB, targetMB);
+  } else if (_pendingGeometryResidencyOverageBytes > 0) {
     std::printf(
         "[GeometryResidency] Over budget eviction: residency=%.2f MB (cap=%.2f "
         "MB, target=%.2f MB) to satisfy pending allocation.\n",
@@ -6935,6 +7126,13 @@ void Renderer::updateGeometryResidency(MTL::CommandBuffer *cmd) {
         residentBytes > static_cast<size_t>(candidateBytes)
             ? residentBytes - static_cast<size_t>(candidateBytes)
             : 0;
+    if (_pendingTotalMemoryOverageBytes > 0) {
+      size_t bytes = static_cast<size_t>(candidateBytes);
+      _pendingTotalMemoryOverageBytes =
+          _pendingTotalMemoryOverageBytes > bytes
+              ? _pendingTotalMemoryOverageBytes - bytes
+              : 0;
+    }
   }
 
   if (residentBytes <= targetBytes)
@@ -7517,6 +7715,39 @@ void Renderer::draw(MTK::View *pView) {
   Camera::deltaTime =
       _observerActive ? 0.0f : static_cast<float>(_deltaTimeSeconds);
   updateUniforms(cameraChanged);
+  double configuredTotalCapMB = _totalGpuMemoryCapMB;
+  double minimumFootprintMB =
+      static_cast<double>(minimumResidentFootprintBytes()) / (1024.0 * 1024.0);
+  _frameMinimumResidentFootprintMB = minimumFootprintMB;
+  bool capBelowFootprint =
+      configuredTotalCapMB > 0.0 && configuredTotalCapMB < minimumFootprintMB;
+  if (capBelowFootprint) {
+    ++_totalMemoryBelowFootprintFrames;
+    _frameTotalMemoryEvictionStall = true;
+    if (_totalMemoryBelowFootprintFrames == kTotalMemoryCapStallFrames) {
+      _memoryCapFallbackActive = true;
+      _totalMemoryCapRelaxedMB = minimumFootprintMB;
+      disableHistoryForMemoryCap();
+      std::printf(
+          "[MemoryBudget] Warning: total cap %.2f MB below minimum footprint "
+          "%.2f MB for %zu frames; disabling history and relaxing cap to %.2f MB.\n",
+          configuredTotalCapMB, minimumFootprintMB,
+          kTotalMemoryCapStallFrames, _totalMemoryCapRelaxedMB);
+    }
+  } else {
+    _totalMemoryBelowFootprintFrames = 0;
+    if (_memoryCapFallbackActive &&
+        configuredTotalCapMB >= minimumFootprintMB) {
+      _memoryCapFallbackActive = false;
+      _totalMemoryCapRelaxedMB = 0.0;
+      std::printf(
+          "[MemoryBudget] Total cap %.2f MB now meets minimum footprint %.2f MB; "
+          "clearing fallback.\n",
+          configuredTotalCapMB, minimumFootprintMB);
+    }
+  }
+  if (_memoryCapFallbackActive)
+    _frameTotalMemoryEvictionStall = true;
   beginFrameMetrics();
   std::swap(_accumulationSlots[0], _accumulationSlots[1]);
   std::swap(_restirSampleSlots[0], _restirSampleSlots[1]);
@@ -7556,23 +7787,28 @@ void Renderer::draw(MTK::View *pView) {
   double contentMemory = residencyMemoryMB();
   bool overCap = contentMemory > _textureResidencyMemoryCapMB;
   double totalMemoryMB = currentGPUMemoryMB();
-  bool totalOverCap = _totalGpuMemoryCapMB > 0.0 &&
-                      totalMemoryMB > _totalGpuMemoryCapMB;
+  double effectiveTotalCapMB = effectiveTotalGpuMemoryCapMB();
+
+  bool totalOverCap = effectiveTotalCapMB > 0.0 &&
+                      (totalMemoryMB > effectiveTotalCapMB ||
+                       _pendingTotalMemoryOverageBytes > 0);
+  if (totalOverCap && _pendingTotalMemoryOverageBytes > 0)
+    _frameTotalMemoryEvictionStall = true;
 
   if (totalOverCap) {
     ++_frameTotalMemoryOverageWarnings;
     std::printf(
-        "[MemoryBudget] Total GPU memory over soft cap: total=%.3f MB "
+        "[MemoryBudget] Total GPU memory over hard cap: total=%.3f MB "
         "cap=%.3f MB (residency=%.3f MB, scratch=%.3f MB)\n",
-        totalMemoryMB, _totalGpuMemoryCapMB, contentMemory, scratchMemoryMB());
+        totalMemoryMB, effectiveTotalCapMB, contentMemory, scratchMemoryMB());
   }
+
+  if (!_needsAccumulationReset && (belowBudget || overCap || totalOverCap))
+    updateTextureResidency(prepCmd);
 
   if (geometryOverCap || _pendingGeometryResidencyOverageBytes > 0 ||
       totalOverCap)
     updateGeometryResidency(prepCmd);
-
-  if (!_needsAccumulationReset && (belowBudget || overCap || totalOverCap))
-    updateTextureResidency(prepCmd);
 
   bool allowResidency =
       _needsAccumulationReset || (!belowBudget && !overCap && !totalOverCap);
@@ -8193,6 +8429,9 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   _frameGeometryResidencyCapHitCount = 0;
   _frameGeometryResidencyHardCapDeniedCount = 0;
   _frameTotalMemoryOverageWarnings = 0;
+  _frameTotalMemoryCapDeniedCount = 0;
+  _frameTotalMemoryEvictionStall = false;
+  _frameMinimumResidentFootprintMB = 0.0;
   _frameRestirReuseRate = 0.0;
   _frameRestirCandidateAcceptance = 0.0;
   ResidencyStrategy strategy = _pScene->getResidencyStrategy();
@@ -13001,7 +13240,9 @@ void Renderer::beginFrameMetrics() {
     sample.scratchMemoryMB = scratchMemoryMB();
     sample.textureMemoryCapMB = _textureResidencyMemoryCapMB;
     sample.geometryMemoryCapMB = _geometryResidencyMemoryCapMB;
-    sample.totalMemoryCapMB = _totalGpuMemoryCapMB;
+    sample.totalMemoryCapMB = effectiveTotalGpuMemoryCapMB();
+    sample.minimumResidentFootprintMB = _frameMinimumResidentFootprintMB;
+    sample.totalMemoryCapRelaxedMB = _totalMemoryCapRelaxedMB;
     double geometryResidentMB = residentGeometryMemoryMB();
     double textureResidentMB = residentTextureMemoryMB();
     double restirResidentMB = restirMemoryMB();
@@ -13145,11 +13386,14 @@ void Renderer::beginFrameMetrics() {
     sample.geometryOverMemoryCap =
         geometryResidentMB > _geometryResidencyMemoryCapMB;
     sample.totalOverMemoryCap =
-        _totalGpuMemoryCapMB > 0.0 && sample.gpuMemoryMB > _totalGpuMemoryCapMB;
+        effectiveTotalGpuMemoryCapMB() > 0.0 &&
+        sample.gpuMemoryMB > effectiveTotalGpuMemoryCapMB();
     sample.geometryCapHitCount = _frameGeometryResidencyCapHitCount;
     sample.geometryHardCapDeniedCount =
         _frameGeometryResidencyHardCapDeniedCount;
     sample.totalMemoryOverageWarnings = _frameTotalMemoryOverageWarnings;
+    sample.totalMemoryCapDeniedCount = _frameTotalMemoryCapDeniedCount;
+    sample.totalMemoryEvictionStall = _frameTotalMemoryEvictionStall;
     _pendingBenchmarkSamples.push_back(std::move(sample));
   }
 }

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -204,6 +204,13 @@ private:
   void completeFrameMetrics(MTL::CommandBuffer *pCmd);
   size_t residentGeometryMemoryBytes() const;
   size_t geometryResidencyCapBytes() const;
+  double effectiveTotalGpuMemoryCapMB() const;
+  size_t totalGpuMemoryCapBytes() const;
+  size_t minimumResidentFootprintBytes() const;
+  size_t essentialGeometryMemoryBytes() const;
+  size_t historyFootprintBytes() const;
+  bool checkTotalMemoryCap(size_t requestedBytes, size_t existingBytes,
+                           const char *context);
   void recordGeometryResidencyHardCapDenied(size_t objectIndex,
                                             size_t requestedBytes,
                                             size_t existingBytes,
@@ -440,6 +447,8 @@ private:
     double textureMemoryCapMB = 0.0;
     double geometryMemoryCapMB = 0.0;
     double totalMemoryCapMB = 0.0;
+    double minimumResidentFootprintMB = 0.0;
+    double totalMemoryCapRelaxedMB = 0.0;
     double deltaTimeSeconds = 0.0;
     double wallSeconds = 0.0;
     double cpuTimeSeconds = 0.0;
@@ -480,9 +489,11 @@ private:
     bool overMemoryCap = false;
     bool geometryOverMemoryCap = false;
     bool totalOverMemoryCap = false;
+    bool totalMemoryEvictionStall = false;
     size_t geometryCapHitCount = 0;
     size_t geometryHardCapDeniedCount = 0;
     size_t totalMemoryOverageWarnings = 0;
+    size_t totalMemoryCapDeniedCount = 0;
   };
 
   struct FrameCaptureRequest {
@@ -712,9 +723,17 @@ private:
   size_t _frameGeometryResidencyCapHitCount = 0;
   size_t _frameGeometryResidencyHardCapDeniedCount = 0;
   size_t _frameTotalMemoryOverageWarnings = 0;
+  size_t _frameTotalMemoryCapDeniedCount = 0;
+  bool _frameTotalMemoryEvictionStall = false;
+  double _frameMinimumResidentFootprintMB = 0.0;
   size_t _geometryResidencyCapHitCount = 0;
   size_t _geometryResidencyHardCapDeniedCount = 0;
+  size_t _totalMemoryCapDeniedCount = 0;
   size_t _pendingGeometryResidencyOverageBytes = 0;
+  size_t _pendingTotalMemoryOverageBytes = 0;
+  size_t _totalMemoryBelowFootprintFrames = 0;
+  double _totalMemoryCapRelaxedMB = 0.0;
+  bool _memoryCapFallbackActive = false;
   ResidencyStrategy _frameStrategy = ResidencyStrategy::DistanceLOD;
   ResidencyStrategy _lastResidencyStrategy = ResidencyStrategy::DistanceLOD;
   AlwaysResidentCache _alwaysResidentCache;
@@ -758,6 +777,7 @@ private:
   bool isRestirHistorySlot(const ManagedTextureSlot &slot) const;
   void updateTextureResidency(MTL::CommandBuffer *cmd);
   void updateGeometryResidency(MTL::CommandBuffer *cmd);
+  void disableHistoryForMemoryCap();
 };
 
 } // namespace NomadPathTracer

--- a/Nomad Path Tracer/StudyNotes.md
+++ b/Nomad Path Tracer/StudyNotes.md
@@ -1,0 +1,21 @@
+# Memory budget study notes
+
+## Single-budget policy (totalGpuMemoryCapMB)
+
+The study now treats `totalGpuMemoryCapMB` as the **single authoritative budget**. Texture and geometry allocations check the total cap before allocating; if the next allocation would exceed the cap, the renderer blocks the allocation and schedules residency evictions until the total budget is satisfied. This keeps `scene_bistro_test_v2_distance.xml` results aligned with a single-budget policy in both runtime logs and benchmark exports.
+
+## Eviction-stall fallback
+
+To avoid getting stuck in a perpetual eviction loop, the renderer tracks a minimum resident footprint estimate:
+
+```
+history + mandatory buffers + essential geometry
+```
+
+When the configured total cap stays below this footprint for several frames, the renderer:
+
+1. Logs a warning that the total cap is below the minimum footprint.
+2. Forces an accumulation reset and disables history preservation.
+3. Temporarily relaxes the effective total cap to the minimum footprint value.
+
+The benchmark CSV exposes the minimum footprint, relaxed cap, and eviction-stall status to make the fallback visible when comparing study runs.


### PR DESCRIPTION
### Motivation
- Treat `totalGpuMemoryCapMB` as the single authoritative GPU budget (hard cap) so texture and geometry allocations are constrained by one unified limit.  
- Prevent allocation/eviction deadlocks where scheduling eviction never recovers when the configured cap is smaller than an unavoidable resident footprint.  
- Surface when the system is in over-cap or eviction-stall mode via benchmark metrics so study runs (e.g. `scene_bistro_test_v2_distance.xml`) reflect the single-budget policy in logs and CSV output.

### Description
- Implemented the hard-cap policy by adding `effectiveTotalGpuMemoryCapMB`, `totalGpuMemoryCapBytes`, `minimumResidentFootprintBytes`, `historyFootprintBytes`, `essentialGeometryMemoryBytes`, and `checkTotalMemoryCap` and using these checks from geometry and texture allocation paths (e.g. `requestResidentTexture`, `allocateTexture`, and `checkGeometryResidencyCap`).
- Unified eviction behavior to honor the total cap by tracking `_pendingTotalMemoryOverageBytes`, decrementing the pending overage when textures/geometry are evicted, and using the effective total cap inside `updateTextureResidency` and `updateGeometryResidency` to drive eviction until the total budget is satisfied.
- Added an eviction-stall detection and fallback: if the configured `totalGpuMemoryCapMB` remains below a computed minimum resident footprint for `kTotalMemoryCapStallFrames` frames, the renderer logs a warning, disables history preservation via `disableHistoryForMemoryCap()` (forces accumulation reset), and temporarily relaxes the effective cap to the footprint to allow progress.
- Exposed metrics and CSV fields so benchmark exports include `total_memory_cap_mb`, `minimum_resident_footprint_mb`, `total_memory_cap_relaxed_mb`, `total_memory_cap_denials`, and `total_memory_eviction_stall`, and added documentation to `README.md`, `Benchmarks/README.md`, and a new `Nomad Path Tracer/StudyNotes.md` describing the single-budget policy and fallback behavior.

### Testing
- No automated tests were executed as part of this change (no test run requested).  
- Changes are limited to residency/memory-budget logic, benchmark output, and documentation; reviewers should run existing benchmark scenarios (for example `scene_bistro_test_v2_distance.xml`) to verify logs and CSVs now reflect the single-budget policy and that the eviction-stall fallback engages when caps are unrealistically low.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69769df17444832daaabcf849c503eff)