### PR TITLE
Use position texture dimensions for temporal ReSTIR threadgroup sizing

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -7614,6 +7614,8 @@ void Renderer::draw(MTK::View *pView) {
         MTL::Size threadsPerThreadgroup =
             MTL::Size::Make(tgWidth, tgHeight, 1);
 
+        NS::UInteger width = positionTexture->width();
+        NS::UInteger height = positionTexture->height();
         MTL::Size threadgroups = MTL::Size::Make(
             (width + threadsPerThreadgroup.width - 1) /
                 threadsPerThreadgroup.width,


### PR DESCRIPTION
### Motivation
- Ensure `width`/`height` used to compute temporal ReSTIR dispatch are taken from a valid texture in scope so threadgroup sizing matches the actual texture dimensions.

### Description
- Add local `NS::UInteger width = positionTexture->width();` and `NS::UInteger height = positionTexture->height();` inside the `_pRestirTemporalPSO` block and use these locals in the `MTL::Size::Make(...)` call when computing `threadgroups`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69776e5c4768832db2ebd0f06518dbdf)