### PR TITLE
Add ReSTIR spatial resampling pass

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -737,6 +737,8 @@ struct UniformsData {
   float lightTotalWeight;
   uint32_t minSamplesPerPixel = 1;
   uint32_t maxSamplesPerPixel = 1;
+  uint32_t restirSpatialRadius = 2;
+  uint32_t restirSpatialNeighborCount = 8;
   uint32_t textureCount = 0;
   uint32_t environmentMapEnabled = 0;
   float environmentMapIntensity = 1.0f;
@@ -1626,6 +1628,8 @@ Renderer::~Renderer() {
     _pAdaptiveSamplingPSO->release();
   if (_pRestirTemporalPSO)
     _pRestirTemporalPSO->release();
+  if (_pRestirSpatialPSO)
+    _pRestirSpatialPSO->release();
   if (_pOverlayPSO)
     _pOverlayPSO->release();
 
@@ -2516,6 +2520,10 @@ void Renderer::buildShaders() {
     _pRestirTemporalPSO->release();
     _pRestirTemporalPSO = nullptr;
   }
+  if (_pRestirSpatialPSO) {
+    _pRestirSpatialPSO->release();
+    _pRestirSpatialPSO = nullptr;
+  }
 
   NS::Error *pError = nullptr;
   MTL::Library *pLibrary = _pDevice->newDefaultLibrary();
@@ -2636,6 +2644,18 @@ void Renderer::buildShaders() {
       __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
     }
     pRestirTemporalFn->release();
+  }
+
+  pError = nullptr;
+  MTL::Function *pRestirSpatialFn = pLibrary->newFunction(
+      NS::String::string("restirSpatialMain", UTF8StringEncoding));
+  if (pRestirSpatialFn) {
+    _pRestirSpatialPSO =
+        _pDevice->newComputePipelineState(pRestirSpatialFn, &pError);
+    if (!_pRestirSpatialPSO && pError) {
+      __builtin_printf("%s\n", pError->localizedDescription()->utf8String());
+    }
+    pRestirSpatialFn->release();
   }
 
   pVertexFn->release();
@@ -7002,6 +7022,8 @@ void Renderer::updateUniforms(bool cameraChanged) {
 
   u.minSamplesPerPixel = minSamples;
   u.maxSamplesPerPixel = maxSamples;
+  u.restirSpatialRadius = _restirSpatialRadius;
+  u.restirSpatialNeighborCount = _restirSpatialNeighborCount;
   size_t boundTextureCount = std::min(
       _materialTextures.size(), static_cast<size_t>(kMaxMaterialTextureSlots));
   u.textureCount = static_cast<uint32_t>(boundTextureCount);
@@ -7560,6 +7582,48 @@ void Renderer::draw(MTK::View *pView) {
       } else {
         trackFrameCommandBuffer(temporalCmd);
         temporalCmd->commit();
+      }
+    }
+  }
+
+  if (_pRestirSpatialPSO && _pReservoirBuffer && positionTexture &&
+      normalTexture && albedoTexture) {
+    MTL::CommandBuffer *spatialCmd = _pCommandQueue->commandBuffer();
+    if (spatialCmd) {
+      MTL::ComputeCommandEncoder *spatialCompute =
+          spatialCmd->computeCommandEncoder();
+      if (spatialCompute) {
+        spatialCompute->setComputePipelineState(_pRestirSpatialPSO);
+        spatialCompute->setBuffer(_pReservoirBuffer, 0, 0);
+        spatialCompute->setBuffer(_pUniformsBuffer, 0, 1);
+        spatialCompute->setTexture(positionTexture, 0);
+        spatialCompute->setTexture(normalTexture, 1);
+        spatialCompute->setTexture(albedoTexture, 2);
+
+        NS::UInteger width = positionTexture->width();
+        NS::UInteger height = positionTexture->height();
+        NS::UInteger tgWidth =
+            std::max<NS::UInteger>(1,
+                                   _pRestirSpatialPSO->threadExecutionWidth());
+        NS::UInteger maxThreads = std::max<NS::UInteger>(
+            tgWidth, _pRestirSpatialPSO->maxTotalThreadsPerThreadgroup());
+        NS::UInteger tgHeight = std::max<NS::UInteger>(1, maxThreads / tgWidth);
+        MTL::Size threadsPerThreadgroup =
+            MTL::Size::Make(tgWidth, tgHeight, 1);
+        MTL::Size threadgroups = MTL::Size::Make(
+            (width + threadsPerThreadgroup.width - 1) /
+                threadsPerThreadgroup.width,
+            (height + threadsPerThreadgroup.height - 1) /
+                threadsPerThreadgroup.height,
+            1);
+        spatialCompute->dispatchThreadgroups(threadgroups,
+                                             threadsPerThreadgroup);
+        spatialCompute->endEncoding();
+        trackFrameCommandBuffer(spatialCmd);
+        spatialCmd->commit();
+      } else {
+        trackFrameCommandBuffer(spatialCmd);
+        spatialCmd->commit();
       }
     }
   }

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -309,6 +309,7 @@ private:
   MTL::ComputePipelineState *_pPathTracePSO = nullptr;
   MTL::ComputePipelineState *_pAdaptiveSamplingPSO = nullptr;
   MTL::ComputePipelineState *_pRestirTemporalPSO = nullptr;
+  MTL::ComputePipelineState *_pRestirSpatialPSO = nullptr;
 
   // Core scene and geometry data
   Scene *_pScene = nullptr;
@@ -748,6 +749,8 @@ private:
 
   uint32_t _minSamplesPerPixel = 1;
   uint32_t _maxSamplesPerPixel = 4;
+  uint32_t _restirSpatialRadius = 2;
+  uint32_t _restirSpatialNeighborCount = 8;
   MTL::Buffer *_pTextureClearBuffer = nullptr;
   size_t _textureClearBufferCapacity = 0;
 

--- a/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
@@ -1,0 +1,133 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+#include "Structs.h"
+
+inline uint hashUint(uint x) {
+    x ^= x >> 16;
+    x *= 0x7feb352d;
+    x ^= x >> 15;
+    x *= 0x846ca68b;
+    x ^= x >> 16;
+    return x;
+}
+
+inline float hashToFloat(uint x) {
+    return float(hashUint(x) & 0x00ffffffu) / float(0x01000000u);
+}
+
+inline bool isFinite3(float3 v) {
+    return all(isfinite(v));
+}
+
+inline void mergeReservoir(thread RestirReservoir &current,
+                           thread const RestirReservoir &neighbor,
+                           float neighborWeight,
+                           float xi) {
+    if (neighbor.m == 0u || neighborWeight <= 0.0f || !isfinite(neighborWeight)) {
+        return;
+    }
+    float currentWeight = max(current.wSum, 0.0f);
+    float totalWeight = currentWeight + neighborWeight;
+    if (totalWeight <= 0.0f || !isfinite(totalWeight)) {
+        return;
+    }
+    float neighborProb = neighborWeight / totalWeight;
+    if (xi < neighborProb) {
+        current.sampleRadiance = neighbor.sampleRadiance;
+        current.wi = neighbor.wi;
+        current.pdf = neighbor.pdf;
+        current.packedLightId = neighbor.packedLightId;
+    }
+    current.wSum = totalWeight;
+    current.m += neighbor.m;
+}
+
+kernel void restirSpatialMain(
+    device RestirReservoir *reservoirBuffer [[buffer(0)]],
+    constant UniformsData &uniforms [[buffer(1)]],
+    texture2d<float, access::read> positionAccum [[texture(0)]],
+    texture2d<float, access::read> normalAccum [[texture(1)]],
+    texture2d<float, access::read> albedoAccum [[texture(2)]],
+    uint2 gid [[thread_position_in_grid]]) {
+    uint width = positionAccum.get_width();
+    uint height = positionAccum.get_height();
+    if (gid.x >= width || gid.y >= height) {
+        return;
+    }
+
+    uint index = gid.y * width + gid.x;
+    RestirReservoir current = reservoirBuffer[index];
+
+    float3 currentPosition = positionAccum.read(gid).xyz;
+    float3 currentNormal = normalAccum.read(gid).xyz;
+    float3 currentAlbedo = albedoAccum.read(gid).xyz;
+
+    if (!isFinite3(currentPosition) || !isFinite3(currentNormal) ||
+        !isFinite3(currentAlbedo)) {
+        reservoirBuffer[index] = current;
+        return;
+    }
+
+    uint radius = uniforms.restirSpatialRadius;
+    uint neighborCount = uniforms.restirSpatialNeighborCount;
+    if (radius == 0u || neighborCount == 0u) {
+        reservoirBuffer[index] = current;
+        return;
+    }
+
+    float3 currentNormalUnit = normalize(currentNormal);
+    uint seed = hashUint(index ^ uint(fabs(uniforms.randomSeed.y) * 4096.0f));
+
+    for (uint i = 0u; i < neighborCount; ++i) {
+        seed = hashUint(seed + 0x9e3779b9u + i);
+        uint span = radius * 2u + 1u;
+        int offsetX = int(seed % span) - int(radius);
+        seed = hashUint(seed + 0x85ebca6bu);
+        int offsetY = int(seed % span) - int(radius);
+        if (offsetX == 0 && offsetY == 0) {
+            continue;
+        }
+
+        int sampleX = int(gid.x) + offsetX;
+        int sampleY = int(gid.y) + offsetY;
+        if (sampleX < 0 || sampleY < 0 || sampleX >= int(width) ||
+            sampleY >= int(height)) {
+            continue;
+        }
+
+        uint2 neighborPixel = uint2(sampleX, sampleY);
+        uint neighborIndex = neighborPixel.y * width + neighborPixel.x;
+        RestirReservoir neighbor = reservoirBuffer[neighborIndex];
+        if (neighbor.m == 0u || neighbor.wSum <= 0.0f || !isfinite(neighbor.wSum)) {
+            continue;
+        }
+
+        float3 neighborPosition = positionAccum.read(neighborPixel).xyz;
+        float3 neighborNormal = normalAccum.read(neighborPixel).xyz;
+        float3 neighborAlbedo = albedoAccum.read(neighborPixel).xyz;
+
+        if (!isFinite3(neighborPosition) || !isFinite3(neighborNormal) ||
+            !isFinite3(neighborAlbedo)) {
+            continue;
+        }
+
+        float normalWeight = max(dot(currentNormalUnit, normalize(neighborNormal)), 0.0f);
+        float positionDelta = length(currentPosition - neighborPosition);
+        float positionWeight = 1.0f / (1.0f + positionDelta);
+        float albedoDiff = length(currentAlbedo - neighborAlbedo);
+        float albedoWeight = 1.0f / (1.0f + albedoDiff * 4.0f);
+        float similarity = normalWeight * positionWeight * albedoWeight;
+
+        if (similarity <= 0.0f || !isfinite(similarity)) {
+            continue;
+        }
+
+        float neighborWeight = max(neighbor.wSum, 0.0f) * similarity;
+        float xi = hashToFloat(seed);
+        mergeReservoir(current, neighbor, neighborWeight, xi);
+    }
+
+    reservoirBuffer[index] = current;
+}

--- a/Nomad Path Tracer/Renderer/Shaders/Structs.h
+++ b/Nomad Path Tracer/Renderer/Shaders/Structs.h
@@ -75,6 +75,8 @@ struct UniformsData
     float lightTotalWeight;
     uint minSamplesPerPixel;
     uint maxSamplesPerPixel;
+    uint restirSpatialRadius;
+    uint restirSpatialNeighborCount;
     uint textureCount;
     uint environmentMapEnabled;
     float environmentMapIntensity;


### PR DESCRIPTION
### Motivation
- Improve spatial reuse of ReSTIR reservoirs by resampling neighboring pixels using appearance similarity to increase sample quality and reduce variance.

### Description
- Add a new compute shader `Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal` that reads the current-frame reservoir plus `position/normal/albedo`, samples a tunable number of neighbors within a tunable radius, computes similarity weights from normal dot, position delta and albedo difference, and updates the reservoir via probabilistic merge logic.
- Expose two new uniform fields `restirSpatialRadius` and `restirSpatialNeighborCount` in `Structs.h` (`UniformsData`) and add corresponding renderer state defaults `_restirSpatialRadius` and `_restirSpatialNeighborCount` in `Renderer.h` and `Renderer.cpp`.
- Wire the uniforms into `updateUniforms` so they are passed to the shader, create/release a new compute pipeline `_pRestirSpatialPSO` in `buildShaders`/destructor, and dispatch the spatial pass after the temporal pass and before final shading in `Renderer::draw` with the reservoir buffer and position/normal/albedo textures bound.
- Files changed: `Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal`, `Nomad Path Tracer/Renderer/Shaders/Structs.h`, `Nomad Path Tracer/Renderer/Renderer.h`, and `Nomad Path Tracer/Renderer/Renderer.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697767f59580832db930258c28a03c0c)