### PR TITLE
Remove accumulation history preservation

### DIFF
--- a/Nomad Path Tracer/README.md
+++ b/Nomad Path Tracer/README.md
@@ -18,6 +18,6 @@ The `geometryResidencyMemoryCapMB` scene parameter remains a hard ceiling. Geome
 
 For the memory-budget study, `totalGpuMemoryCapMB` is now the single authoritative (hard) budget. Both texture and geometry allocations check the total cap before proceeding; if the next allocation would exceed the cap, the renderer blocks the allocation and evicts residency from textures and geometry until the total budget is satisfied.
 
-To prevent eviction scheduling deadlocks, the renderer estimates a minimum resident footprint (history + mandatory buffers + essential geometry). If the configured total cap remains below this footprint for several frames, it logs a warning, disables history, forces an accumulation reset, and temporarily relaxes the effective total cap to the minimum footprint. Benchmark metrics report the minimum footprint, relaxed cap, and whether the frame is in eviction-stall mode.
+To prevent eviction scheduling deadlocks, the renderer estimates a minimum resident footprint (mandatory buffers + essential geometry). If the configured total cap remains below this footprint for several frames, it logs a warning, forces an accumulation reset, and temporarily relaxes the effective total cap to the minimum footprint. Benchmark metrics report the minimum footprint, relaxed cap, and whether the frame is in eviction-stall mode.
 
 See `StudyNotes.md` for the study-specific memory budget notes and recommended interpretation of the new metrics.

--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -568,16 +568,7 @@ size_t Renderer::totalGpuMemoryCapBytes() const {
 }
 
 size_t Renderer::historyFootprintBytes() const {
-  size_t totalBytes = 0;
-  auto addSlot = [&](const ManagedTextureSlot &slot) {
-    totalBytes += textureByteSize(slot);
-  };
-
-  addSlot(_accumulationSlots[0]);
-  addSlot(_accumulationSlots[1]);
-  addSlot(_sampleCountSlot);
-  addSlot(_sampleImportanceSlot);
-  return totalBytes;
+  return 0;
 }
 
 size_t Renderer::essentialGeometryMemoryBytes() const {
@@ -6361,158 +6352,6 @@ void Renderer::disableHistoryForMemoryCap() {
   _accumulationTargetsNeedClear = true;
 }
 
-bool Renderer::captureCpuHistoryProxy(ManagedTextureSlot &slot) {
-  clearTextureHistory(slot);
-
-  if (!slot.texture)
-    return false;
-
-  if (slot.width == 0 || slot.height == 0)
-    return false;
-
-  size_t pixelBytes = bytesPerPixel(slot.pixelFormat);
-  if (pixelBytes == 0)
-    return false;
-
-  NS::UInteger proxyWidth = slot.width;
-  NS::UInteger proxyHeight = slot.height;
-  size_t proxyRowBytes = proxyWidth * pixelBytes;
-  size_t proxyTotalBytes = proxyRowBytes * proxyHeight;
-
-  while (proxyTotalBytes > kMaxTextureHistoryBytes && proxyWidth > 1 &&
-         proxyHeight > 1) {
-    proxyWidth = std::max<NS::UInteger>(1, proxyWidth / 2);
-    proxyHeight = std::max<NS::UInteger>(1, proxyHeight / 2);
-    proxyRowBytes = proxyWidth * pixelBytes;
-    proxyTotalBytes = proxyRowBytes * proxyHeight;
-  }
-
-  if (proxyTotalBytes == 0)
-    return false;
-
-  std::vector<uint8_t> data(proxyTotalBytes, 0);
-  std::vector<uint8_t> pixel(pixelBytes, 0);
-  for (NS::UInteger y = 0; y < proxyHeight; ++y) {
-    NS::UInteger srcY = static_cast<NS::UInteger>(
-        std::min<NS::UInteger>(slot.height - 1,
-                                (y * slot.height) / std::max<NS::UInteger>(proxyHeight, 1)));
-    uint8_t *dstRow = data.data() + static_cast<size_t>(y) * proxyRowBytes;
-    for (NS::UInteger x = 0; x < proxyWidth; ++x) {
-      NS::UInteger srcX = static_cast<NS::UInteger>(
-          std::min<NS::UInteger>(slot.width - 1,
-                                  (x * slot.width) /
-                                      std::max<NS::UInteger>(proxyWidth, 1)));
-      MTL::Region region = MTL::Region::Make2D(srcX, srcY, 1, 1);
-      slot.texture->getBytes(pixel.data(), pixelBytes, region, 0);
-      std::memcpy(dstRow + static_cast<size_t>(x) * pixelBytes, pixel.data(),
-                  pixelBytes);
-    }
-  }
-
-  slot.historyBacking = ManagedTextureSlot::HistoryBacking::CpuData;
-  slot.historyIsProxy = proxyWidth != slot.width || proxyHeight != slot.height;
-  slot.historyWidth = proxyWidth;
-  slot.historyHeight = proxyHeight;
-  slot.historyBytesPerRow = proxyRowBytes;
-  slot.historyData = std::move(data);
-  slot.needsGpuRefresh = true;
-  slot.stagingValid = false;
-  return true;
-}
-
-bool Renderer::uploadHistoryToTexture(ManagedTextureSlot &slot,
-                                      MTL::CommandBuffer *cmd,
-                                      MTL::BlitCommandEncoder *&blit) {
-  if (!slot.texture)
-    return false;
-
-  size_t pixelBytes = bytesPerPixel(slot.pixelFormat);
-  if (pixelBytes == 0)
-    return false;
-
-  if (slot.historyBacking == ManagedTextureSlot::HistoryBacking::SharedBuffer) {
-    if (!slot.stagingBuffer || !slot.stagingValid)
-      return false;
-
-    size_t totalBytes = textureByteSize(slot);
-    if (totalBytes == 0 || slot.stagingCapacity < totalBytes)
-      return false;
-
-    if (cmd) {
-      if (!blit)
-        blit = cmd->blitCommandEncoder();
-      if (blit) {
-        MTL::Size size = MTL::Size::Make(slot.historyWidth, slot.historyHeight, 1);
-        MTL::Origin origin = MTL::Origin::Make(0, 0, 0);
-        NS::UInteger bytesPerImage = static_cast<NS::UInteger>(
-            slot.historyBytesPerRow * slot.historyHeight);
-        blit->copyFromBuffer(slot.stagingBuffer, 0, slot.historyBytesPerRow,
-                             bytesPerImage, size, slot.texture, 0, 0, origin);
-        slot.needsGpuRefresh = false;
-        return true;
-      }
-    }
-
-    if (void *contents = slot.stagingBuffer->contents()) {
-      const uint8_t *src = static_cast<const uint8_t *>(contents);
-      NS::UInteger uploadWidth = std::max<NS::UInteger>(1, slot.historyWidth);
-      NS::UInteger uploadHeight = std::max<NS::UInteger>(1, slot.historyHeight);
-      MTL::Region region = MTL::Region::Make2D(0, 0, uploadWidth, uploadHeight);
-      slot.texture->replaceRegion(region, 0, src, slot.historyBytesPerRow);
-      slot.needsGpuRefresh = false;
-      return true;
-    }
-
-    return false;
-  }
-
-  if (slot.historyBacking == ManagedTextureSlot::HistoryBacking::CpuData) {
-    if (slot.historyData.empty() || slot.historyWidth == 0 ||
-        slot.historyHeight == 0)
-      return false;
-
-    std::vector<uint8_t> expanded;
-    const uint8_t *srcData = slot.historyData.data();
-    size_t srcRowBytes = slot.historyBytesPerRow;
-
-    if (slot.historyIsProxy &&
-        (slot.historyWidth != slot.width || slot.historyHeight != slot.height)) {
-      size_t expandedBytes = static_cast<size_t>(slot.width) * slot.height *
-                             pixelBytes;
-      expanded.resize(expandedBytes);
-      for (NS::UInteger y = 0; y < slot.height; ++y) {
-        NS::UInteger srcY = static_cast<NS::UInteger>(
-            std::min<NS::UInteger>(slot.historyHeight - 1,
-                                    (y * slot.historyHeight) /
-                                        std::max<NS::UInteger>(slot.height, 1)));
-        const uint8_t *srcRow =
-            srcData + static_cast<size_t>(srcY) * slot.historyBytesPerRow;
-        uint8_t *dstRow = expanded.data() +
-                          static_cast<size_t>(y) * slot.width * pixelBytes;
-        for (NS::UInteger x = 0; x < slot.width; ++x) {
-          NS::UInteger srcX = static_cast<NS::UInteger>(
-              std::min<NS::UInteger>(slot.historyWidth - 1,
-                                      (x * slot.historyWidth) /
-                                          std::max<NS::UInteger>(slot.width, 1)));
-          const uint8_t *srcPixel =
-              srcRow + static_cast<size_t>(srcX) * pixelBytes;
-          std::memcpy(dstRow + static_cast<size_t>(x) * pixelBytes, srcPixel,
-                      pixelBytes);
-        }
-      }
-      srcData = expanded.data();
-      srcRowBytes = static_cast<size_t>(slot.width) * pixelBytes;
-    }
-
-    MTL::Region region =
-        MTL::Region::Make2D(0, 0, slot.width, slot.height);
-    slot.texture->replaceRegion(region, 0, srcData, srcRowBytes);
-    slot.needsGpuRefresh = false;
-    return true;
-  }
-
-  return false;
-}
 
 MTL::Texture *Renderer::requestResidentTexture(ManagedTextureSlot &slot,
                                                MTL::CommandBuffer *cmd,
@@ -6521,35 +6360,6 @@ MTL::Texture *Renderer::requestResidentTexture(ManagedTextureSlot &slot,
       slot.height == 0) {
     if (slot.texture)
       slot.lastUsedFrame = _renderedFrameCount;
-    if (slot.texture && slot.needsGpuRefresh &&
-        slot.historyBacking != ManagedTextureSlot::HistoryBacking::None) {
-      if (uploadHistoryToTexture(slot, cmd, blit)) {
-        _historyStreamingActive = true;
-        ++_historyStreamingRestoreCount;
-        if (slot.historyIsProxy)
-          _historyStreamingUsedProxy = true;
-        const char *source =
-            slot.historyBacking == ManagedTextureSlot::HistoryBacking::SharedBuffer
-                ? "staging buffer"
-                : (slot.historyIsProxy ? "CPU proxy" : "CPU history");
-        std::printf(
-            "[TextureResidency] Refreshed slot %s from %s (%ux%u).\n",
-            textureSlotLabel(slot), source,
-            static_cast<unsigned>(slot.historyWidth),
-            static_cast<unsigned>(slot.historyHeight));
-      } else {
-        std::printf(
-            "[TextureResidency] Failed to refresh resident slot %s from history;"
-            " history unavailable.\n",
-            textureSlotLabel(slot));
-        slot.needsGpuRefresh = false;
-        if (!slot.stagingValid &&
-            slot.historyBacking == ManagedTextureSlot::HistoryBacking::CpuData)
-          slot.historyData.clear();
-        _needsAccumulationReset = true;
-        _accumulationTargetsNeedClear = true;
-      }
-    }
     return slot.texture;
   }
 
@@ -6621,41 +6431,16 @@ MTL::Texture *Renderer::requestResidentTexture(ManagedTextureSlot &slot,
     _accumulationTargetsNeedClear = true;
   }
 
-  bool logged = false;
-  if (slot.historyBacking != ManagedTextureSlot::HistoryBacking::None) {
-    if (uploadHistoryToTexture(slot, cmd, blit)) {
-      logged = true;
-      _historyStreamingActive = true;
-      ++_historyStreamingRestoreCount;
-      if (slot.historyIsProxy)
-        _historyStreamingUsedProxy = true;
-      const char *source =
-          slot.historyBacking == ManagedTextureSlot::HistoryBacking::SharedBuffer
-              ? "staging buffer"
-              : (slot.historyIsProxy ? "CPU proxy" : "CPU history");
-      std::printf(
-          "[TextureResidency] Restored slot %s from %s (%ux%u).\n", label,
-          source, static_cast<unsigned>(slot.historyWidth),
-          static_cast<unsigned>(slot.historyHeight));
-    } else {
-      std::printf(
-          "[TextureResidency] Restored slot %s without history data.\n", label);
-      clearTextureHistory(slot);
-      _needsAccumulationReset = true;
-      _accumulationTargetsNeedClear = true;
-    }
-  } else {
-    std::printf("[TextureResidency] Restored slot %s without staging data.\n",
-                label);
-    if (&slot == &_accumulationSlots[0] || &slot == &_accumulationSlots[1] ||
-        &slot == &_sampleCountSlot || &slot == &_albedoSlot ||
-        &slot == &_normalSlot || &slot == &_positionSlot) {
-      _needsAccumulationReset = true;
-      _accumulationTargetsNeedClear = true;
-    }
-    if (&slot == &_accumulationSlots[0] || &slot == &_accumulationSlots[1])
-      clearSlotTexture(slot);
+  std::printf("[TextureResidency] Restored slot %s without history data.\n",
+              label);
+  if (&slot == &_accumulationSlots[0] || &slot == &_accumulationSlots[1] ||
+      &slot == &_sampleCountSlot || &slot == &_albedoSlot ||
+      &slot == &_normalSlot || &slot == &_positionSlot) {
+    _needsAccumulationReset = true;
+    _accumulationTargetsNeedClear = true;
   }
+  if (&slot == &_accumulationSlots[0] || &slot == &_accumulationSlots[1])
+    clearSlotTexture(slot);
 
   slot.lastUsedFrame = _renderedFrameCount;
   return slot.texture;
@@ -6668,98 +6453,18 @@ bool Renderer::evictTextureSlot(ManagedTextureSlot &slot,
     return false;
 
   const char *label = textureSlotLabel(slot);
-  size_t totalBytes = textureByteSize(slot);
-  bool preservedHistory = false;
-  if (totalBytes == 0 || !cmd) {
-    std::string reason;
-    if (totalBytes == 0)
-      reason += "zero-sized texture";
-    if (!cmd) {
-      if (!reason.empty())
-        reason += ", ";
-      reason += "no command buffer";
-    }
-
-    if (captureCpuHistoryProxy(slot)) {
-      preservedHistory = true;
-      std::printf(
-          "[TextureResidency] Evicting slot %s: captured CPU %s (%ux%u).\n",
-          label, slot.historyIsProxy ? "proxy" : "copy",
-          static_cast<unsigned>(slot.historyWidth),
-          static_cast<unsigned>(slot.historyHeight));
-    } else {
-      std::printf("[TextureResidency] Evicting slot %s: releasing without staging"
-                  " (%s).\n",
-                  label, reason.c_str());
-    }
-  } else {
-    ensureBufferCapacity(slot.stagingBuffer, totalBytes, slot.stagingCapacity,
-                         false, MTL::ResourceStorageModeShared,
-                         GpuMemoryTracker::Category::Staging);
-    if (!slot.stagingBuffer) {
-      if (captureCpuHistoryProxy(slot)) {
-        preservedHistory = true;
-        std::printf("[TextureResidency] Evicting slot %s: captured CPU %s (%ux%u)"
-                    " after staging allocation failure.\n",
-                    label, slot.historyIsProxy ? "proxy" : "copy",
-                    static_cast<unsigned>(slot.historyWidth),
-                    static_cast<unsigned>(slot.historyHeight));
-      } else {
-        std::printf("[TextureResidency] Evicting slot %s: releasing without staging"
-                    " (failed to allocate staging buffer).\n",
-                    label);
-      }
-    } else {
-      if (!blit)
-        blit = cmd->blitCommandEncoder();
-      if (!blit) {
-        if (captureCpuHistoryProxy(slot)) {
-          preservedHistory = true;
-          std::printf(
-              "[TextureResidency] Evicting slot %s: captured CPU %s (%ux%u) after"
-              " blit encoder failure.\n",
-              label, slot.historyIsProxy ? "proxy" : "copy",
-              static_cast<unsigned>(slot.historyWidth),
-              static_cast<unsigned>(slot.historyHeight));
-        } else {
-          std::printf("[TextureResidency] Evicting slot %s: releasing without staging"
-                      " (failed to create blit encoder).\n",
-                      label);
-        }
-      } else {
-        size_t rowBytes = slot.width * bytesPerPixel(slot.pixelFormat);
-        size_t alignedRowBytes = alignTo(rowBytes, 256);
-        NS::UInteger bytesPerImage =
-            static_cast<NS::UInteger>(alignedRowBytes * slot.height);
-        MTL::Size size = MTL::Size::Make(slot.width, slot.height, 1);
-        MTL::Origin origin = MTL::Origin::Make(0, 0, 0);
-        blit->copyFromTexture(slot.texture, 0, 0, origin, size,
-                              slot.stagingBuffer, 0, alignedRowBytes,
-                              bytesPerImage);
-
-        slot.stagingValid = true;
-        slot.historyBacking = ManagedTextureSlot::HistoryBacking::SharedBuffer;
-        slot.historyIsProxy = false;
-        slot.historyWidth = slot.width;
-        slot.historyHeight = slot.height;
-        slot.historyBytesPerRow = alignedRowBytes;
-        slot.needsGpuRefresh = true;
-        preservedHistory = true;
-
-        std::printf(
-            "[TextureResidency] Evicting slot %s: copied %zu bytes to staging buffer"
-            " before release.\n",
-            label, totalBytes);
-      }
-    }
+  std::printf(
+      "[TextureResidency] Evicting slot %s: releasing without history.\n",
+      label);
+  clearTextureHistory(slot);
+  slot.stagingValid = false;
+  if (slot.stagingBuffer) {
+    releaseTrackedResource(slot.stagingBuffer);
+    slot.stagingBuffer = nullptr;
+    slot.stagingCapacity = 0;
   }
-
-  if (!preservedHistory) {
-    clearTextureHistory(slot);
-    slot.stagingValid = false;
-    _needsAccumulationReset = true;
-    _accumulationTargetsNeedClear = true;
-  }
+  _needsAccumulationReset = true;
+  _accumulationTargetsNeedClear = true;
 
   if (slot.texture) {
     releaseTrackedResource(slot.texture);
@@ -7481,55 +7186,6 @@ void Renderer::draw(MTK::View *pView) {
   Camera::State viewCamera =
       _observerActive ? _observerCameraState : _primaryCameraState;
 
-  auto historyBackingName = [](ManagedTextureSlot::HistoryBacking backing) {
-    switch (backing) {
-    case ManagedTextureSlot::HistoryBacking::SharedBuffer:
-      return "staging";
-    case ManagedTextureSlot::HistoryBacking::CpuData:
-      return "cpu";
-    case ManagedTextureSlot::HistoryBacking::None:
-    default:
-      return "none";
-    }
-  };
-
-  auto historyMissing = [&](const ManagedTextureSlot &slot) {
-    if (slot.texture && !slot.needsGpuRefresh)
-      return false;
-    const char *label = textureSlotLabel(slot);
-    switch (slot.historyBacking) {
-    case ManagedTextureSlot::HistoryBacking::SharedBuffer:
-      if (!slot.stagingBuffer || !slot.stagingValid) {
-        return true;
-      }
-      return false;
-    case ManagedTextureSlot::HistoryBacking::CpuData:
-      if (slot.historyData.empty() || slot.historyWidth == 0 ||
-          slot.historyHeight == 0) {
-        return true;
-      }
-      return false;
-    case ManagedTextureSlot::HistoryBacking::None:
-    default:
-      return true;
-    }
-  };
-
-  auto proxyRestorePending = [&](const ManagedTextureSlot &slot) {
-    bool pending = slot.historyIsProxy && (!slot.texture || slot.needsGpuRefresh);
-    return pending;
-  };
-
-  if (proxyRestorePending(_accumulationSlots[0]) ||
-      proxyRestorePending(_accumulationSlots[1]) ||
-      proxyRestorePending(_sampleCountSlot) ||
-      historyMissing(_accumulationSlots[0]) ||
-      historyMissing(_accumulationSlots[1]) ||
-      historyMissing(_sampleCountSlot)) {
-    _needsAccumulationReset = true;
-    _accumulationTargetsNeedClear = true;
-  }
-
   Camera::applyState(_primaryCameraState);
   updateResidency();
 
@@ -7575,10 +7231,6 @@ void Renderer::draw(MTK::View *pView) {
     _frameTotalMemoryEvictionStall = true;
   beginFrameMetrics();
   std::swap(_accumulationSlots[0], _accumulationSlots[1]);
-
-  _historyStreamingActive = false;
-  _historyStreamingRestoreCount = 0;
-  _historyStreamingUsedProxy = false;
 
   uint64_t frameIndex = _renderedFrameCount;
   bool captureThisFrame = _frameCaptureEnabled && _frameCaptureInterval > 0 &&
@@ -8102,13 +7754,6 @@ void Renderer::draw(MTK::View *pView) {
     u.frameCount++;
     markBufferModified(_pUniformsBuffer,
                        NS::Range::Make(0, sizeof(UniformsData)));
-  }
-
-  if (_historyStreamingActive) {
-    std::printf("[TextureResidency] History streaming active: restored %zu slot%s%s.\n",
-                _historyStreamingRestoreCount,
-                (_historyStreamingRestoreCount == 1) ? "" : "s",
-                _historyStreamingUsedProxy ? " (proxy data involved)" : "");
   }
 
   if (!_frameCaptureEnabled &&

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -740,9 +740,6 @@ private:
   bool _accumulationTargetsNeedClear = false;
   MTL::Buffer *_pTextureClearBuffer = nullptr;
   size_t _textureClearBufferCapacity = 0;
-  bool _historyStreamingActive = false;
-  bool _historyStreamingUsedProxy = false;
-  size_t _historyStreamingRestoreCount = 0;
 
   size_t setObjectActive(size_t objectIndex, bool active);
   void configureTextureSlot(ManagedTextureSlot &slot, NS::UInteger width,
@@ -750,9 +747,6 @@ private:
                             MTL::TextureUsage usage);
   size_t textureByteSize(const ManagedTextureSlot &slot) const;
   void clearTextureHistory(ManagedTextureSlot &slot);
-  bool captureCpuHistoryProxy(ManagedTextureSlot &slot);
-  bool uploadHistoryToTexture(ManagedTextureSlot &slot, MTL::CommandBuffer *cmd,
-                              MTL::BlitCommandEncoder *&blit);
   MTL::Texture *requestResidentTexture(ManagedTextureSlot &slot,
                                        MTL::CommandBuffer *cmd,
                                        MTL::BlitCommandEncoder *&blit);

--- a/Nomad Path Tracer/StudyNotes.md
+++ b/Nomad Path Tracer/StudyNotes.md
@@ -9,13 +9,13 @@ The study now treats `totalGpuMemoryCapMB` as the **single authoritative budget*
 To avoid getting stuck in a perpetual eviction loop, the renderer tracks a minimum resident footprint estimate:
 
 ```
-history + mandatory buffers + essential geometry
+mandatory buffers + essential geometry
 ```
 
 When the configured total cap stays below this footprint for several frames, the renderer:
 
 1. Logs a warning that the total cap is below the minimum footprint.
-2. Forces an accumulation reset and disables history preservation.
+2. Forces an accumulation reset.
 3. Temporarily relaxes the effective total cap to the minimum footprint value.
 
 The benchmark CSV exposes the minimum footprint, relaxed cap, and eviction-stall status to make the fallback visible when comparing study runs.


### PR DESCRIPTION
### Motivation
- The accumulation-history save/restore flow added texture residency complexity and is no longer wanted, so history preservation should be removed to simplify residency and eviction behavior.
- The minimum-resident-footprint calculation and eviction-stall fallback should no longer include accumulation history since history is no longer preserved.

### Description
- Disabled history accounting by making `historyFootprintBytes()` return `0` and removing associated history bookkeeping and flags from the renderer implementation and header (`Renderer.cpp`, `Renderer.h`).
- Removed CPU/staging history capture and upload code paths (`captureCpuHistoryProxy` and `uploadHistoryToTexture`) and all restore-from-history branches in `requestResidentTexture` and `draw` so restored textures are treated as having no history.
- Simplified eviction so `evictTextureSlot` releases textures without attempting to preserve history and clears any history/staging buffers; eviction still triggers accumulation reset behavior.
- Updated documentation (`README.md`, `StudyNotes.md`) to remove "history" from the minimum resident footprint description and to reflect that only mandatory buffers + essential geometry are included.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69775593de54832db1fe288d742eae27)