### PR TITLE
Resolve duplicate 'dist2' locals in PathTraceKernel.metal

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -178,9 +178,9 @@ kernel void restirSpatialKernel(
     float neighborDepthDelta = abs(dot(delta, neighborNormal));
     bool depthSimilar = depthDelta <= kSpatialDepthThreshold &&
                         neighborDepthDelta <= kSpatialDepthThreshold;
-    float dist2 = dot(delta, delta);
+    float dist2_neighbor = dot(delta, delta);
     bool positionSimilar =
-        dist2 <= kSpatialPositionThreshold * kSpatialPositionThreshold;
+        dist2_neighbor <= kSpatialPositionThreshold * kSpatialPositionThreshold;
     if (!depthSimilar && !positionSimilar)
       continue;
 
@@ -205,10 +205,10 @@ kernel void restirSpatialKernel(
       continue;
     uint lightPrimIndex = lightIndices[lightOffset];
     float3 toLight = candidateSample.position - bestHit.point;
-    float dist2 = dot(toLight, toLight);
-    if (dist2 <= 1e-6f)
+    float dist2_light = dot(toLight, toLight);
+    if (dist2_light <= 1e-6f)
       continue;
-    float dist = sqrt(dist2);
+    float dist = sqrt(dist2_light);
     float3 wi = toLight / dist;
     bool visible = isLightVisible(
         bestHit.point, shadingNormal, wi, dist, lightPrimIndex, bounceCache,


### PR DESCRIPTION
### Motivation
- Prevent a local variable name collision in the shader kernel that led to duplicate `dist2` declarations in the same scope.

### Description
- Rename the spatial distance local to `dist2_neighbor` and the light-distance local to `dist2_light`, and update the `kSpatialPositionThreshold` check and `sqrt` call accordingly in `PathTraceKernel.metal`.

### Testing
- Ran `xcodebuild -project "Nomad Path Tracer.xcodeproj" -scheme "Nomad Path Tracer" build`, which could not run in this environment because `xcodebuild` is not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976cb76b8a8832d9356c4635df23e17)