### PR TITLE
Fix ReSTIR history slot swapping and allow limited temporal reuse on invalid history

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -7784,9 +7784,6 @@ void Renderer::draw(MTK::View *pView) {
     _frameTotalMemoryEvictionStall = true;
   beginFrameMetrics();
   std::swap(_accumulationSlots[0], _accumulationSlots[1]);
-  std::swap(_restirSampleSlots[0], _restirSampleSlots[1]);
-  std::swap(_restirNormalSlots[0], _restirNormalSlots[1]);
-  std::swap(_restirStateSlots[0], _restirStateSlots[1]);
 
   _historyStreamingActive = false;
   _historyStreamingRestoreCount = 0;
@@ -8306,10 +8303,12 @@ void Renderer::draw(MTK::View *pView) {
       }
     }
   }
-  if (restirSpatialDispatched) {
-    std::swap(_restirSampleSlots[0], _restirSampleSlots[1]);
-    std::swap(_restirNormalSlots[0], _restirNormalSlots[1]);
-    std::swap(_restirStateSlots[0], _restirStateSlots[1]);
+  if (_residencyConfig.restirSamplingEnabled) {
+    if (!restirSpatialDispatched) {
+      std::swap(_restirSampleSlots[0], _restirSampleSlots[1]);
+      std::swap(_restirNormalSlots[0], _restirNormalSlots[1]);
+      std::swap(_restirStateSlots[0], _restirStateSlots[1]);
+    }
   }
 
   MTL::CommandBuffer *presentCmd = _pCommandQueue->commandBuffer();

--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -25,6 +25,7 @@ struct PathTraceSample {
 constant uint kRestirCandidateCount = 4;
 constant uint kRestirReseedCandidateBoost = 4;
 constant uint kRestirReseedFrameCount = 3;
+constant float kRestirInvalidHistoryReuseScale = 0.05f;
 constant float kVisibilityRayEpsilon = 1e-4f;
 constant float kVisibilityRayOffset = 5e-4f;
 
@@ -1158,11 +1159,18 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
                                       memory_order_relaxed);
           }
         }
-        allowTemporal = allowTemporal && historyValid;
+        float effectiveReuseChance = reuseChance;
+        if (!historyValid) {
+          // Allow a small amount of temporal reuse even when history validation
+          // fails so the pipeline doesn't devolve to zero reuse.
+          effectiveReuseChance *= kRestirInvalidHistoryReuseScale;
+        }
+        allowTemporal = allowTemporal && restirReservoir->valid != 0u &&
+                        effectiveReuseChance > 0.0f;
         if (restirReservoir->valid != 0u && allowTemporal) {
           float reuseRoll = randomFloat(seed);
           seed = random(seed);
-          if (reuseRoll > reuseChance) {
+          if (reuseRoll > effectiveReuseChance) {
             allowTemporal = false;
           }
         }


### PR DESCRIPTION
### Motivation
- Prevent ReSTIR temporal history from being lost or double-advanced by ensuring the history buffer only advances once per frame and only when appropriate.
- Prevent the reuse rate from becoming stuck at zero when history validation fails by permitting a small amount of temporal reuse so the pipeline doesn't collapse to motion blur.

### Description
- Add `kRestirInvalidHistoryReuseScale` to `PathTracing.h` and use it to compute an `effectiveReuseChance` so a small fraction of temporal reuse is allowed when `historyValid` is false. 
- Use `effectiveReuseChance` for both the temporal gating (`allowTemporal`) and the reuse RNG check so behavior is consistent when history validation fails. 
- Remove the unconditional frame-start swap of `_restir*Slots` in `Renderer.cpp` and change the later swap to only occur when `_residencyConfig.restirSamplingEnabled` is true and spatial reuse was not dispatched, ensuring the ReSTIR history buffer advances exactly once per frame and is not canceled by a second swap.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69772ae3d840832d974e89fac7706262)