### PR TITLE
Gate ReSTIR shade on valid reservoirs

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -7677,7 +7677,10 @@ void Renderer::draw(MTK::View *pView) {
     }
   }
 
-  if (_pRestirShadePSO && _pRestirReservoirBuffer && colorTexture) {
+  const bool restirShadeValid =
+      _pRestirReservoirBuffer &&
+      (_restirSettings.enableTemporal || _restirSettings.enableSpatial);
+  if (_pRestirShadePSO && colorTexture && restirShadeValid) {
     MTL::CommandBuffer *shadeCmd = _pCommandQueue->commandBuffer();
     if (shadeCmd) {
       MTL::ComputeCommandEncoder *shadeCompute =


### PR DESCRIPTION
### Motivation
- Avoid running the ReSTIR shade compute pass when reservoirs are not expected to be valid, preserving the base path-traced color and saving unnecessary GPU work.

### Description
- In `Nomad Path Tracer/Renderer/Renderer.cpp` add a `restirShadeValid` condition that requires `_pRestirReservoirBuffer` and either `enableTemporal` or `enableSpatial` to be true, and use it to gate the `_pRestirShadePSO` dispatch.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69776fe0cd44832db8371ae4a2f053ad)