### PR TITLE
Allow limited ReSTIR temporal reuse when history validation fails

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -25,6 +25,7 @@ struct PathTraceSample {
 constant uint kRestirCandidateCount = 4;
 constant uint kRestirReseedCandidateBoost = 4;
 constant uint kRestirReseedFrameCount = 3;
+constant float kRestirInvalidHistoryReuseScale = 0.05f;
 constant float kVisibilityRayEpsilon = 1e-4f;
 constant float kVisibilityRayOffset = 5e-4f;
 
@@ -1158,11 +1159,18 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
                                       memory_order_relaxed);
           }
         }
-        allowTemporal = allowTemporal && historyValid;
+        float effectiveReuseChance = reuseChance;
+        if (!historyValid) {
+          // Allow a small amount of temporal reuse even when history validation
+          // fails so the pipeline doesn't devolve to zero reuse.
+          effectiveReuseChance *= kRestirInvalidHistoryReuseScale;
+        }
+        allowTemporal = allowTemporal && restirReservoir->valid != 0u &&
+                        effectiveReuseChance > 0.0f;
         if (restirReservoir->valid != 0u && allowTemporal) {
           float reuseRoll = randomFloat(seed);
           seed = random(seed);
-          if (reuseRoll > reuseChance) {
+          if (reuseRoll > effectiveReuseChance) {
             allowTemporal = false;
           }
         }


### PR DESCRIPTION
### Motivation
- Prevent ReSTIR `reuse_rate` from becoming stuck at zero and the render from collapsing to motion-blur by permitting a small amount of temporal reuse even when history validation fails.

### Description
- Add `kRestirInvalidHistoryReuseScale` and apply it in `PathTracing.h` so that when `historyValid` is false an `effectiveReuseChance` = `reuseChance * kRestirInvalidHistoryReuseScale` is used for temporal gating and the reuse RNG check, keeping the existing reseed behavior intact; the change is localized to `Nomad Path Tracer/Renderer/Shaders/PathTracing.h`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69772ae3d840832d974e89fac7706262)