### PR TITLE
Respect restirEnabled in path trace output

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -7051,12 +7051,16 @@ void Renderer::updateUniforms(bool cameraChanged) {
 
   u.minSamplesPerPixel = minSamples;
   u.maxSamplesPerPixel = maxSamples;
+  bool restirEnabled = _restirSettings.enabled;
+  u.restirEnabled = restirEnabled ? 1u : 0u;
   u.restirSpatialRadius = _restirSpatialRadius;
   u.restirSpatialNeighborCount = _restirSpatialNeighborCount;
   u.restirCandidateCount = std::max<uint32_t>(_restirSettings.candidateCount, 1);
   u.restirMaxTemporalM = std::max<uint32_t>(_restirSettings.maxTemporalM, 1);
-  u.restirEnableTemporal = _restirSettings.enableTemporal ? 1u : 0u;
-  u.restirEnableSpatial = _restirSettings.enableSpatial ? 1u : 0u;
+  u.restirEnableTemporal =
+      (restirEnabled && _restirSettings.enableTemporal) ? 1u : 0u;
+  u.restirEnableSpatial =
+      (restirEnabled && _restirSettings.enableSpatial) ? 1u : 0u;
   u.restirNormalDepthThresholds = _restirSettings.normalDepthThresholds;
   u.restirDebugMode = _restirSettings.debugMode;
   size_t boundTextureCount = std::min(
@@ -7235,7 +7239,7 @@ void Renderer::draw(MTK::View *pView) {
 
   bool allowResidency = !belowBudget && !overCap && !totalOverCap;
 
-  if (!_restirSettings.enableTemporal) {
+  if (!_restirSettings.enabled || !_restirSettings.enableTemporal) {
     _restirHistoryValid = false;
   }
 
@@ -7584,7 +7588,8 @@ void Renderer::draw(MTK::View *pView) {
     _restirHistoryValid = false;
   }
 
-  if (_pRestirTemporalPSO && _restirSettings.enableTemporal &&
+  if (_pRestirTemporalPSO && _restirSettings.enabled &&
+      _restirSettings.enableTemporal &&
       _restirHistoryValid && _pRestirReservoirBuffer &&
       _pRestirReservoirHistoryBuffer && positionTexture && normalTexture &&
       albedoTexture && positionHistoryTexture && normalHistoryTexture &&
@@ -7634,7 +7639,8 @@ void Renderer::draw(MTK::View *pView) {
     }
   }
 
-  if (_pRestirSpatialPSO && _restirSettings.enableSpatial &&
+  if (_pRestirSpatialPSO && _restirSettings.enabled &&
+      _restirSettings.enableSpatial &&
       _pRestirReservoirBuffer && positionTexture &&
       normalTexture && albedoTexture) {
     MTL::CommandBuffer *spatialCmd = _pCommandQueue->commandBuffer();
@@ -7678,7 +7684,7 @@ void Renderer::draw(MTK::View *pView) {
   }
 
   const bool restirShadeValid =
-      _pRestirReservoirBuffer &&
+      _pRestirReservoirBuffer && _restirSettings.enabled &&
       (_restirSettings.enableTemporal || _restirSettings.enableSpatial);
   if (_pRestirShadePSO && colorTexture && restirShadeValid) {
     MTL::CommandBuffer *shadeCmd = _pCommandQueue->commandBuffer();

--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -58,12 +58,14 @@ kernel void pathTraceKernel(
 
   uint samplesThisFrame = max(u.maxSamplesPerPixel, 1u);
 
+  float3 accumulatedColor = float3(0.0);
   float3 accumulatedAlbedo = float3(0.0);
   float3 accumulatedNormal = float3(0.0);
   float3 accumulatedPosition = float3(0.0);
   float accumulatedRoughness = 0.0f;
   RestirReservoir reservoir = initReservoir();
   uint restirCandidateCount = max(u.restirCandidateCount, 1u);
+  bool useRestir = (u.restirEnabled != 0u);
 
   float3 rayDx = u.rayDx;
   float3 rayDy = u.rayDy;
@@ -103,6 +105,24 @@ kernel void pathTraceKernel(
     r.direction = rayDirection;
     r.minDistance = 0.0001f;
     r.maxDistance = INFINITY;
+
+    if (!useRestir) {
+      PathTraceSample sample = rayColor(
+          r, rayDx, rayDy, tlasNodes, u.tlasNodeCount, bvhNodes, primitives,
+          materials, u.primitiveCount, primitiveIndices, activeMask,
+          instanceRecords, lightIndices, lightCdf, primitiveRemap,
+          primitiveRayStats, seed, u.maxRayDepth, u.debugAS, u.blasNodeCount,
+          u.lightCount, u.lightTotalWeight,
+          static_cast<uint>(u.totalPrimitiveCount), materialTextures,
+          u.textureCount, environmentMap, environmentSampler,
+          u.environmentMapEnabled, u.environmentMapIntensity);
+      accumulatedColor += sample.radiance;
+      accumulatedAlbedo += sample.albedo;
+      accumulatedNormal += sample.normal;
+      accumulatedPosition += sample.position;
+      accumulatedRoughness += sample.roughness;
+      continue;
+    }
 
     TlasLeafCache bounceCache;
     bounceCache.valid = false;
@@ -239,6 +259,9 @@ kernel void pathTraceKernel(
   }
 
   float totalSamples = float(samplesThisFrame);
+  float3 averaged =
+      (totalSamples > 0.0f) ? accumulatedColor / totalSamples : float3(0.0f);
+  averaged = clamp(averaged, 0.0f, 1.0f);
   float3 reservoirEstimate = finalizeReservoir(reservoir);
   reservoirEstimate = clamp(reservoirEstimate, 0.0f, 1.0f);
 
@@ -254,13 +277,14 @@ kernel void pathTraceKernel(
       (totalSamples > 0.0f) ? accumulatedRoughness / totalSamples : 0.0f;
   averagedRoughness = clamp(averagedRoughness, 0.0f, 1.0f);
 
-  float4 result = float4(reservoirEstimate, 1.0f);
+  float3 outputColor = useRestir ? reservoirEstimate : averaged;
+  float4 result = float4(outputColor, 1.0f);
   currentFrame.write(result, pixel);
   albedoAccum.write(float4(averagedAlbedo, 1.0f), pixel);
   normalAccum.write(float4(averagedNormal, averagedRoughness), pixel);
   positionAccum.write(float4(averagedPosition, 1.0f), pixel);
 
-  if (reservoirBuffer) {
+  if (useRestir && reservoirBuffer) {
     uint pixelIndex = pixel.y * width + pixel.x;
     reservoirBuffer[pixelIndex] = reservoir;
   }

--- a/Nomad Path Tracer/Renderer/Shaders/Structs.h
+++ b/Nomad Path Tracer/Renderer/Shaders/Structs.h
@@ -75,6 +75,7 @@ struct UniformsData
     float lightTotalWeight;
     uint minSamplesPerPixel;
     uint maxSamplesPerPixel;
+    uint restirEnabled;
     uint restirSpatialRadius;
     uint restirSpatialNeighborCount;
     uint restirCandidateCount;


### PR DESCRIPTION
### Motivation
- Ensure the ReSTIR pipeline can be fully disabled per-scene and that the path-traced baseline color is preserved when ReSTIR is turned off to avoid black outputs.
- Surface a uniform to shaders so the path tracer and ReSTIR passes share the same scene-level enable flag for consistent behavior.
- Make it easy to bisect whether image darkening originates from ReSTIR by providing a clear fallback to the classic `rayColor` path.

### Description
- Add `restirEnabled` to `UniformsData` and propagate `_restirSettings.enabled` into the GPU uniforms via `updateUniforms`.
- Gate temporal, spatial and shade ReSTIR compute passes on both the per-setting `enableTemporal`/`enableSpatial` and the new global `restirEnabled` flag, and include it when computing `restirShadeValid` in the renderer.
- In `pathTraceKernel.metal` introduce `useRestir = (u.restirEnabled != 0u)`, accumulate classic `PathTraceSample` into `accumulatedColor` when `useRestir` is false, and early-continue so the existing ReSTIR logic is skipped; compute `averaged` from `accumulatedColor` and select final output as either the ReSTIR `reservoirEstimate` or the classic averaged radiance accordingly.
- Only write the reservoir buffer when `useRestir` is true, and keep all existing buffer/texture binding indices and reservoir buffer sizing intact (reservoir bound at `buffer(14)`, material textures at `texture(13..)` and the reservoir stride remains `kRestirReservoirStride = 48`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977731c6720832da5995da0bce749c4)