### PR TITLE
Add ReSTIR reservoir output for direct lighting

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -1531,6 +1531,8 @@ Renderer::~Renderer() {
     releaseTrackedResource(_pPrimitiveHitBufferGPU);
   if (_pPrimitiveHitReadback)
     releaseTrackedResource(_pPrimitiveHitReadback);
+  if (_pReservoirBuffer)
+    releaseTrackedResource(_pReservoirBuffer);
   if (_pLightIndexBuffer)
     releaseTrackedResource(_pLightIndexBuffer);
   if (_pLightCdfBuffer)
@@ -3050,7 +3052,7 @@ void Renderer::prewarmAlwaysResidentResources() {
     if (!_pSphereBuffer || !_pSphereMaterialBuffer || !_pUniformsBuffer ||
         !_pActiveBuffer || !_pLightIndexBuffer || !_pLightCdfBuffer ||
         !_pPrimitiveRemapBuffer || !_pPrimitiveHitBufferGPU ||
-        !_pInstanceBuffer) {
+        !_pInstanceBuffer || !_pReservoirBuffer) {
       trackFrameCommandBuffer(cmd);
       cmd->commit();
       return;
@@ -3061,7 +3063,7 @@ void Renderer::prewarmAlwaysResidentResources() {
         !_pTriangleIndexBuffer || !_pPrimitiveIndexBuffer || !_pTLASBuffer ||
         !_pActiveBuffer || !_pLightIndexBuffer || !_pLightCdfBuffer ||
         !_pPrimitiveRemapBuffer || !_pPrimitiveHitBufferGPU ||
-        !_pInstanceBuffer) {
+        !_pInstanceBuffer || !_pReservoirBuffer) {
       trackFrameCommandBuffer(cmd);
       cmd->commit();
       return;
@@ -3091,6 +3093,7 @@ void Renderer::prewarmAlwaysResidentResources() {
     compute->setBuffer(_pInstanceBuffer, 0, 10);
     compute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
     compute->setBuffer(_pInstanceBuffer, 0, 13);
+    compute->setBuffer(_pReservoirBuffer, 0, 14);
   } else {
     compute->setBuffer(_pBVHBuffer, 0, 0);
     compute->setBuffer(_pSphereBuffer, 0, 1);
@@ -3106,6 +3109,7 @@ void Renderer::prewarmAlwaysResidentResources() {
     compute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
     compute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
     compute->setBuffer(_pInstanceBuffer, 0, 13);
+    compute->setBuffer(_pReservoirBuffer, 0, 14);
   }
 
   compute->setTexture(colorTexture, 0);
@@ -6790,6 +6794,14 @@ void Renderer::buildTextures() {
                        MTL::PixelFormat::PixelFormatRGBA32Float, usage);
   configureTextureSlot(_positionSlot, width, height,
                        MTL::PixelFormat::PixelFormatRGBA32Float, usage);
+
+  size_t reservoirBytes = static_cast<size_t>(width) *
+                          static_cast<size_t>(height) * kRestirReservoirStride;
+  ensureBufferCapacity(_pReservoirBuffer, reservoirBytes,
+                       _reservoirBufferCapacity, true,
+                       MTL::ResourceStorageModePrivate,
+                       GpuMemoryTracker::Category::RendererBuffers,
+                       "RestirReservoirBuffer", "buildTextures");
 }
 
 void Renderer::updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd) {
@@ -7334,6 +7346,7 @@ void Renderer::draw(MTK::View *pView) {
         pCompute->setBuffer(_pInstanceBuffer, 0, 10);
         pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
         pCompute->setBuffer(_pInstanceBuffer, 0, 13);
+        pCompute->setBuffer(_pReservoirBuffer, 0, 14);
       } else {
         pCompute->setBuffer(_pBVHBuffer, 0, 0);
         pCompute->setBuffer(_pSphereBuffer, 0, 1);
@@ -7349,6 +7362,7 @@ void Renderer::draw(MTK::View *pView) {
         pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
         pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
         pCompute->setBuffer(_pInstanceBuffer, 0, 13);
+        pCompute->setBuffer(_pReservoirBuffer, 0, 14);
       }
 
       pCompute->setTexture(colorTexture, 0);

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -320,6 +320,7 @@ private:
   MTL::Buffer *_pPrimitiveRemapBuffer = nullptr;
   MTL::Buffer *_pPrimitiveHitBufferGPU = nullptr;
   MTL::Buffer *_pPrimitiveHitReadback = nullptr;
+  MTL::Buffer *_pReservoirBuffer = nullptr;
   struct FrameCommandBufferRecord {
     MTL::CommandBuffer *buffer = nullptr;
     std::chrono::steady_clock::time_point trackedSince{};
@@ -373,6 +374,8 @@ private:
     std::vector<uint8_t> historyData;
     uint64_t lastUsedFrame = 0;
   };
+
+  static constexpr size_t kRestirReservoirStride = 48;
 
   // Framebuffers
   ManagedTextureSlot _colorSlot;
@@ -671,6 +674,7 @@ private:
   size_t _primitiveHitBufferCapacity = 0;
   size_t _instanceBufferCapacity = 0;
   size_t _geometryHandleBufferCapacity = 0;
+  size_t _reservoirBufferCapacity = 0;
   size_t _primitiveHitReadbackCapacity = 0;
   size_t _frustumVertexCapacity = 0;
 

--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -19,6 +19,7 @@ kernel void pathTraceKernel(
     device const uint *primitiveRemap [[buffer(11)]],
     device atomic_uint *primitiveRayStats [[buffer(12)]],
     device const InstanceRecord *instanceRecords [[buffer(13)]],
+    device RestirReservoir *reservoirBuffer [[buffer(14)]],
     texture2d<float, access::write> currentFrame [[texture(0)]],
     texture2d<float, access::write> albedoAccum [[texture(1)]],
     texture2d<float, access::write> normalAccum [[texture(2)]],
@@ -57,14 +58,16 @@ kernel void pathTraceKernel(
 
   uint samplesThisFrame = max(u.maxSamplesPerPixel, 1u);
 
-  float3 accumulatedColor = float3(0.0);
   float3 accumulatedAlbedo = float3(0.0);
   float3 accumulatedNormal = float3(0.0);
   float3 accumulatedPosition = float3(0.0);
   float accumulatedRoughness = 0.0f;
+  RestirReservoir reservoir = initReservoir();
 
   float3 rayDx = u.rayDx;
   float3 rayDy = u.rayDy;
+  float footprint = length(cross(rayDx, rayDy));
+  float lodAtten = 1.0 / (1.0 + footprint);
 
   for (uint sampleIdx = 0; sampleIdx < samplesThisFrame; ++sampleIdx) {
     float xOff = (randomFloat(seed) - 0.5f) / screenSize.x;
@@ -100,29 +103,140 @@ kernel void pathTraceKernel(
     r.minDistance = 0.0001f;
     r.maxDistance = INFINITY;
 
-    PathTraceSample sample = rayColor(r, rayDx, rayDy, tlasNodes, u.tlasNodeCount,
-                                      bvhNodes, primitives, materials,
-                                      u.primitiveCount, primitiveIndices,
-                                      activeMask, instanceRecords, lightIndices,
-                                      lightCdf, primitiveRemap, primitiveRayStats,
-                                      seed, u.maxRayDepth, u.debugAS,
-                                      u.blasNodeCount, u.lightCount, u.lightTotalWeight,
-                                      static_cast<uint>(u.totalPrimitiveCount),
-                                      materialTextures, u.textureCount,
-                                      environmentMap, environmentSampler,
-                                      u.environmentMapEnabled,
-                                      u.environmentMapIntensity);
-    accumulatedColor += sample.radiance;
-    accumulatedAlbedo += sample.albedo;
-    accumulatedNormal += sample.normal;
-    accumulatedPosition += sample.position;
-    accumulatedRoughness += sample.roughness;
+    TlasLeafCache bounceCache;
+    bounceCache.valid = false;
+    intersection bestHit = firstHitTLAS(
+        r, tlasNodes, u.tlasNodeCount, bvhNodes, primitives, primitiveIndices,
+        activeMask, instanceRecords, primitiveRemap, u.primitiveCount,
+        static_cast<uint>(u.totalPrimitiveCount), primitiveRayStats, &bounceCache);
+
+    if (bestHit.primitiveId != -1) {
+      int matBase = bestHit.primitiveId * int(kMaterialFloat4Count);
+      int totalEntries = int(u.primitiveCount) * int(kMaterialFloat4Count);
+      if (matBase >= 0 && matBase + int(kMaterialFloat4Count) <= totalEntries) {
+        MaterialPayload material = decodeMaterial(matBase, materials, lodAtten);
+        if (!bestHit.supportsNormalMap)
+          material.normalTextureIndex = -1;
+
+        float2 surfaceUV = float2(0.0f);
+        bool haveUV = false;
+        int primBase = bestHit.primitiveId * int(kPrimitiveFloat4Count);
+        int primEntries = int(u.primitiveCount) * int(kPrimitiveFloat4Count);
+        if (primBase + int(kPrimitiveFloat4Count) <= primEntries && primBase >= 0) {
+          float4 gp0 = primitives[primBase + 0];
+          float4 gp1 = primitives[primBase + 1];
+          float4 gp2 = primitives[primBase + 2];
+          float4 gp3 = primitives[primBase + 3];
+          int primitiveType = int(gp0.w);
+          if (primitiveType == 1) {
+            float2 uv0 = float2(gp1.w, gp2.w);
+            float2 uv1 = gp3.xy;
+            float2 uv2 = gp3.zw;
+            float2 bary = bestHit.barycentric;
+            float w = 1.0f - bary.x - bary.y;
+            surfaceUV = uv0 * w + uv1 * bary.x + uv2 * bary.y;
+            haveUV = true;
+          } else if (primitiveType == 2) {
+            surfaceUV = bestHit.uv;
+            haveUV = true;
+          } else if (primitiveType == 0) {
+            float3 center = gp0.xyz;
+            float3 dir = normalize(bestHit.point - center);
+            if (all(isfinite(dir))) {
+              float u = 0.5f + atan2(dir.z, dir.x) / (2.0f * M_PI);
+              float v = 0.5f - asin(clamp(dir.y, -1.0f, 1.0f)) / M_PI;
+              surfaceUV = float2(u, v);
+              haveUV = true;
+            }
+          }
+        }
+
+        if (haveUV) {
+          if (material.diffuseTextureIndex >= 0) {
+            float4 sample = samplePackedTexture(material.diffuseTextureIndex,
+                                                surfaceUV, materialTextures,
+                                                u.textureCount);
+            material.diffuseColor *= sample.xyz;
+            material.opacity *= clamp(sample.w, 0.0f, 1.0f);
+          }
+          if (material.specularTextureIndex >= 0) {
+            float4 sample = samplePackedTexture(material.specularTextureIndex,
+                                                surfaceUV, materialTextures,
+                                                u.textureCount);
+            material.specularColor *= sample.xyz;
+          }
+        }
+
+        float3 shadingNormal = bestHit.normal;
+        if (!all(isfinite(shadingNormal)) ||
+            dot(shadingNormal, shadingNormal) <= RAY_EPS) {
+          shadingNormal = -rayDirection;
+        }
+        if (haveUV && material.normalTextureIndex >= 0 &&
+            bestHit.supportsNormalMap) {
+          float4 normalSample =
+              samplePackedTexture(material.normalTextureIndex, surfaceUV,
+                                  materialTextures, u.textureCount);
+          float3 sampledNormal = normalSample.xyz;
+          float3 localNormal = sampledNormal * 2.0f - float3(1.0f);
+
+          float3 geomNormal = bestHit.normal;
+          float3 tangent = bestHit.tangent;
+          float3 bitangent = bestHit.bitangent;
+
+          bool validFrame =
+              dot(tangent, tangent) > RAY_EPS &&
+              dot(bitangent, bitangent) > RAY_EPS &&
+              dot(geomNormal, geomNormal) > RAY_EPS &&
+              all(isfinite(tangent)) && all(isfinite(bitangent)) &&
+              all(isfinite(geomNormal));
+
+          if (validFrame && all(isfinite(localNormal))) {
+            float3 t = normalize(tangent);
+            float3 b = normalize(bitangent);
+            float3 n = normalize(geomNormal);
+            float3 worldNormal = localNormal.x * t + localNormal.y * b +
+                                 localNormal.z * n;
+            if (dot(worldNormal, worldNormal) > RAY_EPS &&
+                all(isfinite(worldNormal))) {
+              shadingNormal = normalize(worldNormal);
+              if (dot(shadingNormal, n) < 0.0f)
+                shadingNormal = -shadingNormal;
+            }
+          }
+        }
+
+        accumulatedAlbedo += material.diffuseColor;
+        accumulatedNormal += shadingNormal;
+        accumulatedPosition += bestHit.point;
+        accumulatedRoughness += clamp(material.roughness, 0.0f, 1.0f);
+
+        float3 diffuseColor = material.diffuseColor * material.opacity;
+        if (luminance(diffuseColor) > 0.0f && u.lightCount > 0 &&
+            u.lightTotalWeight > 0.0f) {
+          LightSampleCandidate candidate;
+          if (sampleDirectLightCandidate(
+                  bestHit.point, shadingNormal, diffuseColor,
+                  bestHit.primitiveId, tlasNodes, u.tlasNodeCount, bvhNodes,
+                  primitives, materials, u.primitiveCount, primitiveIndices,
+                  activeMask, instanceRecords, lightIndices, lightCdf,
+                  primitiveRemap, primitiveRayStats, bounceCache, seed,
+                  u.lightCount, u.lightTotalWeight,
+                  static_cast<uint>(u.totalPrimitiveCount), candidate)) {
+            float weight = luminance(candidate.radiance) /
+                           max(candidate.pdf, RAY_EPS);
+            float xi = randomFloat(seed);
+            seed = random(seed);
+            updateReservoir(reservoir, candidate, weight, xi);
+          }
+        }
+      }
+    }
   }
 
   float totalSamples = float(samplesThisFrame);
-  float3 averaged =
-      (totalSamples > 0.0f) ? accumulatedColor / totalSamples : float3(0.0f);
-  averaged = clamp(averaged, 0.0f, 1.0f);
+  float3 reservoirEstimate = finalizeReservoir(reservoir);
+  reservoirEstimate = clamp(reservoirEstimate, 0.0f, 1.0f);
 
   float3 averagedAlbedo =
       (totalSamples > 0.0f) ? accumulatedAlbedo / totalSamples : float3(0.0f);
@@ -136,9 +250,14 @@ kernel void pathTraceKernel(
       (totalSamples > 0.0f) ? accumulatedRoughness / totalSamples : 0.0f;
   averagedRoughness = clamp(averagedRoughness, 0.0f, 1.0f);
 
-  float4 result = float4(averaged, 1.0f);
+  float4 result = float4(reservoirEstimate, 1.0f);
   currentFrame.write(result, pixel);
   albedoAccum.write(float4(averagedAlbedo, 1.0f), pixel);
   normalAccum.write(float4(averagedNormal, averagedRoughness), pixel);
   positionAccum.write(float4(averagedPosition, 1.0f), pixel);
+
+  if (reservoirBuffer) {
+    uint pixelIndex = pixel.y * width + pixel.x;
+    reservoirBuffer[pixelIndex] = reservoir;
+  }
 }

--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -42,6 +42,13 @@ struct TlasLeafCache {
   float3 boundsMax = float3(0.0f);
 };
 
+struct LightSampleCandidate {
+  float3 radiance = float3(0.0f);
+  float3 wi = float3(0.0f);
+  float pdf = 0.0f;
+  uint lightId = 0u;
+};
+
 #include "Intersect.h"
 #include "Random.h"
 #include "Scatter.h"
@@ -177,6 +184,137 @@ inline float lightPdfFromCdf(uint offset, device const float *lightCdf,
   if (weight <= 0.0f)
     return 0.0f;
   return weight / lightTotalWeight;
+}
+
+inline RestirReservoir initReservoir() {
+  RestirReservoir reservoir;
+  reservoir.sampleRadiance = float3(0.0f);
+  reservoir.wi = float3(0.0f);
+  reservoir.pdf = 0.0f;
+  reservoir.wSum = 0.0f;
+  reservoir.m = 0u;
+  reservoir.packedLightId = 0xffffffffu;
+  return reservoir;
+}
+
+inline void updateReservoir(thread RestirReservoir &reservoir,
+                            thread const LightSampleCandidate &candidate,
+                            float weight, float xi) {
+  reservoir.m += 1u;
+  if (weight <= 0.0f || !isfinite(weight)) {
+    return;
+  }
+  reservoir.wSum += weight;
+  float threshold = weight / reservoir.wSum;
+  if (xi < threshold) {
+    reservoir.sampleRadiance = candidate.radiance;
+    reservoir.wi = candidate.wi;
+    reservoir.pdf = candidate.pdf;
+    reservoir.packedLightId = candidate.lightId;
+  }
+}
+
+inline float3 finalizeReservoir(thread const RestirReservoir &reservoir) {
+  if (reservoir.m == 0u || reservoir.pdf <= 0.0f) {
+    return float3(0.0f);
+  }
+  float weightSelected =
+      luminance(reservoir.sampleRadiance) / max(reservoir.pdf, RAY_EPS);
+  if (weightSelected <= 0.0f) {
+    return float3(0.0f);
+  }
+  float normalization = reservoir.wSum / (float(reservoir.m) * weightSelected);
+  return reservoir.sampleRadiance * normalization;
+}
+
+inline bool sampleDirectLightCandidate(
+    float3 hitPoint, float3 offsetNormal, float3 diffuseColor,
+    int hitPrimitiveId, device const float4 *tlasNodes, uint tlasNodeCount,
+    device const float4 *bvhNodes, device const float4 *primitives,
+    device const float4 *materials, uint primitiveCount,
+    device const int *primitiveIndices, device const uchar *activeMask,
+    device const InstanceRecord *instanceRecords,
+    device const uint *lightIndices, device const float *lightCdf,
+    device const uint *primitiveRemap, device atomic_uint *primitiveRayStats,
+    thread TlasLeafCache &bounceCache, thread uint32_t &seed, uint lightCount,
+    float lightTotalWeight, uint totalPrimitiveCount,
+    thread LightSampleCandidate &candidate) {
+  candidate = LightSampleCandidate();
+  if (lightCount == 0 || lightTotalWeight <= 0.0f)
+    return false;
+
+  float lightXi = randomFloat(seed);
+  seed = random(seed);
+  uint selectedOffset =
+      selectLightOffset(lightXi, lightCdf, lightCount, lightTotalWeight);
+  if (selectedOffset >= lightCount)
+    return false;
+
+  uint lightPrimIndex = lightIndices[selectedOffset];
+  if (int(lightPrimIndex) == hitPrimitiveId)
+    return false;
+
+  int base = int(lightPrimIndex) * int(kPrimitiveFloat4Count);
+  int primEntries = int(primitiveCount) * int(kPrimitiveFloat4Count);
+  if (base < 0 || base + 2 >= primEntries)
+    return false;
+
+  float4 lp0 = primitives[base + 0];
+  float4 lp1 = primitives[base + 1];
+  float4 lp2 = primitives[base + 2];
+  float3 lightPoint;
+  float3 lightNormal;
+  float area = 0.0f;
+  if (!sampleLightPoint(int(lp0.w), lp0, lp1, lp2, seed, lightPoint,
+                        lightNormal, area) ||
+      area <= 0.0f) {
+    return false;
+  }
+
+  float3 toLight = lightPoint - hitPoint;
+  float dist2 = dot(toLight, toLight);
+  if (dist2 <= RAY_EPS)
+    return false;
+
+  float dist = sqrt(dist2);
+  float3 wi = toLight / dist;
+  float cosTheta = max(dot(offsetNormal, wi), 0.0f);
+  float cosLight = max(dot(lightNormal, -wi), 0.0f);
+  if (cosTheta <= 0.0f || cosLight <= 0.0f)
+    return false;
+
+  float lightPdf = lightPdfFromCdf(selectedOffset, lightCdf, lightTotalWeight);
+  if (lightPdf <= 0.0f)
+    return false;
+
+  float pdfArea = 1.0f / area;
+  float pdfSolid = pdfArea * dist2 / cosLight;
+  float totalPdf = lightPdf * pdfSolid;
+  if (totalPdf <= 0.0f)
+    return false;
+
+  bool visible = isLightVisible(
+      hitPoint, offsetNormal, wi, dist, lightPrimIndex, bounceCache, tlasNodes,
+      tlasNodeCount, bvhNodes, primitives, primitiveIndices, activeMask,
+      instanceRecords, primitiveRemap, primitiveCount, totalPrimitiveCount,
+      primitiveRayStats);
+  if (!visible)
+    return false;
+
+  int lightMatIndex = int(lightPrimIndex) * int(kMaterialFloat4Count);
+  int totalEntries = int(primitiveCount) * int(kMaterialFloat4Count);
+  if (lightMatIndex < 0 || lightMatIndex + int(kMaterialFloat4Count) > totalEntries)
+    return false;
+
+  MaterialPayload lightMaterial = decodeMaterial(lightMatIndex, materials, 1.0f);
+  float3 lightRadiance =
+      lightMaterial.emissionColor * lightMaterial.emissionPower;
+  float3 throughput = diffuseColor / M_PI;
+  candidate.radiance = throughput * lightRadiance * cosTheta;
+  candidate.wi = wi;
+  candidate.pdf = totalPdf;
+  candidate.lightId = lightPrimIndex;
+  return true;
 }
 
 inline bool intersectAABB(thread const Ray &r, float3 bmin, float3 bmax,

--- a/Nomad Path Tracer/Renderer/Shaders/Structs.h
+++ b/Nomad Path Tracer/Renderer/Shaders/Structs.h
@@ -98,6 +98,16 @@ struct PackedTexture
     uint flags;
 };
 
+struct RestirReservoir
+{
+    float3 sampleRadiance = float3(0.0f);
+    float3 wi = float3(0.0f);
+    float pdf = 0.0f;
+    float wSum = 0.0f;
+    uint m = 0u;
+    uint packedLightId = 0u;
+};
+
 
 
 


### PR DESCRIPTION
### Motivation
- Implement per-pixel ReSTIR-style reservoir sampling to improve direct-light selection and enable storing a single reservoir estimate per pixel instead of raw per-sample radiance.
- Expose the reservoir as a GPU-side buffer so downstream stages or debug tools can read/store per-pixel reservoir state.

### Description
- Added a `RestirReservoir` struct in `Nomad Path Tracer/Renderer/Shaders/Structs.h` containing `sampleRadiance`, `wi`, `pdf`, `wSum`, `m`, and a packed light id (`packedLightId`).
- Introduced `LightSampleCandidate` and ReSTIR helpers in `Nomad Path Tracer/Renderer/Shaders/PathTracing.h`, including `initReservoir()`, `updateReservoir(...)`, `finalizeReservoir(...)`, and `sampleDirectLightCandidate(...)` which samples a candidate using the existing `lightIndices`/`lightCdf` path and computes candidate radiance, PDF and direction.
- Updated `Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal` to fill a per-pixel reservoir: the kernel now generates candidates per pixel, calls the sampling helper, updates a local `RestirReservoir`, writes out the finalized reservoir estimate to `currentFrame`, and stores the final reservoir into a `reservoirBuffer`.
- Allocated and bound a GPU buffer for reservoirs in the renderer: added `_pReservoirBuffer` and `_reservoirBufferCapacity` in `Renderer.h`, ensured allocation in `Renderer::buildTextures()`, bound the buffer to the compute pipeline in `Renderer.cpp`, and release handling during shutdown.
- Minor bookkeeping and PDF/throughput adjustments in the sampling/normalization logic to produce a reservoir-weighted estimate.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69776024d7c8832d8b122fcd912dcda0)