### PR TITLE
Add scene toggle for ReSTIR settings

### DIFF
--- a/Nomad Path Tracer/README.md
+++ b/Nomad Path Tracer/README.md
@@ -12,6 +12,13 @@ Long-running path tracing commands can trigger GPU timeout errors when the pixel
 
 The renderer clamps the budget so each command can still process at least one full tile, based on the current tile dimensions and sample count.
 
+## ReSTIR toggle
+
+Scenes can disable ReSTIR sampling entirely by setting the `restirEnabled` flag on the `<Scene>` root:
+
+- **Scene XML:** add `restirEnabled="false"` to disable ReSTIR (temporal + spatial passes).
+- **Default:** when unset, ReSTIR remains enabled (equivalent to `restirEnabled="true"`).
+
 ## Geometry residency memory cap
 
 The `geometryResidencyMemoryCapMB` scene parameter remains a hard ceiling. Geometry residency allocations (including streaming uploads, prewarm passes, and rebuilds) are rejected if the next allocation would exceed the cap; the renderer queues the request and triggers eviction until enough space is available to retry.

--- a/Nomad Path Tracer/Scene/Scene.cpp
+++ b/Nomad Path Tracer/Scene/Scene.cpp
@@ -266,6 +266,10 @@ const ReSTIRSettings &Scene::getReSTIRSettings() const {
 
 void Scene::setReSTIRSettings(const ReSTIRSettings &settings) {
   restirSettings = settings;
+  if (!restirSettings.enabled) {
+    restirSettings.enableTemporal = false;
+    restirSettings.enableSpatial = false;
+  }
 }
 
 size_t Scene::getMaxTileSampleWorkPerCommand() const {

--- a/Nomad Path Tracer/Scene/Scene.h
+++ b/Nomad Path Tracer/Scene/Scene.h
@@ -125,6 +125,7 @@ struct ResidencyParameters {
 };
 
 struct ReSTIRSettings {
+  bool enabled = true;
   bool enableTemporal = true;
   bool enableSpatial = true;
   uint32_t candidateCount = 1;

--- a/Nomad Path Tracer/Scene/SceneLoader.cpp
+++ b/Nomad Path Tracer/Scene/SceneLoader.cpp
@@ -883,6 +883,8 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
     scene->setResidencyParameters(params);
 
     ReSTIRSettings restirSettings = scene->getReSTIRSettings();
+    restirSettings.enabled =
+        root->BoolAttribute("restirEnabled", restirSettings.enabled);
     restirSettings.enableTemporal =
         root->BoolAttribute("restirEnableTemporal", restirSettings.enableTemporal);
     restirSettings.enableSpatial =


### PR DESCRIPTION
### Motivation

- Provide a per-scene switch to disable ReSTIR sampling (both temporal and spatial) so scenes can opt out without changing individual flags.  
- Preserve existing behavior by default so existing scenes continue to have ReSTIR enabled.  

### Description

- Add a new `enabled` boolean to `ReSTIRSettings` with a default of `true` in `Scene/Scene.h`.  
- Parse the new `restirEnabled` attribute from scene XML in `Scene/SceneLoader.cpp` and populate `ReSTIRSettings.enabled`.  
- Enforce the toggle in `Scene::setReSTIRSettings()` so when `enabled` is `false` both `enableTemporal` and `enableSpatial` are cleared.  
- Document the new `restirEnabled` scene-root attribute and its default in `Nomad Path Tracer/README.md`.  

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697770ef2bb8832d9dfe6dd048a3e193)