### PR TITLE
Add ReSTIR temporal reservoir pass with double-buffered history and reprojection

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -24,6 +24,7 @@
 #include <thread>
 #include <limits>
 #include <functional>
+#include <utility>
 #include <filesystem>
 #include <fstream>
 #include <chrono>
@@ -550,6 +551,9 @@ double Renderer::residentTextureMemoryMB() const {
   addSlot(_albedoSlot);
   addSlot(_normalSlot);
   addSlot(_positionSlot);
+  addSlot(_albedoHistorySlot);
+  addSlot(_normalHistorySlot);
+  addSlot(_positionHistorySlot);
 
   for (MTL::Texture *texture : _materialTextures) {
     totalBytes += textureByteSize(texture);
@@ -739,6 +743,7 @@ struct UniformsData {
   float environmentPadding0 = 0.0f;
   float environmentPadding1 = 0.0f;
   float cameraMotionMetric = 0.0f;
+  simd::float4x4 viewProjection{};
   simd::float4x4 prevViewProjection{};
 };
 
@@ -1562,6 +1567,8 @@ Renderer::~Renderer() {
     releaseTrackedResource(_pPrimitiveHitReadback);
   if (_pReservoirBuffer)
     releaseTrackedResource(_pReservoirBuffer);
+  if (_pReservoirHistoryBuffer)
+    releaseTrackedResource(_pReservoirHistoryBuffer);
   if (_pLightIndexBuffer)
     releaseTrackedResource(_pLightIndexBuffer);
   if (_pLightCdfBuffer)
@@ -1606,6 +1613,9 @@ Renderer::~Renderer() {
   releaseTextureSlot(_albedoSlot);
   releaseTextureSlot(_normalSlot);
   releaseTextureSlot(_positionSlot);
+  releaseTextureSlot(_albedoHistorySlot);
+  releaseTextureSlot(_normalHistorySlot);
+  releaseTextureSlot(_positionHistorySlot);
 
   if (_pTextureClearBuffer)
     releaseTrackedResource(_pTextureClearBuffer);
@@ -1614,6 +1624,8 @@ Renderer::~Renderer() {
     _pPathTracePSO->release();
   if (_pAdaptiveSamplingPSO)
     _pAdaptiveSamplingPSO->release();
+  if (_pRestirTemporalPSO)
+    _pRestirTemporalPSO->release();
   if (_pOverlayPSO)
     _pOverlayPSO->release();
 
@@ -2500,6 +2512,10 @@ void Renderer::buildShaders() {
     _pAdaptiveSamplingPSO->release();
     _pAdaptiveSamplingPSO = nullptr;
   }
+  if (_pRestirTemporalPSO) {
+    _pRestirTemporalPSO->release();
+    _pRestirTemporalPSO = nullptr;
+  }
 
   NS::Error *pError = nullptr;
   MTL::Library *pLibrary = _pDevice->newDefaultLibrary();
@@ -2608,6 +2624,18 @@ void Renderer::buildShaders() {
       __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
     }
     pAdaptiveFn->release();
+  }
+
+  pError = nullptr;
+  MTL::Function *pRestirTemporalFn = pLibrary->newFunction(
+      NS::String::string("restirTemporalMain", UTF8StringEncoding));
+  if (pRestirTemporalFn) {
+    _pRestirTemporalPSO =
+        _pDevice->newComputePipelineState(pRestirTemporalFn, &pError);
+    if (!_pRestirTemporalPSO && pError) {
+      __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
+    }
+    pRestirTemporalFn->release();
   }
 
   pVertexFn->release();
@@ -6274,6 +6302,12 @@ const char *Renderer::textureSlotLabel(const ManagedTextureSlot &slot) const {
     return "_normalSlot";
   if (&slot == &_positionSlot)
     return "_positionSlot";
+  if (&slot == &_albedoHistorySlot)
+    return "_albedoHistorySlot";
+  if (&slot == &_normalHistorySlot)
+    return "_normalHistorySlot";
+  if (&slot == &_positionHistorySlot)
+    return "_positionHistorySlot";
   return "<unknown texture slot>";
 }
 
@@ -6351,6 +6385,9 @@ void Renderer::disableHistoryForMemoryCap() {
   disableSlot(_albedoSlot);
   disableSlot(_normalSlot);
   disableSlot(_positionSlot);
+  disableSlot(_albedoHistorySlot);
+  disableSlot(_normalHistorySlot);
+  disableSlot(_positionHistorySlot);
 }
 
 
@@ -6455,8 +6492,10 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
                 totalMemoryMB, residencyMB, scratchMB, totalCapMB);
   }
 
-  std::array<ManagedTextureSlot *, 4> slots = {
-      &_colorSlot, &_albedoSlot, &_normalSlot, &_positionSlot};
+  std::array<ManagedTextureSlot *, 7> slots = {
+      &_colorSlot,          &_albedoSlot,          &_normalSlot,
+      &_positionSlot,       &_albedoHistorySlot,   &_normalHistorySlot,
+      &_positionHistorySlot};
 
   struct ResidencyCandidate {
     ManagedTextureSlot *slot = nullptr;
@@ -6823,6 +6862,12 @@ void Renderer::buildTextures() {
                        MTL::PixelFormat::PixelFormatRGBA32Float, usage);
   configureTextureSlot(_positionSlot, width, height,
                        MTL::PixelFormat::PixelFormatRGBA32Float, usage);
+  configureTextureSlot(_albedoHistorySlot, width, height,
+                       MTL::PixelFormat::PixelFormatRGBA32Float, usage);
+  configureTextureSlot(_normalHistorySlot, width, height,
+                       MTL::PixelFormat::PixelFormatRGBA32Float, usage);
+  configureTextureSlot(_positionHistorySlot, width, height,
+                       MTL::PixelFormat::PixelFormatRGBA32Float, usage);
 
   size_t reservoirBytes = static_cast<size_t>(width) *
                           static_cast<size_t>(height) * kRestirReservoirStride;
@@ -6831,6 +6876,12 @@ void Renderer::buildTextures() {
                        MTL::ResourceStorageModePrivate,
                        GpuMemoryTracker::Category::RendererBuffers,
                        "RestirReservoirBuffer", "buildTextures");
+  ensureBufferCapacity(_pReservoirHistoryBuffer, reservoirBytes,
+                       _reservoirHistoryBufferCapacity, true,
+                       MTL::ResourceStorageModePrivate,
+                       GpuMemoryTracker::Category::RendererBuffers,
+                       "RestirReservoirHistoryBuffer", "buildTextures");
+  _restirHistoryValid = false;
 }
 
 void Renderer::updateAdaptiveSamplingMaps(MTL::CommandBuffer *pCmd) {
@@ -6964,6 +7015,11 @@ void Renderer::updateUniforms(bool cameraChanged) {
   float aspect = Camera::screenSize.y > 0.0f
                      ? Camera::screenSize.x / Camera::screenSize.y
                      : 1.0f;
+  u.viewProjection =
+      simd_mul(makePerspectiveMatrix(activeView.verticalFov, aspect,
+                                     kReprojectionNearPlane,
+                                     kReprojectionFarPlane),
+               makeViewMatrix(activeView));
   if (_lastUniformCameraStateValid) {
     u.prevViewProjection =
         simd_mul(makePerspectiveMatrix(_lastUniformCameraState.verticalFov,
@@ -7022,6 +7078,8 @@ void Renderer::updateUniforms(bool cameraChanged) {
 void Renderer::draw(MTK::View *pView) {
   processRayHitCounters();
   bool cameraChanged = updateCameraStates();
+  if (cameraChanged)
+    _restirHistoryValid = false;
   Camera::State viewCamera =
       _observerActive ? _observerCameraState : _primaryCameraState;
 
@@ -7125,12 +7183,23 @@ void Renderer::draw(MTK::View *pView) {
   MTL::Texture *albedoTexture = _albedoSlot.texture;
   MTL::Texture *normalTexture = _normalSlot.texture;
   MTL::Texture *positionTexture = _positionSlot.texture;
+  MTL::Texture *albedoHistoryTexture = _albedoHistorySlot.texture;
+  MTL::Texture *normalHistoryTexture = _normalHistorySlot.texture;
+  MTL::Texture *positionHistoryTexture = _positionHistorySlot.texture;
   if (allowResidency) {
     colorTexture = requestResidentTexture(_colorSlot, prepCmd, restoreBlit);
     albedoTexture = requestResidentTexture(_albedoSlot, prepCmd, restoreBlit);
     normalTexture = requestResidentTexture(_normalSlot, prepCmd, restoreBlit);
     positionTexture =
         requestResidentTexture(_positionSlot, prepCmd, restoreBlit);
+    if (_restirHistoryValid) {
+      albedoHistoryTexture =
+          requestResidentTexture(_albedoHistorySlot, prepCmd, restoreBlit);
+      normalHistoryTexture =
+          requestResidentTexture(_normalHistorySlot, prepCmd, restoreBlit);
+      positionHistoryTexture =
+          requestResidentTexture(_positionHistorySlot, prepCmd, restoreBlit);
+    }
   }
 
   auto ensureSlotReady = [&](ManagedTextureSlot &slot, MTL::Texture *&handle) {
@@ -7157,6 +7226,11 @@ void Renderer::draw(MTK::View *pView) {
   markSlotUsed(_albedoSlot, albedoTexture);
   markSlotUsed(_normalSlot, normalTexture);
   markSlotUsed(_positionSlot, positionTexture);
+  if (_restirHistoryValid) {
+    markSlotUsed(_albedoHistorySlot, albedoHistoryTexture);
+    markSlotUsed(_normalHistorySlot, normalHistoryTexture);
+    markSlotUsed(_positionHistorySlot, positionHistoryTexture);
+  }
 
   if (restoreBlit)
     restoreBlit->endEncoding();
@@ -7443,6 +7517,53 @@ void Renderer::draw(MTK::View *pView) {
     }
   }
 
+  if (_pRestirTemporalPSO && _restirHistoryValid && _pReservoirBuffer &&
+      _pReservoirHistoryBuffer && positionTexture && normalTexture &&
+      albedoTexture && positionHistoryTexture && normalHistoryTexture &&
+      albedoHistoryTexture) {
+    MTL::CommandBuffer *temporalCmd = _pCommandQueue->commandBuffer();
+    if (temporalCmd) {
+      MTL::ComputeCommandEncoder *temporalCompute =
+          temporalCmd->computeCommandEncoder();
+      if (temporalCompute) {
+        temporalCompute->setComputePipelineState(_pRestirTemporalPSO);
+        temporalCompute->setBuffer(_pReservoirHistoryBuffer, 0, 0);
+        temporalCompute->setBuffer(_pReservoirBuffer, 0, 1);
+        temporalCompute->setBuffer(_pUniformsBuffer, 0, 2);
+        temporalCompute->setTexture(positionTexture, 0);
+        temporalCompute->setTexture(normalTexture, 1);
+        temporalCompute->setTexture(albedoTexture, 2);
+        temporalCompute->setTexture(positionHistoryTexture, 3);
+        temporalCompute->setTexture(normalHistoryTexture, 4);
+        temporalCompute->setTexture(albedoHistoryTexture, 5);
+
+        NS::UInteger tgWidth =
+            std::max<NS::UInteger>(1,
+                                   _pRestirTemporalPSO->threadExecutionWidth());
+        NS::UInteger maxThreads = std::max<NS::UInteger>(
+            tgWidth, _pRestirTemporalPSO->maxTotalThreadsPerThreadgroup());
+        NS::UInteger tgHeight = std::max<NS::UInteger>(1, maxThreads / tgWidth);
+        MTL::Size threadsPerThreadgroup =
+            MTL::Size::Make(tgWidth, tgHeight, 1);
+
+        MTL::Size threadgroups = MTL::Size::Make(
+            (width + threadsPerThreadgroup.width - 1) /
+                threadsPerThreadgroup.width,
+            (height + threadsPerThreadgroup.height - 1) /
+                threadsPerThreadgroup.height,
+            1);
+        temporalCompute->dispatchThreadgroups(threadgroups,
+                                              threadsPerThreadgroup);
+        temporalCompute->endEncoding();
+        trackFrameCommandBuffer(temporalCmd);
+        temporalCmd->commit();
+      } else {
+        trackFrameCommandBuffer(temporalCmd);
+        temporalCmd->commit();
+      }
+    }
+  }
+
   MTL::CommandBuffer *presentCmd = _pCommandQueue->commandBuffer();
   if (!presentCmd) {
     completeFrameMetrics(nullptr);
@@ -7570,6 +7691,19 @@ void Renderer::draw(MTK::View *pView) {
 
   ++_renderedFrameCount;
   pPool->release();
+
+  if (_positionSlot.texture && _positionHistorySlot.texture) {
+    std::swap(_positionSlot, _positionHistorySlot);
+    std::swap(_normalSlot, _normalHistorySlot);
+    std::swap(_albedoSlot, _albedoHistorySlot);
+  }
+  if (_pReservoirBuffer && _pReservoirHistoryBuffer) {
+    std::swap(_pReservoirBuffer, _pReservoirHistoryBuffer);
+  }
+  if (!_restirHistoryValid && _pReservoirBuffer && _pReservoirHistoryBuffer &&
+      _positionSlot.texture && _positionHistorySlot.texture) {
+    _restirHistoryValid = true;
+  }
 }
 
 void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -308,6 +308,7 @@ private:
   MTL::RenderPipelineState *_pOverlayPSO = nullptr;
   MTL::ComputePipelineState *_pPathTracePSO = nullptr;
   MTL::ComputePipelineState *_pAdaptiveSamplingPSO = nullptr;
+  MTL::ComputePipelineState *_pRestirTemporalPSO = nullptr;
 
   // Core scene and geometry data
   Scene *_pScene = nullptr;
@@ -326,6 +327,7 @@ private:
   MTL::Buffer *_pPrimitiveHitBufferGPU = nullptr;
   MTL::Buffer *_pPrimitiveHitReadback = nullptr;
   MTL::Buffer *_pReservoirBuffer = nullptr;
+  MTL::Buffer *_pReservoirHistoryBuffer = nullptr;
   struct FrameCommandBufferRecord {
     MTL::CommandBuffer *buffer = nullptr;
     std::chrono::steady_clock::time_point trackedSince{};
@@ -339,6 +341,7 @@ private:
   std::deque<double> _pathTraceGpuMsPerTileHistory;
   size_t _pathTraceTilesPerCommandBudget = 0;
   bool _pathTraceCommandTimeout = false;
+  bool _restirHistoryValid = false;
   MTL::Buffer *_pLightIndexBuffer = nullptr;
   MTL::Buffer *_pLightCdfBuffer = nullptr;
   MTL::Buffer *_pInstanceBuffer = nullptr;
@@ -387,6 +390,9 @@ private:
   ManagedTextureSlot _albedoSlot;
   ManagedTextureSlot _normalSlot;
   ManagedTextureSlot _positionSlot;
+  ManagedTextureSlot _albedoHistorySlot;
+  ManagedTextureSlot _normalHistorySlot;
+  ManagedTextureSlot _positionHistorySlot;
 
   struct PendingBlasBuild {
     Renderer *renderer = nullptr;
@@ -680,6 +686,7 @@ private:
   size_t _instanceBufferCapacity = 0;
   size_t _geometryHandleBufferCapacity = 0;
   size_t _reservoirBufferCapacity = 0;
+  size_t _reservoirHistoryBufferCapacity = 0;
   size_t _primitiveHitReadbackCapacity = 0;
   size_t _frustumVertexCapacity = 0;
 

--- a/Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal
@@ -1,0 +1,155 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+#include "Structs.h"
+
+inline uint hashUint(uint x) {
+    x ^= x >> 16;
+    x *= 0x7feb352d;
+    x ^= x >> 15;
+    x *= 0x846ca68b;
+    x ^= x >> 16;
+    return x;
+}
+
+inline float hashToFloat(uint x) {
+    return float(hashUint(x) & 0x00ffffffu) / float(0x01000000u);
+}
+
+inline bool isFinite3(float3 v) {
+    return all(isfinite(v));
+}
+
+inline float depthFromClip(float4 clip) {
+    if (clip.w == 0.0f) {
+        return 0.0f;
+    }
+    return clip.z / clip.w;
+}
+
+inline void mergeReservoir(thread RestirReservoir &current,
+                           thread const RestirReservoir &history,
+                           float xi) {
+    if (history.m == 0u || history.wSum <= 0.0f || !isfinite(history.wSum)) {
+        return;
+    }
+    float currentWeight = max(current.wSum, 0.0f);
+    float historyWeight = max(history.wSum, 0.0f);
+    float totalWeight = currentWeight + historyWeight;
+    if (totalWeight <= 0.0f || !isfinite(totalWeight)) {
+        return;
+    }
+    float historyProb = historyWeight / totalWeight;
+    if (xi < historyProb) {
+        current.sampleRadiance = history.sampleRadiance;
+        current.wi = history.wi;
+        current.pdf = history.pdf;
+        current.packedLightId = history.packedLightId;
+    }
+    current.wSum = totalWeight;
+    current.m += history.m;
+}
+
+kernel void restirTemporalMain(
+    device const RestirReservoir *historyReservoir [[buffer(0)]],
+    device RestirReservoir *currentReservoir [[buffer(1)]],
+    constant UniformsData &uniforms [[buffer(2)]],
+    texture2d<float, access::read> positionAccum [[texture(0)]],
+    texture2d<float, access::read> normalAccum [[texture(1)]],
+    texture2d<float, access::read> albedoAccum [[texture(2)]],
+    texture2d<float, access::read> historyPosition [[texture(3)]],
+    texture2d<float, access::read> historyNormal [[texture(4)]],
+    texture2d<float, access::read> historyAlbedo [[texture(5)]],
+    uint2 gid [[thread_position_in_grid]]) {
+    uint width = positionAccum.get_width();
+    uint height = positionAccum.get_height();
+    if (gid.x >= width || gid.y >= height) {
+        return;
+    }
+
+    uint index = gid.y * width + gid.x;
+    RestirReservoir current = currentReservoir[index];
+
+    float3 currentPosition = positionAccum.read(gid).xyz;
+    float3 currentNormal = normalAccum.read(gid).xyz;
+    float3 currentAlbedo = albedoAccum.read(gid).xyz;
+
+    if (!isFinite3(currentPosition) || !isFinite3(currentNormal) ||
+        !isFinite3(currentAlbedo)) {
+        currentReservoir[index] = current;
+        return;
+    }
+
+    float4 currentClip = uniforms.viewProjection * float4(currentPosition, 1.0f);
+    if (currentClip.w <= 0.0f) {
+        currentReservoir[index] = current;
+        return;
+    }
+
+    float4 prevClip = uniforms.prevViewProjection * float4(currentPosition, 1.0f);
+    if (prevClip.w <= 0.0f) {
+        currentReservoir[index] = current;
+        return;
+    }
+
+    float2 prevNdc = prevClip.xy / prevClip.w;
+    float2 prevUv = prevNdc * 0.5f + 0.5f;
+    if (prevUv.x < 0.0f || prevUv.x > 1.0f || prevUv.y < 0.0f || prevUv.y > 1.0f) {
+        currentReservoir[index] = current;
+        return;
+    }
+
+    uint2 prevPixel = uint2(prevUv * float2(width, height));
+    if (prevPixel.x >= width || prevPixel.y >= height) {
+        currentReservoir[index] = current;
+        return;
+    }
+
+    float3 historyPositionValue = historyPosition.read(prevPixel).xyz;
+    float3 historyNormalValue = historyNormal.read(prevPixel).xyz;
+    float3 historyAlbedoValue = historyAlbedo.read(prevPixel).xyz;
+
+    if (!isFinite3(historyPositionValue) || !isFinite3(historyNormalValue) ||
+        !isFinite3(historyAlbedoValue)) {
+        currentReservoir[index] = current;
+        return;
+    }
+
+    float motion = clamp(uniforms.cameraMotionMetric, 0.0f, 1.0f);
+    float depthThreshold = mix(0.02f, 0.005f, motion);
+    float normalThreshold = mix(0.8f, 0.95f, motion);
+    float albedoThreshold = mix(0.25f, 0.1f, motion);
+
+    float4 historyClip = uniforms.viewProjection * float4(historyPositionValue, 1.0f);
+    if (historyClip.w <= 0.0f) {
+        currentReservoir[index] = current;
+        return;
+    }
+
+    float depthCurrent = depthFromClip(currentClip);
+    float depthHistory = depthFromClip(historyClip);
+    float depthDiff = fabs(depthCurrent - depthHistory);
+
+    float3 currentNormalUnit = normalize(currentNormal);
+    float3 historyNormalUnit = normalize(historyNormalValue);
+    float normalDot = dot(currentNormalUnit, historyNormalUnit);
+
+    float albedoDiff = length(currentAlbedo - historyAlbedoValue);
+
+    bool valid = depthDiff <= depthThreshold &&
+                 normalDot >= normalThreshold &&
+                 albedoDiff <= albedoThreshold &&
+                 motion < 0.95f;
+
+    if (valid) {
+        uint prevIndex = prevPixel.y * width + prevPixel.x;
+        RestirReservoir history = historyReservoir[prevIndex];
+        uint seed = hashUint(index ^
+                             uint(fabs(uniforms.randomSeed.x) * 4096.0f));
+        float xi = hashToFloat(seed);
+        mergeReservoir(current, history, xi);
+    }
+
+    currentReservoir[index] = current;
+}

--- a/Nomad Path Tracer/Renderer/Shaders/Structs.h
+++ b/Nomad Path Tracer/Renderer/Shaders/Structs.h
@@ -81,6 +81,7 @@ struct UniformsData
     float environmentPadding0;
     float environmentPadding1;
     float cameraMotionMetric;
+    simd::float4x4 viewProjection;
     simd::float4x4 prevViewProjection;
 };
 


### PR DESCRIPTION
### Motivation
- Add a temporal ReSTIR pass to reuse/resample light candidate reservoirs from the previous frame to improve sampling stability and efficiency via reprojection and reservoir merging.
- Track and double-buffer reservoirs and G-buffer history to enable reprojection-based validation and merging while supporting camera-motion-aware invalidation.
- Expose current view-projection in shader uniforms so the temporal pass can reproject world positions between frames for validation.

### Description
- New compute shader `Renderer/Shaders/RestirTemporal.metal` that reprojections using `UniformsData.prevViewProjection` and `UniformsData.viewProjection`, validates reprojected samples with depth/normal/albedo thresholds and `cameraMotionMetric`, and merges history reservoirs into the current reservoir using reservoir-merge logic.
- Extended `Structs.h` / `Renderer::UniformsData` to include `viewProjection` (in addition to `prevViewProjection`) and preserved `cameraMotionMetric` for motion-aware validation.
- Renderer changes: added `_pRestirTemporalPSO` compute pipeline, compiled from `restirTemporalMain` in `buildShaders()`, and new shader file is added to the project.
- Double-buffered reservoir support: added `_pReservoirHistoryBuffer`, `_reservoirHistoryBufferCapacity`, `_restirHistoryValid` flag, and allocation in `buildTextures()` (same stride and size as `_pReservoirBuffer`).
- History G-buffer management: added managed texture slots `_albedoHistorySlot`, `_normalHistorySlot`, `_positionHistorySlot`, configured and tracked alongside current G-buffers, integrated into residency, allocation, release, and eviction logic.
- Temporal dispatch integrated into `Renderer::draw` after the path trace dispatch: it conditionally dispatches the `restirTemporalMain` compute pass when history is available, sets buffers/textures (history + current), and dispatches full-screen threadgroups.
- Swap/reset flow: after present the code swaps current/history texture slots and reservoir buffers and sets `_restirHistoryValid` once both history and current resources are available; camera changes reset `_restirHistoryValid` so history is cleared on large camera motion.
- Misc: added small utility includes/guards and updated resource cleanup to release the new buffers/textures.

### Testing
- No automated tests were run for this change (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69776561eac0832da06efe6d7a828d1e)