### PR TITLE
Add ReSTIR scene settings and shader controls

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -739,6 +739,13 @@ struct UniformsData {
   uint32_t maxSamplesPerPixel = 1;
   uint32_t restirSpatialRadius = 2;
   uint32_t restirSpatialNeighborCount = 8;
+  uint32_t restirCandidateCount = 1;
+  uint32_t restirMaxTemporalM = 32;
+  uint32_t restirEnableTemporal = 1;
+  uint32_t restirEnableSpatial = 1;
+  simd::float4 restirNormalDepthThresholds =
+      simd::make_float4(0.8f, 0.95f, 0.02f, 0.005f);
+  uint32_t restirDebugMode = 0;
   uint32_t textureCount = 0;
   uint32_t environmentMapEnabled = 0;
   float environmentMapIntensity = 1.0f;
@@ -2829,6 +2836,10 @@ void Renderer::updateVisibleScene() {
          _totalGpuMemoryCapMB);
   _residentCompacted = _pScene->getStartCompacted();
   _compactionCooldown = 0;
+
+  _restirSettings = _pScene->getReSTIRSettings();
+  _restirSpatialRadius = _restirSettings.spatialRadius;
+  _restirHistoryValid = false;
 
   printf("LOD activation threshold: %.1f, deactivation threshold: %.1f (cooldown "
          "%u frames, toggle budget %zu)\n",
@@ -7042,6 +7053,12 @@ void Renderer::updateUniforms(bool cameraChanged) {
   u.maxSamplesPerPixel = maxSamples;
   u.restirSpatialRadius = _restirSpatialRadius;
   u.restirSpatialNeighborCount = _restirSpatialNeighborCount;
+  u.restirCandidateCount = std::max<uint32_t>(_restirSettings.candidateCount, 1);
+  u.restirMaxTemporalM = std::max<uint32_t>(_restirSettings.maxTemporalM, 1);
+  u.restirEnableTemporal = _restirSettings.enableTemporal ? 1u : 0u;
+  u.restirEnableSpatial = _restirSettings.enableSpatial ? 1u : 0u;
+  u.restirNormalDepthThresholds = _restirSettings.normalDepthThresholds;
+  u.restirDebugMode = _restirSettings.debugMode;
   size_t boundTextureCount = std::min(
       _materialTextures.size(), static_cast<size_t>(kMaxMaterialTextureSlots));
   u.textureCount = static_cast<uint32_t>(boundTextureCount);
@@ -7217,6 +7234,10 @@ void Renderer::draw(MTK::View *pView) {
     updateGeometryResidency(prepCmd);
 
   bool allowResidency = !belowBudget && !overCap && !totalOverCap;
+
+  if (!_restirSettings.enableTemporal) {
+    _restirHistoryValid = false;
+  }
 
   MTL::BlitCommandEncoder *restoreBlit = nullptr;
   MTL::Texture *colorTexture = _colorSlot.texture;
@@ -7563,7 +7584,8 @@ void Renderer::draw(MTK::View *pView) {
     _restirHistoryValid = false;
   }
 
-  if (_pRestirTemporalPSO && _restirHistoryValid && _pRestirReservoirBuffer &&
+  if (_pRestirTemporalPSO && _restirSettings.enableTemporal &&
+      _restirHistoryValid && _pRestirReservoirBuffer &&
       _pRestirReservoirHistoryBuffer && positionTexture && normalTexture &&
       albedoTexture && positionHistoryTexture && normalHistoryTexture &&
       albedoHistoryTexture) {
@@ -7610,7 +7632,8 @@ void Renderer::draw(MTK::View *pView) {
     }
   }
 
-  if (_pRestirSpatialPSO && _pRestirReservoirBuffer && positionTexture &&
+  if (_pRestirSpatialPSO && _restirSettings.enableSpatial &&
+      _pRestirReservoirBuffer && positionTexture &&
       normalTexture && albedoTexture) {
     MTL::CommandBuffer *spatialCmd = _pCommandQueue->commandBuffer();
     if (spatialCmd) {
@@ -7660,6 +7683,7 @@ void Renderer::draw(MTK::View *pView) {
       if (shadeCompute) {
         shadeCompute->setComputePipelineState(_pRestirShadePSO);
         shadeCompute->setBuffer(_pRestirReservoirBuffer, 0, 0);
+        shadeCompute->setBuffer(_pUniformsBuffer, 0, 1);
         shadeCompute->setTexture(colorTexture, 0);
 
         NS::UInteger width = colorTexture->width();
@@ -7817,17 +7841,22 @@ void Renderer::draw(MTK::View *pView) {
   ++_renderedFrameCount;
   pPool->release();
 
-  if (_positionSlot.texture && _positionHistorySlot.texture) {
-    std::swap(_positionSlot, _positionHistorySlot);
-    std::swap(_normalSlot, _normalHistorySlot);
-    std::swap(_albedoSlot, _albedoHistorySlot);
-  }
-  if (_pRestirReservoirBuffer && _pRestirReservoirHistoryBuffer) {
-    std::swap(_pRestirReservoirBuffer, _pRestirReservoirHistoryBuffer);
-  }
-  if (!_restirHistoryValid && _pRestirReservoirBuffer && _pRestirReservoirHistoryBuffer &&
-      _positionSlot.texture && _positionHistorySlot.texture) {
-    _restirHistoryValid = true;
+  if (_restirSettings.enableTemporal) {
+    if (_positionSlot.texture && _positionHistorySlot.texture) {
+      std::swap(_positionSlot, _positionHistorySlot);
+      std::swap(_normalSlot, _normalHistorySlot);
+      std::swap(_albedoSlot, _albedoHistorySlot);
+    }
+    if (_pRestirReservoirBuffer && _pRestirReservoirHistoryBuffer) {
+      std::swap(_pRestirReservoirBuffer, _pRestirReservoirHistoryBuffer);
+    }
+    if (!_restirHistoryValid && _pRestirReservoirBuffer &&
+        _pRestirReservoirHistoryBuffer && _positionSlot.texture &&
+        _positionHistorySlot.texture) {
+      _restirHistoryValid = true;
+    }
+  } else {
+    _restirHistoryValid = false;
   }
 }
 

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -750,6 +750,7 @@ private:
 
   uint32_t _minSamplesPerPixel = 1;
   uint32_t _maxSamplesPerPixel = 4;
+  ReSTIRSettings _restirSettings{};
   uint32_t _restirSpatialRadius = 2;
   uint32_t _restirSpatialNeighborCount = 8;
   MTL::Buffer *_pTextureClearBuffer = nullptr;

--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -63,6 +63,7 @@ kernel void pathTraceKernel(
   float3 accumulatedPosition = float3(0.0);
   float accumulatedRoughness = 0.0f;
   RestirReservoir reservoir = initReservoir();
+  uint restirCandidateCount = max(u.restirCandidateCount, 1u);
 
   float3 rayDx = u.rayDx;
   float3 rayDy = u.rayDy;
@@ -214,20 +215,23 @@ kernel void pathTraceKernel(
         float3 diffuseColor = material.diffuseColor * material.opacity;
         if (luminance(diffuseColor) > 0.0f && u.lightCount > 0 &&
             u.lightTotalWeight > 0.0f) {
-          LightSampleCandidate candidate;
-          if (sampleDirectLightCandidate(
-                  bestHit.point, shadingNormal, diffuseColor,
-                  bestHit.primitiveId, tlasNodes, u.tlasNodeCount, bvhNodes,
-                  primitives, materials, u.primitiveCount, primitiveIndices,
-                  activeMask, instanceRecords, lightIndices, lightCdf,
-                  primitiveRemap, primitiveRayStats, bounceCache, seed,
-                  u.lightCount, u.lightTotalWeight,
-                  static_cast<uint>(u.totalPrimitiveCount), candidate)) {
-            float weight = luminance(candidate.radiance) /
-                           max(candidate.pdf, RAY_EPS);
-            float xi = randomFloat(seed);
-            seed = random(seed);
-            updateReservoir(reservoir, candidate, weight, xi);
+          for (uint candidateIdx = 0u; candidateIdx < restirCandidateCount;
+               ++candidateIdx) {
+            LightSampleCandidate candidate;
+            if (sampleDirectLightCandidate(
+                    bestHit.point, shadingNormal, diffuseColor,
+                    bestHit.primitiveId, tlasNodes, u.tlasNodeCount, bvhNodes,
+                    primitives, materials, u.primitiveCount, primitiveIndices,
+                    activeMask, instanceRecords, lightIndices, lightCdf,
+                    primitiveRemap, primitiveRayStats, bounceCache, seed,
+                    u.lightCount, u.lightTotalWeight,
+                    static_cast<uint>(u.totalPrimitiveCount), candidate)) {
+              float weight = luminance(candidate.radiance) /
+                             max(candidate.pdf, RAY_EPS);
+              float xi = randomFloat(seed);
+              seed = random(seed);
+              updateReservoir(reservoir, candidate, weight, xi);
+            }
           }
         }
       }

--- a/Nomad Path Tracer/Renderer/Shaders/RestirShade.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirShade.metal
@@ -4,8 +4,18 @@ using namespace metal;
 
 #include "PathTracing.h"
 
+inline uint hashUint(uint x) {
+  x ^= x >> 16;
+  x *= 0x7feb352d;
+  x ^= x >> 15;
+  x *= 0x846ca68b;
+  x ^= x >> 16;
+  return x;
+}
+
 kernel void restirShadeMain(
     device const RestirReservoir *reservoirBuffer [[buffer(0)]],
+    constant UniformsData &uniforms [[buffer(1)]],
     texture2d<float, access::write> currentFrame [[texture(0)]],
     uint2 gid [[thread_position_in_grid]]) {
   if (!reservoirBuffer)
@@ -19,6 +29,18 @@ kernel void restirShadeMain(
   uint index = gid.y * width + gid.x;
   RestirReservoir reservoir = reservoirBuffer[index];
   float3 reservoirEstimate = finalizeReservoir(reservoir);
+  if (uniforms.restirDebugMode == 1u) {
+    float denom = max(float(reservoir.m), 1.0f);
+    float normalized = clamp(reservoir.wSum / denom, 0.0f, 1.0f);
+    reservoirEstimate = float3(normalized);
+  } else if (uniforms.restirDebugMode == 2u) {
+    uint hashed = hashUint(reservoir.packedLightId ^ index);
+    float3 color = float3(float(hashed & 0xffu),
+                          float((hashed >> 8) & 0xffu),
+                          float((hashed >> 16) & 0xffu)) /
+                   255.0f;
+    reservoirEstimate = color;
+  }
   reservoirEstimate = clamp(reservoirEstimate, 0.0f, 1.0f);
   currentFrame.write(float4(reservoirEstimate, 1.0f), gid);
 }

--- a/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
@@ -51,6 +51,10 @@ kernel void restirSpatialMain(
     texture2d<float, access::read> normalAccum [[texture(1)]],
     texture2d<float, access::read> albedoAccum [[texture(2)]],
     uint2 gid [[thread_position_in_grid]]) {
+    if (uniforms.restirEnableSpatial == 0u) {
+        return;
+    }
+
     uint width = positionAccum.get_width();
     uint height = positionAccum.get_height();
     if (gid.x >= width || gid.y >= height) {

--- a/Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal
@@ -62,6 +62,10 @@ kernel void restirTemporalMain(
     texture2d<float, access::read> historyNormal [[texture(4)]],
     texture2d<float, access::read> historyAlbedo [[texture(5)]],
     uint2 gid [[thread_position_in_grid]]) {
+    if (uniforms.restirEnableTemporal == 0u) {
+        return;
+    }
+
     uint width = positionAccum.get_width();
     uint height = positionAccum.get_height();
     if (gid.x >= width || gid.y >= height) {
@@ -118,8 +122,12 @@ kernel void restirTemporalMain(
     }
 
     float motion = clamp(uniforms.cameraMotionMetric, 0.0f, 1.0f);
-    float depthThreshold = mix(0.02f, 0.005f, motion);
-    float normalThreshold = mix(0.8f, 0.95f, motion);
+    float normalLow = uniforms.restirNormalDepthThresholds.x;
+    float normalHigh = uniforms.restirNormalDepthThresholds.y;
+    float depthLow = uniforms.restirNormalDepthThresholds.z;
+    float depthHigh = uniforms.restirNormalDepthThresholds.w;
+    float depthThreshold = mix(depthLow, depthHigh, motion);
+    float normalThreshold = mix(normalLow, normalHigh, motion);
     float albedoThreshold = mix(0.25f, 0.1f, motion);
 
     float4 historyClip =
@@ -151,6 +159,9 @@ kernel void restirTemporalMain(
                              uint(fabs(uniforms.randomSeed.x) * 4096.0f));
         float xi = hashToFloat(seed);
         mergeReservoir(current, history, xi);
+        if (uniforms.restirMaxTemporalM > 0u) {
+            current.m = min(current.m, uniforms.restirMaxTemporalM);
+        }
     }
 
     currentReservoir[index] = current;

--- a/Nomad Path Tracer/Renderer/Shaders/Structs.h
+++ b/Nomad Path Tracer/Renderer/Shaders/Structs.h
@@ -77,6 +77,12 @@ struct UniformsData
     uint maxSamplesPerPixel;
     uint restirSpatialRadius;
     uint restirSpatialNeighborCount;
+    uint restirCandidateCount;
+    uint restirMaxTemporalM;
+    uint restirEnableTemporal;
+    uint restirEnableSpatial;
+    float4 restirNormalDepthThresholds;
+    uint restirDebugMode;
     uint textureCount;
     uint environmentMapEnabled;
     float environmentMapIntensity;

--- a/Nomad Path Tracer/Scene/Scene.cpp
+++ b/Nomad Path Tracer/Scene/Scene.cpp
@@ -86,6 +86,7 @@ void Scene::clear() {
   maxRayDepth = 32;
   residencyStrategy = ResidencyStrategy::DistanceLOD;
   residencyParams = ResidencyParameters{};
+  restirSettings = ReSTIRSettings{};
   startCompacted = false;
   textureResidencyMemoryCapMB = 2048.0;
   geometryResidencyMemoryCapMB = 2048.0;
@@ -257,6 +258,14 @@ const ResidencyParameters &Scene::getResidencyParameters() const {
 void Scene::setResidencyParameters(const ResidencyParameters &params) {
   residencyParams = params;
   residencyParams.normalizeEnvironmentDepthSettings();
+}
+
+const ReSTIRSettings &Scene::getReSTIRSettings() const {
+  return restirSettings;
+}
+
+void Scene::setReSTIRSettings(const ReSTIRSettings &settings) {
+  restirSettings = settings;
 }
 
 size_t Scene::getMaxTileSampleWorkPerCommand() const {

--- a/Nomad Path Tracer/Scene/Scene.h
+++ b/Nomad Path Tracer/Scene/Scene.h
@@ -124,6 +124,18 @@ struct ResidencyParameters {
   void normalizeEnvironmentDepthSettings();
 };
 
+struct ReSTIRSettings {
+  bool enableTemporal = true;
+  bool enableSpatial = true;
+  uint32_t candidateCount = 1;
+  uint32_t spatialRadius = 2;
+  uint32_t maxTemporalM = 32;
+  // (normalLow, normalHigh, depthLow, depthHigh)
+  simd::float4 normalDepthThresholds =
+      simd::make_float4(0.8f, 0.95f, 0.02f, 0.005f);
+  uint32_t debugMode = 0;
+};
+
 struct TLASNode {
   simd::float3 boundsMin = simd::make_float3(0.0f, 0.0f, 0.0f);
   simd::float3 boundsMax = simd::make_float3(0.0f, 0.0f, 0.0f);
@@ -204,6 +216,9 @@ public:
   const ResidencyParameters &getResidencyParameters() const;
   void setResidencyParameters(const ResidencyParameters &params);
 
+  const ReSTIRSettings &getReSTIRSettings() const;
+  void setReSTIRSettings(const ReSTIRSettings &settings);
+
   size_t getMaxTileSampleWorkPerCommand() const;
   bool hasCustomMaxTileSampleWorkPerCommand() const;
   void setMaxTileSampleWorkPerCommand(size_t work);
@@ -277,6 +292,7 @@ private:
   EnvironmentSettings environment;
   ResidencyStrategy residencyStrategy;
   ResidencyParameters residencyParams;
+  ReSTIRSettings restirSettings;
   bool startCompacted;
   double textureResidencyMemoryCapMB;
   double geometryResidencyMemoryCapMB;

--- a/Nomad Path Tracer/Scene/SceneLoader.cpp
+++ b/Nomad Path Tracer/Scene/SceneLoader.cpp
@@ -60,6 +60,21 @@ static std::vector<float> parseFloatList(const char *attr) {
     return values;
 }
 
+static simd::float4 parseRestirThresholds(const char *attr,
+                                          const simd::float4 &defaults) {
+    if (!attr) {
+        return defaults;
+    }
+    std::vector<float> values = parseFloatList(attr);
+    if (values.size() >= 4) {
+        return simd::make_float4(values[0], values[1], values[2], values[3]);
+    }
+    if (values.size() == 2) {
+        return simd::make_float4(values[0], defaults.y, values[1], defaults.w);
+    }
+    return defaults;
+}
+
 // Rotates a vector by Euler angles applied in X->Y->Z order.
 static simd::float3 rotateVectorEulerXYZ(const simd::float3& v,
                                          const simd::float3& radians) {
@@ -866,6 +881,27 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         "buildCachedBlas", params.buildCachedBlas);
 
     scene->setResidencyParameters(params);
+
+    ReSTIRSettings restirSettings = scene->getReSTIRSettings();
+    restirSettings.enableTemporal =
+        root->BoolAttribute("restirEnableTemporal", restirSettings.enableTemporal);
+    restirSettings.enableSpatial =
+        root->BoolAttribute("restirEnableSpatial", restirSettings.enableSpatial);
+    restirSettings.candidateCount = root->UnsignedAttribute(
+        "restirCandidateCount", restirSettings.candidateCount);
+    restirSettings.spatialRadius = root->UnsignedAttribute(
+        "restirSpatialRadius", restirSettings.spatialRadius);
+    restirSettings.maxTemporalM = root->UnsignedAttribute(
+        "restirMaxTemporalM", restirSettings.maxTemporalM);
+    if (const char *thresholdsAttr =
+            root->Attribute("restirNormalDepthThresholds")) {
+        restirSettings.normalDepthThresholds =
+            parseRestirThresholds(thresholdsAttr,
+                                  restirSettings.normalDepthThresholds);
+    }
+    restirSettings.debugMode =
+        root->UnsignedAttribute("restirDebugMode", restirSettings.debugMode);
+    scene->setReSTIRSettings(restirSettings);
 
     bool startCompacted = root->BoolAttribute("startCompacted", scene->getStartCompacted());
     scene->setStartCompacted(startCompacted);


### PR DESCRIPTION
### Motivation
- Expose ReSTIR configuration from scene XML so temporal/spatial resampling can be tuned per-scene. 
- Propagate those controls into the renderer and GPU shaders to allow runtime gating, parameterization, and simple debugging visualizations.

### Description
- Add `ReSTIRSettings` to `Scene` (defaults for `enableTemporal`, `enableSpatial`, `candidateCount`, `spatialRadius`, `maxTemporalM`, `normalDepthThresholds`, `debugMode`) and provide `getReSTIRSettings`/`setReSTIRSettings` accessors in `Scene.h` and `Scene.cpp`.
- Parse new XML attributes in `SceneLoader.cpp` (e.g. `restirEnableTemporal`, `restirEnableSpatial`, `restirCandidateCount`, `restirSpatialRadius`, `restirMaxTemporalM`, `restirNormalDepthThresholds`, `restirDebugMode`) using a new helper `parseRestirThresholds` and apply them to the `Scene`.
- Store `ReSTIRSettings` in `Renderer` (`_restirSettings`) and initialize it when loading a scene, then forward values into the uniform block (`UniformsData`) for shaders.
- Gate temporal and spatial passes in `Renderer::draw` by `enableTemporal`/`enableSpatial`, prevent using history when temporal is disabled, and swap/clear history buffers conditionally.
- Extend shader interfaces and implementations: add fields to `Renderer/Shaders/Structs.h` and update `PathTraceKernel.metal` to sample multiple ReSTIR candidates (`candidateCount`), add temporal thresholds/clamping in `RestirTemporal.metal` (`restirNormalDepthThresholds`, `restirMaxTemporalM`), early-return gating in `RestirTemporal.metal`/`RestirSpatial.metal` based on enable flags, and add debug visualizations in `RestirShade.metal` (reservoir weight or hashed light id color). 

### Testing
- No automated tests were executed for this change; no test run was requested or performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69776b798948832da7c8323076f8a8a5)