### PR TITLE
Add ReSTIR enabled flag to UniformsData

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -737,6 +737,7 @@ struct UniformsData {
   float lightTotalWeight;
   uint32_t minSamplesPerPixel = 1;
   uint32_t maxSamplesPerPixel = 1;
+  uint32_t restirEnabled = 1;
   uint32_t restirSpatialRadius = 2;
   uint32_t restirSpatialNeighborCount = 8;
   uint32_t restirCandidateCount = 1;


### PR DESCRIPTION
### Motivation
- Ensure the CPU-side `UniformsData` layout matches the shader `UniformsData` so the `u.restirEnabled` assignment compiles and the layout ordering is preserved.

### Description
- Inserted `uint32_t restirEnabled = 1;` in `Nomad Path Tracer/Renderer/Renderer.cpp` between `maxSamplesPerPixel` and `restirSpatialRadius` to mirror the shader struct and committed the change.

### Testing
- Ran `xcodebuild -project "Nomad Path Tracer.xcodeproj" -scheme "Nomad Path Tracer" build`, which failed because `xcodebuild` is not available in this environment, and inspected the source with `sed`/`nl` to confirm the field was added successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697775bd4a7c832da0232cbf4d18c2ff)