### PR TITLE
Add reprojection-based ReSTIR temporal validation

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -754,6 +754,11 @@ struct UniformsData {
   float environmentPadding0 = 0.0f;
   float environmentPadding1 = 0.0f;
   float cameraMotionMetric = 0.0f;
+  simd::float4x4 prevViewProjection{};
+  float restirTemporalPositionEpsilon = 0.0f;
+  float restirTemporalNormalThreshold = 0.0f;
+  float restirTemporalRoughnessBucketSize = 0.0f;
+  float restirTemporalPadding0 = 0.0f;
 };
 
 struct TileDispatchRegion {
@@ -771,6 +776,11 @@ constexpr double kPathTraceTargetGpuMsPerCommand = 6.0;
 constexpr size_t kPathTraceCommandHistorySamples = 30;
 constexpr std::chrono::milliseconds kFrameCommandBufferWaitTimeout(4);
 constexpr uint32_t kMaxMaterialTextureSlots = 64;
+constexpr float kRestirTemporalPositionEpsilon = 0.25f;
+constexpr float kRestirTemporalNormalThreshold = 0.85f;
+constexpr float kRestirTemporalRoughnessBucketSize = 0.2f;
+constexpr float kReprojectionNearPlane = 0.1f;
+constexpr float kReprojectionFarPlane = 1000.0f;
 
 inline uint32_t bitm_random() {
   static uint32_t current_seed = 92407235;
@@ -7561,6 +7571,26 @@ void Renderer::updateUniforms(bool cameraChanged) {
   u.environmentMapIntensity = _environmentBrightness;
   u.environmentPadding0 = 0.0f;
   u.environmentPadding1 = 0.0f;
+  float aspect = Camera::screenSize.y > 0.0f
+                     ? Camera::screenSize.x / Camera::screenSize.y
+                     : 1.0f;
+  if (_lastUniformCameraStateValid) {
+    u.prevViewProjection =
+        simd_mul(makePerspectiveMatrix(_lastUniformCameraState.verticalFov,
+                                       aspect, kReprojectionNearPlane,
+                                       kReprojectionFarPlane),
+                 makeViewMatrix(_lastUniformCameraState));
+  } else {
+    u.prevViewProjection =
+        simd_mul(makePerspectiveMatrix(activeView.verticalFov, aspect,
+                                       kReprojectionNearPlane,
+                                       kReprojectionFarPlane),
+                 makeViewMatrix(activeView));
+  }
+  u.restirTemporalPositionEpsilon = kRestirTemporalPositionEpsilon;
+  u.restirTemporalNormalThreshold = kRestirTemporalNormalThreshold;
+  u.restirTemporalRoughnessBucketSize = kRestirTemporalRoughnessBucketSize;
+  u.restirTemporalPadding0 = 0.0f;
   if (_lastUniformCameraStateValid) {
     u.cameraMotionMetric =
         computeCameraMotionMetric(activeView, _lastUniformCameraState);

--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -298,11 +298,17 @@ kernel void pathTraceKernel(
 
   float previousSampleCount = float(sampleCount.read(pixel).x);
   float4 previousColor = float4(lastFrame.read(pixel));
+  float3 previousAlbedo = float3(float4(albedoAccum.read(pixel)).xyz);
+  float4 previousNormalData = float4(normalAccum.read(pixel));
+  float3 previousNormal = previousNormalData.xyz;
+  float previousRoughness = previousNormalData.w;
+  float3 previousPosition = float3(float4(positionAccum.read(pixel)).xyz);
 
   float3 accumulatedColor = float3(0.0);
   float3 accumulatedAlbedo = float3(0.0);
   float3 accumulatedNormal = float3(0.0);
   float3 accumulatedPosition = float3(0.0);
+  float accumulatedRoughness = 0.0f;
 
   float3 rayDx = u.rayDx;
   float3 rayDy = u.rayDy;
@@ -375,6 +381,13 @@ kernel void pathTraceKernel(
                                       environmentMap, environmentSampler,
                                       u.environmentMapEnabled,
                                       u.environmentMapIntensity,
+                                      positionAccum,
+                                      normalAccum,
+                                      screenSize,
+                                      u.prevViewProjection,
+                                      u.restirTemporalPositionEpsilon,
+                                      u.restirTemporalNormalThreshold,
+                                      u.restirTemporalRoughnessBucketSize,
                                       restirEnabled && sampleIdx == 0
                                           ? &restir
                                           : nullptr,
@@ -384,6 +397,7 @@ kernel void pathTraceKernel(
     accumulatedAlbedo += sample.albedo;
     accumulatedNormal += sample.normal;
     accumulatedPosition += sample.position;
+    accumulatedRoughness += sample.roughness;
   }
 
   if (restirEnabled) {
@@ -422,16 +436,12 @@ kernel void pathTraceKernel(
   float3 averaged = (totalSamples > 0.0f) ? combinedSum / totalSamples : float3(0.0f);
   averaged = clamp(averaged, 0.0f, 1.0f);
 
-  float3 previousAlbedo =
-      float3(float4(albedoAccum.read(pixel)).xyz);
-  float3 previousNormal =
-      float3(float4(normalAccum.read(pixel)).xyz);
-  float3 previousPosition =
-      float3(float4(positionAccum.read(pixel)).xyz);
   float3 albedoSum = previousAlbedo * previousSampleCount + accumulatedAlbedo;
   float3 normalSum = previousNormal * previousSampleCount + accumulatedNormal;
   float3 positionSum =
       previousPosition * previousSampleCount + accumulatedPosition;
+  float roughnessSum =
+      previousRoughness * previousSampleCount + accumulatedRoughness;
   float3 averagedAlbedo =
       (totalSamples > 0.0f) ? albedoSum / totalSamples : float3(0.0f);
   averagedAlbedo = clamp(averagedAlbedo, 0.0f, 1.0f);
@@ -440,11 +450,14 @@ kernel void pathTraceKernel(
   averagedNormal = clamp(averagedNormal, -1.0f, 1.0f);
   float3 averagedPosition =
       (totalSamples > 0.0f) ? positionSum / totalSamples : float3(0.0f);
+  float averagedRoughness =
+      (totalSamples > 0.0f) ? roughnessSum / totalSamples : 0.0f;
+  averagedRoughness = clamp(averagedRoughness, 0.0f, 1.0f);
 
   float4 result = float4(averaged, 1.0f);
   currentFrame.write(result, pixel);
   albedoAccum.write(float4(averagedAlbedo, 1.0f), pixel);
-  normalAccum.write(float4(averagedNormal, 1.0f), pixel);
+  normalAccum.write(float4(averagedNormal, averagedRoughness), pixel);
   positionAccum.write(float4(averagedPosition, 1.0f), pixel);
   sampleCount.write(float4(totalSamples, 0.0f, 0.0f, 0.0f), pixel);
 }

--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -19,6 +19,7 @@ struct PathTraceSample {
   float3 albedo;
   float3 normal;
   float3 position;
+  float roughness;
 };
 
 constant uint kRestirCandidateCount = 4;
@@ -869,6 +870,13 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
                                 sampler environmentSampler,
                                 uint environmentEnabled,
                                 float environmentIntensity,
+                                texture2d<float, access::read_write> positionAccum,
+                                texture2d<float, access::read_write> normalAccum,
+                                float2 screenSize,
+                                float4x4 prevViewProjection,
+                                float restirTemporalPositionEpsilon,
+                                float restirTemporalNormalThreshold,
+                                float restirTemporalRoughnessBucketSize,
                                 thread RestirReservoir *restirReservoir,
                                 bool restirEnabled,
                                 float temporalReuseChance) {
@@ -877,6 +885,7 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
   sampleResult.albedo = float3(0.0f);
   sampleResult.normal = float3(0.0f);
   sampleResult.position = float3(0.0f);
+  sampleResult.roughness = 0.0f;
   bool recordedFirstHit = false;
 
   float footprint = length(cross(rayDx, rayDy));
@@ -1066,6 +1075,7 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
       sampleResult.albedo = material.diffuseColor;
       sampleResult.normal = offsetNormal;
       sampleResult.position = bestHit.point;
+      sampleResult.roughness = clamp(material.roughness, 0.0f, 1.0f);
       recordedFirstHit = true;
     }
 
@@ -1083,6 +1093,51 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
 
         float reuseChance = clamp(temporalReuseChance, 0.0f, 1.0f);
         bool allowTemporal = reuseChance > 0.0f;
+        bool historyValid = false;
+        if (restirReservoir->valid != 0u && allowTemporal) {
+          float4 prevClip = prevViewProjection * float4(bestHit.point, 1.0f);
+          if (isfinite(prevClip.x) && isfinite(prevClip.y) &&
+              isfinite(prevClip.z) && isfinite(prevClip.w) &&
+              prevClip.w > 1e-5f) {
+            float3 prevNdc = prevClip.xyz / prevClip.w;
+            if (all(isfinite(prevNdc)) && abs(prevNdc.x) <= 1.0f &&
+                abs(prevNdc.y) <= 1.0f) {
+              float2 prevUv = prevNdc.xy * 0.5f + float2(0.5f);
+              float2 clampedUv =
+                  clamp(prevUv, float2(0.0f), float2(0.999999f));
+              uint2 prevPixel =
+                  uint2(clampedUv * max(screenSize, float2(1.0f)));
+              float3 prevPosition =
+                  float3(positionAccum.read(prevPixel).xyz);
+              float4 prevNormalData = float4(normalAccum.read(prevPixel));
+              float3 prevNormal = prevNormalData.xyz;
+              float prevRoughness = prevNormalData.w;
+              bool hasPrevData = all(isfinite(prevPosition)) &&
+                                 all(isfinite(prevNormal)) &&
+                                 isfinite(prevRoughness);
+              float prevNormalLen = length(prevNormal);
+              if (hasPrevData && prevNormalLen > 1e-4f) {
+                float3 prevNormalUnit = prevNormal / prevNormalLen;
+                float3 currentNormal = normalize(offsetNormal);
+                float positionDelta =
+                    length(bestHit.point - prevPosition);
+                float normalSimilarity =
+                    dot(currentNormal, prevNormalUnit);
+                float bucketSize =
+                    max(restirTemporalRoughnessBucketSize, 1e-4f);
+                uint prevBucket = uint(floor(
+                    clamp(prevRoughness, 0.0f, 1.0f) / bucketSize));
+                uint currentBucket = uint(floor(
+                    clamp(material.roughness, 0.0f, 1.0f) / bucketSize));
+                historyValid =
+                    positionDelta <= restirTemporalPositionEpsilon &&
+                    normalSimilarity >= restirTemporalNormalThreshold &&
+                    prevBucket == currentBucket;
+              }
+            }
+          }
+        }
+        allowTemporal = allowTemporal && historyValid;
         if (restirReservoir->valid != 0u && allowTemporal) {
           float reuseRoll = randomFloat(seed);
           seed = random(seed);

--- a/Nomad Path Tracer/Renderer/Shaders/Structs.h
+++ b/Nomad Path Tracer/Renderer/Shaders/Structs.h
@@ -85,6 +85,11 @@ struct UniformsData
     float environmentPadding0;
     float environmentPadding1;
     float cameraMotionMetric;
+    simd::float4x4 prevViewProjection;
+    float restirTemporalPositionEpsilon;
+    float restirTemporalNormalThreshold;
+    float restirTemporalRoughnessBucketSize;
+    float restirTemporalPadding0;
 };
 
 struct TileRegion


### PR DESCRIPTION
### Motivation
- Improve ReSTIR temporal reuse by performing a true reprojection of the current world-space hit into the previous frame and sampling the prior accumulations there to validate temporal candidates.
- Avoid incorrect reuse from camera motion or scene changes by checking previous-frame position/normal/roughness at the reprojected UV before accepting temporal samples.
- Keep the validation tunable by exposing temporal thresholds and a previous-frame view-projection matrix in the uniforms.

### Description
- Added a `prevViewProjection` matrix and temporal validation parameters to `UniformsData` on both CPU (`Renderer.cpp`) and GPU (`Structs.h`) sides and added `kReprojectionNearPlane`/`kReprojectionFarPlane` defaults in `Renderer.cpp`.
- Populated `u.prevViewProjection` in `Renderer::updateUniforms` using `_lastUniformCameraState` (or the current active view if not available) so the shader can reproject world-space positions into last-frame clip space.
- Updated `rayColor` signature in `PathTracing.h` to accept `positionAccum`, `normalAccum`, `screenSize`, `prevViewProjection`, and the temporal thresholds, and extended `PathTraceSample` with `roughness` so shading/accumulation flows include roughness.
- Implemented reprojection-based validation inside `rayColor`: project the current hit (`bestHit.point`) with `prevViewProjection`, compute previous UV, sample `positionAccum` and `normalAccum` at that UV, and require position distance, normal dot, and coarse roughness-bucket equality (using the supplied thresholds) before allowing temporal ReSTIR reuse.
- Changed accumulation/storage so roughness is stored in the alpha channel of `normalAccum` while `positionAccum` stores world-space position (kept in `PathTraceKernel.metal`), and updated accumulation math to track and blend `roughness` across frames.
- Wired the new parameters through the path tracing kernel call sites (`PathTraceKernel.metal`) and adjusted restir read/write paths to use the updated channels and signatures.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976bd39c904832d9bf0d3f3db0826be)