### PR TITLE
Reevaluate ReSTIR reused samples at current surfaces

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -7592,9 +7592,11 @@ void Renderer::draw(MTK::View *pView) {
   if (_pRestirTemporalPSO && _restirSettings.enabled &&
       _restirSettings.enableTemporal &&
       _restirHistoryValid && _pRestirReservoirBuffer &&
-      _pRestirReservoirHistoryBuffer && positionTexture && normalTexture &&
-      albedoTexture && positionHistoryTexture && normalHistoryTexture &&
-      albedoHistoryTexture) {
+      _pRestirReservoirHistoryBuffer && _pBVHBuffer && _pSphereBuffer &&
+      _pSphereMaterialBuffer && _pPrimitiveIndexBuffer && _pTLASBuffer &&
+      _pActiveBuffer && _pPrimitiveRemapBuffer && _pInstanceBuffer &&
+      positionTexture && normalTexture && albedoTexture && positionHistoryTexture &&
+      normalHistoryTexture && albedoHistoryTexture) {
     MTL::CommandBuffer *temporalCmd = _pCommandQueue->commandBuffer();
     if (temporalCmd) {
       MTL::ComputeCommandEncoder *temporalCompute =
@@ -7604,6 +7606,15 @@ void Renderer::draw(MTK::View *pView) {
         temporalCompute->setBuffer(_pRestirReservoirHistoryBuffer, 0, 0);
         temporalCompute->setBuffer(_pRestirReservoirBuffer, 0, 1);
         temporalCompute->setBuffer(_pUniformsBuffer, 0, 2);
+        temporalCompute->setBuffer(_pBVHBuffer, 0, 3);
+        temporalCompute->setBuffer(_pSphereBuffer, 0, 4);
+        temporalCompute->setBuffer(_pSphereMaterialBuffer, 0, 5);
+        temporalCompute->setBuffer(_pPrimitiveIndexBuffer, 0, 6);
+        temporalCompute->setBuffer(_pTLASBuffer, 0, 7);
+        temporalCompute->setBuffer(_pActiveBuffer, 0, 8);
+        temporalCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 9);
+        temporalCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 10);
+        temporalCompute->setBuffer(_pInstanceBuffer, 0, 11);
         temporalCompute->setTexture(positionTexture, 0);
         temporalCompute->setTexture(normalTexture, 1);
         temporalCompute->setTexture(albedoTexture, 2);
@@ -7642,8 +7653,10 @@ void Renderer::draw(MTK::View *pView) {
 
   if (_pRestirSpatialPSO && _restirSettings.enabled &&
       _restirSettings.enableSpatial &&
-      _pRestirReservoirBuffer && positionTexture &&
-      normalTexture && albedoTexture) {
+      _pRestirReservoirBuffer && _pBVHBuffer && _pSphereBuffer &&
+      _pSphereMaterialBuffer && _pPrimitiveIndexBuffer && _pTLASBuffer &&
+      _pActiveBuffer && _pPrimitiveRemapBuffer && _pInstanceBuffer &&
+      positionTexture && normalTexture && albedoTexture) {
     MTL::CommandBuffer *spatialCmd = _pCommandQueue->commandBuffer();
     if (spatialCmd) {
       MTL::ComputeCommandEncoder *spatialCompute =
@@ -7652,6 +7665,15 @@ void Renderer::draw(MTK::View *pView) {
         spatialCompute->setComputePipelineState(_pRestirSpatialPSO);
         spatialCompute->setBuffer(_pRestirReservoirBuffer, 0, 0);
         spatialCompute->setBuffer(_pUniformsBuffer, 0, 1);
+        spatialCompute->setBuffer(_pBVHBuffer, 0, 2);
+        spatialCompute->setBuffer(_pSphereBuffer, 0, 3);
+        spatialCompute->setBuffer(_pSphereMaterialBuffer, 0, 4);
+        spatialCompute->setBuffer(_pPrimitiveIndexBuffer, 0, 5);
+        spatialCompute->setBuffer(_pTLASBuffer, 0, 6);
+        spatialCompute->setBuffer(_pActiveBuffer, 0, 7);
+        spatialCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 8);
+        spatialCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 9);
+        spatialCompute->setBuffer(_pInstanceBuffer, 0, 10);
         spatialCompute->setTexture(positionTexture, 0);
         spatialCompute->setTexture(normalTexture, 1);
         spatialCompute->setTexture(albedoTexture, 2);

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -385,7 +385,7 @@ private:
     uint64_t lastUsedFrame = 0;
   };
 
-  static constexpr size_t kRestirReservoirStride = 48;
+  static constexpr size_t kRestirReservoirStride = 96;
 
   // Framebuffers
   ManagedTextureSlot _colorSlot;

--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -47,6 +47,10 @@ struct LightSampleCandidate {
   float3 wi = float3(0.0f);
   float pdf = 0.0f;
   uint lightId = 0u;
+  float3 lightPosition = float3(0.0f);
+  float3 lightNormal = float3(0.0f);
+  float lightArea = 0.0f;
+  float lightPdf = 0.0f;
 };
 
 #include "Intersect.h"
@@ -194,6 +198,10 @@ inline RestirReservoir initReservoir() {
   reservoir.wSum = 0.0f;
   reservoir.m = 0u;
   reservoir.packedLightId = 0xffffffffu;
+  reservoir.lightPosition = float3(0.0f);
+  reservoir.lightNormal = float3(0.0f);
+  reservoir.lightArea = 0.0f;
+  reservoir.lightPdf = 0.0f;
   return reservoir;
 }
 
@@ -211,6 +219,10 @@ inline void updateReservoir(thread RestirReservoir &reservoir,
     reservoir.wi = candidate.wi;
     reservoir.pdf = candidate.pdf;
     reservoir.packedLightId = candidate.lightId;
+    reservoir.lightPosition = candidate.lightPosition;
+    reservoir.lightNormal = candidate.lightNormal;
+    reservoir.lightArea = candidate.lightArea;
+    reservoir.lightPdf = candidate.lightPdf;
   }
 }
 
@@ -327,6 +339,10 @@ inline bool sampleDirectLightCandidate(
   candidate.wi = wi;
   candidate.pdf = totalPdf;
   candidate.lightId = lightPrimIndex;
+  candidate.lightPosition = lightPoint;
+  candidate.lightNormal = lightNormal;
+  candidate.lightArea = area;
+  candidate.lightPdf = lightPdf;
   return true;
 }
 

--- a/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
@@ -2,7 +2,7 @@
 
 using namespace metal;
 
-#include "Structs.h"
+#include "PathTracing.h"
 
 inline uint hashUint(uint x) {
     x ^= x >> 16;
@@ -21,32 +21,158 @@ inline bool isFinite3(float3 v) {
     return all(isfinite(v));
 }
 
+struct RestirSampleData {
+    float3 radiance = float3(0.0f);
+    float3 wi = float3(0.0f);
+    float pdf = 0.0f;
+    uint packedLightId = 0u;
+    float3 lightPosition = float3(0.0f);
+    float3 lightNormal = float3(0.0f);
+    float lightArea = 0.0f;
+    float lightPdf = 0.0f;
+};
+
+inline bool reevaluateReservoirSample(
+    thread const RestirReservoir &source,
+    float3 currentPosition,
+    float3 currentNormal,
+    float3 currentAlbedo,
+    constant UniformsData &uniforms,
+    device const float4 *materials,
+    device const float4 *tlasNodes,
+    device const float4 *bvhNodes,
+    device const float4 *primitives,
+    device const int *primitiveIndices,
+    device const uchar *activeMask,
+    device const InstanceRecord *instanceRecords,
+    device const uint *primitiveRemap,
+    device atomic_uint *primitiveRayStats,
+    thread RestirSampleData &outSample,
+    thread float &outWeight) {
+    if (source.m == 0u || source.packedLightId == 0xffffffffu) {
+        return false;
+    }
+
+    uint primitiveCount = uint(uniforms.primitiveCount);
+    uint totalPrimitiveCount = uint(uniforms.totalPrimitiveCount);
+    uint tlasNodeCount = uint(uniforms.tlasNodeCount);
+
+    float3 toLight = source.lightPosition - currentPosition;
+    float dist2 = dot(toLight, toLight);
+    if (dist2 <= RAY_EPS || !isfinite(dist2)) {
+        return false;
+    }
+
+    float dist = sqrt(dist2);
+    float3 wi = toLight / dist;
+    float3 normalUnit = normalize(currentNormal);
+    float3 lightNormal = normalize(source.lightNormal);
+    float cosTheta = max(dot(normalUnit, wi), 0.0f);
+    float cosLight = max(dot(lightNormal, -wi), 0.0f);
+    if (cosTheta <= 0.0f || cosLight <= 0.0f) {
+        return false;
+    }
+
+    float lightArea = source.lightArea;
+    float lightPdf = source.lightPdf;
+    if (lightArea <= 0.0f || lightPdf <= 0.0f) {
+        return false;
+    }
+
+    float totalPdf = lightPdf * dist2 / (cosLight * lightArea);
+    if (totalPdf <= 0.0f || !isfinite(totalPdf)) {
+        return false;
+    }
+
+    TlasLeafCache cache;
+    bool visible = isLightVisible(
+        currentPosition, normalUnit, wi, dist, source.packedLightId, cache,
+        tlasNodes, tlasNodeCount, bvhNodes, primitives,
+        primitiveIndices, activeMask, instanceRecords, primitiveRemap,
+        primitiveCount, totalPrimitiveCount,
+        primitiveRayStats);
+    if (!visible) {
+        return false;
+    }
+
+    if (source.packedLightId >= primitiveCount) {
+        return false;
+    }
+
+    int lightMatIndex = int(source.packedLightId) * int(kMaterialFloat4Count);
+    int totalEntries = int(primitiveCount) * int(kMaterialFloat4Count);
+    if (lightMatIndex < 0 ||
+        lightMatIndex + int(kMaterialFloat4Count) > totalEntries) {
+        return false;
+    }
+
+    MaterialPayload lightMaterial = decodeMaterial(lightMatIndex, materials, 1.0f);
+    float3 lightRadiance =
+        lightMaterial.emissionColor * lightMaterial.emissionPower;
+    float3 throughput = currentAlbedo / M_PI;
+    float3 radiance = throughput * lightRadiance * cosTheta;
+    float target = luminance(radiance);
+    float weight = target / max(totalPdf, RAY_EPS);
+    if (weight <= 0.0f || !isfinite(weight)) {
+        return false;
+    }
+
+    outSample.radiance = radiance;
+    outSample.wi = wi;
+    outSample.pdf = totalPdf;
+    outSample.packedLightId = source.packedLightId;
+    outSample.lightPosition = source.lightPosition;
+    outSample.lightNormal = source.lightNormal;
+    outSample.lightArea = source.lightArea;
+    outSample.lightPdf = source.lightPdf;
+    outWeight = weight;
+    return true;
+}
+
 inline void mergeReservoir(thread RestirReservoir &current,
-                           thread const RestirReservoir &neighbor,
-                           float neighborWeight,
+                           thread const RestirSampleData &candidate,
+                           float weight,
+                           uint candidateCount,
                            float xi) {
-    if (neighbor.m == 0u || neighborWeight <= 0.0f || !isfinite(neighborWeight)) {
+    if (candidateCount == 0u || weight <= 0.0f || !isfinite(weight)) {
+        return;
+    }
+    float scaledWeight = weight * float(candidateCount);
+    if (scaledWeight <= 0.0f || !isfinite(scaledWeight)) {
         return;
     }
     float currentWeight = max(current.wSum, 0.0f);
-    float totalWeight = currentWeight + neighborWeight;
+    float totalWeight = currentWeight + scaledWeight;
     if (totalWeight <= 0.0f || !isfinite(totalWeight)) {
         return;
     }
-    float neighborProb = neighborWeight / totalWeight;
-    if (xi < neighborProb) {
-        current.sampleRadiance = neighbor.sampleRadiance;
-        current.wi = neighbor.wi;
-        current.pdf = neighbor.pdf;
-        current.packedLightId = neighbor.packedLightId;
+    float candidateProb = scaledWeight / totalWeight;
+    if (xi < candidateProb) {
+        current.sampleRadiance = candidate.radiance;
+        current.wi = candidate.wi;
+        current.pdf = candidate.pdf;
+        current.packedLightId = candidate.packedLightId;
+        current.lightPosition = candidate.lightPosition;
+        current.lightNormal = candidate.lightNormal;
+        current.lightArea = candidate.lightArea;
+        current.lightPdf = candidate.lightPdf;
     }
     current.wSum = totalWeight;
-    current.m += neighbor.m;
+    current.m += candidateCount;
 }
 
 kernel void restirSpatialMain(
     device RestirReservoir *reservoirBuffer [[buffer(0)]],
     constant UniformsData &uniforms [[buffer(1)]],
+    device const float4 *bvhNodes [[buffer(2)]],
+    device const float4 *primitives [[buffer(3)]],
+    device const float4 *materials [[buffer(4)]],
+    device const int *primitiveIndices [[buffer(5)]],
+    device const float4 *tlasNodes [[buffer(6)]],
+    device const uchar *activeMask [[buffer(7)]],
+    device const uint *primitiveRemap [[buffer(8)]],
+    device atomic_uint *primitiveRayStats [[buffer(9)]],
+    device const InstanceRecord *instanceRecords [[buffer(10)]],
     texture2d<float, access::read> positionAccum [[texture(0)]],
     texture2d<float, access::read> normalAccum [[texture(1)]],
     texture2d<float, access::read> albedoAccum [[texture(2)]],
@@ -128,9 +254,17 @@ kernel void restirSpatialMain(
             continue;
         }
 
-        float neighborWeight = max(neighbor.wSum, 0.0f) * similarity;
-        float xi = hashToFloat(seed);
-        mergeReservoir(current, neighbor, neighborWeight, xi);
+        RestirSampleData candidate;
+        float candidateWeight = 0.0f;
+        if (reevaluateReservoirSample(
+                neighbor, currentPosition, currentNormal, currentAlbedo,
+                uniforms, materials, tlasNodes, bvhNodes, primitives,
+                primitiveIndices, activeMask, instanceRecords, primitiveRemap,
+                primitiveRayStats, candidate, candidateWeight)) {
+            float xi = hashToFloat(seed);
+            mergeReservoir(current, candidate, candidateWeight * similarity,
+                           neighbor.m, xi);
+        }
     }
 
     reservoirBuffer[index] = current;

--- a/Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal
@@ -2,7 +2,7 @@
 
 using namespace metal;
 
-#include "Structs.h"
+#include "PathTracing.h"
 
 inline uint hashUint(uint x) {
     x ^= x >> 16;
@@ -28,33 +28,159 @@ inline float depthFromClip(float4 clip) {
     return clip.z / clip.w;
 }
 
+struct RestirSampleData {
+    float3 radiance = float3(0.0f);
+    float3 wi = float3(0.0f);
+    float pdf = 0.0f;
+    uint packedLightId = 0u;
+    float3 lightPosition = float3(0.0f);
+    float3 lightNormal = float3(0.0f);
+    float lightArea = 0.0f;
+    float lightPdf = 0.0f;
+};
+
+inline bool reevaluateReservoirSample(
+    thread const RestirReservoir &source,
+    float3 currentPosition,
+    float3 currentNormal,
+    float3 currentAlbedo,
+    constant UniformsData &uniforms,
+    device const float4 *materials,
+    device const float4 *tlasNodes,
+    device const float4 *bvhNodes,
+    device const float4 *primitives,
+    device const int *primitiveIndices,
+    device const uchar *activeMask,
+    device const InstanceRecord *instanceRecords,
+    device const uint *primitiveRemap,
+    device atomic_uint *primitiveRayStats,
+    thread RestirSampleData &outSample,
+    thread float &outWeight) {
+    if (source.m == 0u || source.packedLightId == 0xffffffffu) {
+        return false;
+    }
+
+    uint primitiveCount = uint(uniforms.primitiveCount);
+    uint totalPrimitiveCount = uint(uniforms.totalPrimitiveCount);
+    uint tlasNodeCount = uint(uniforms.tlasNodeCount);
+
+    float3 toLight = source.lightPosition - currentPosition;
+    float dist2 = dot(toLight, toLight);
+    if (dist2 <= RAY_EPS || !isfinite(dist2)) {
+        return false;
+    }
+
+    float dist = sqrt(dist2);
+    float3 wi = toLight / dist;
+    float3 normalUnit = normalize(currentNormal);
+    float3 lightNormal = normalize(source.lightNormal);
+    float cosTheta = max(dot(normalUnit, wi), 0.0f);
+    float cosLight = max(dot(lightNormal, -wi), 0.0f);
+    if (cosTheta <= 0.0f || cosLight <= 0.0f) {
+        return false;
+    }
+
+    float lightArea = source.lightArea;
+    float lightPdf = source.lightPdf;
+    if (lightArea <= 0.0f || lightPdf <= 0.0f) {
+        return false;
+    }
+
+    float totalPdf = lightPdf * dist2 / (cosLight * lightArea);
+    if (totalPdf <= 0.0f || !isfinite(totalPdf)) {
+        return false;
+    }
+
+    TlasLeafCache cache;
+    bool visible = isLightVisible(
+        currentPosition, normalUnit, wi, dist, source.packedLightId, cache,
+        tlasNodes, tlasNodeCount, bvhNodes, primitives,
+        primitiveIndices, activeMask, instanceRecords, primitiveRemap,
+        primitiveCount, totalPrimitiveCount,
+        primitiveRayStats);
+    if (!visible) {
+        return false;
+    }
+
+    if (source.packedLightId >= primitiveCount) {
+        return false;
+    }
+
+    int lightMatIndex = int(source.packedLightId) * int(kMaterialFloat4Count);
+    int totalEntries = int(primitiveCount) * int(kMaterialFloat4Count);
+    if (lightMatIndex < 0 ||
+        lightMatIndex + int(kMaterialFloat4Count) > totalEntries) {
+        return false;
+    }
+
+    MaterialPayload lightMaterial = decodeMaterial(lightMatIndex, materials, 1.0f);
+    float3 lightRadiance =
+        lightMaterial.emissionColor * lightMaterial.emissionPower;
+    float3 throughput = currentAlbedo / M_PI;
+    float3 radiance = throughput * lightRadiance * cosTheta;
+    float target = luminance(radiance);
+    float weight = target / max(totalPdf, RAY_EPS);
+    if (weight <= 0.0f || !isfinite(weight)) {
+        return false;
+    }
+
+    outSample.radiance = radiance;
+    outSample.wi = wi;
+    outSample.pdf = totalPdf;
+    outSample.packedLightId = source.packedLightId;
+    outSample.lightPosition = source.lightPosition;
+    outSample.lightNormal = source.lightNormal;
+    outSample.lightArea = source.lightArea;
+    outSample.lightPdf = source.lightPdf;
+    outWeight = weight;
+    return true;
+}
+
 inline void mergeReservoir(thread RestirReservoir &current,
-                           thread const RestirReservoir &history,
+                           thread const RestirSampleData &candidate,
+                           float weight,
+                           uint candidateCount,
                            float xi) {
-    if (history.m == 0u || history.wSum <= 0.0f || !isfinite(history.wSum)) {
+    if (candidateCount == 0u || weight <= 0.0f || !isfinite(weight)) {
+        return;
+    }
+    float scaledWeight = weight * float(candidateCount);
+    if (scaledWeight <= 0.0f || !isfinite(scaledWeight)) {
         return;
     }
     float currentWeight = max(current.wSum, 0.0f);
-    float historyWeight = max(history.wSum, 0.0f);
-    float totalWeight = currentWeight + historyWeight;
+    float totalWeight = currentWeight + scaledWeight;
     if (totalWeight <= 0.0f || !isfinite(totalWeight)) {
         return;
     }
-    float historyProb = historyWeight / totalWeight;
-    if (xi < historyProb) {
-        current.sampleRadiance = history.sampleRadiance;
-        current.wi = history.wi;
-        current.pdf = history.pdf;
-        current.packedLightId = history.packedLightId;
+    float candidateProb = scaledWeight / totalWeight;
+    if (xi < candidateProb) {
+        current.sampleRadiance = candidate.radiance;
+        current.wi = candidate.wi;
+        current.pdf = candidate.pdf;
+        current.packedLightId = candidate.packedLightId;
+        current.lightPosition = candidate.lightPosition;
+        current.lightNormal = candidate.lightNormal;
+        current.lightArea = candidate.lightArea;
+        current.lightPdf = candidate.lightPdf;
     }
     current.wSum = totalWeight;
-    current.m += history.m;
+    current.m += candidateCount;
 }
 
 kernel void restirTemporalMain(
     device const RestirReservoir *historyReservoir [[buffer(0)]],
     device RestirReservoir *currentReservoir [[buffer(1)]],
     constant UniformsData &uniforms [[buffer(2)]],
+    device const float4 *bvhNodes [[buffer(3)]],
+    device const float4 *primitives [[buffer(4)]],
+    device const float4 *materials [[buffer(5)]],
+    device const int *primitiveIndices [[buffer(6)]],
+    device const float4 *tlasNodes [[buffer(7)]],
+    device const uchar *activeMask [[buffer(8)]],
+    device const uint *primitiveRemap [[buffer(9)]],
+    device atomic_uint *primitiveRayStats [[buffer(10)]],
+    device const InstanceRecord *instanceRecords [[buffer(11)]],
     texture2d<float, access::read> positionAccum [[texture(0)]],
     texture2d<float, access::read> normalAccum [[texture(1)]],
     texture2d<float, access::read> albedoAccum [[texture(2)]],
@@ -158,7 +284,15 @@ kernel void restirTemporalMain(
         uint seed = hashUint(index ^
                              uint(fabs(uniforms.randomSeed.x) * 4096.0f));
         float xi = hashToFloat(seed);
-        mergeReservoir(current, history, xi);
+        RestirSampleData candidate;
+        float candidateWeight = 0.0f;
+        if (reevaluateReservoirSample(
+                history, currentPosition, currentNormal, currentAlbedo,
+                uniforms, materials, tlasNodes, bvhNodes, primitives,
+                primitiveIndices, activeMask, instanceRecords, primitiveRemap,
+                primitiveRayStats, candidate, candidateWeight)) {
+            mergeReservoir(current, candidate, candidateWeight, history.m, xi);
+        }
         if (uniforms.restirMaxTemporalM > 0u) {
             current.m = min(current.m, uniforms.restirMaxTemporalM);
         }

--- a/Nomad Path Tracer/Renderer/Shaders/Structs.h
+++ b/Nomad Path Tracer/Renderer/Shaders/Structs.h
@@ -116,6 +116,10 @@ struct RestirReservoir
     float wSum = 0.0f;
     uint m = 0u;
     uint packedLightId = 0u;
+    float3 lightPosition = float3(0.0f);
+    float3 lightNormal = float3(0.0f);
+    float lightArea = 0.0f;
+    float lightPdf = 0.0f;
 };
 
 


### PR DESCRIPTION
### Motivation

- Improve correctness of temporal and spatial ReSTIR merging by re-evaluating a reused sample's contribution at the current surface (including visibility) so merge weights use the current target value.
- Ensure reservoir merging follows the canonical ReSTIR weight update `w = target / pdf` and proper resampling `w / sumW` when reusing samples from history or neighbors.

### Description

- Expanded `RestirReservoir` layout to store light sample metadata (`lightPosition`, `lightNormal`, `lightArea`, `lightPdf`) and increased `kRestirReservoirStride` accordingly.
- Augmented `LightSampleCandidate` and `initReservoir`/`updateReservoir` to record light sample geometry and PDFs so stored reservoirs can be re-evaluated later.
- Added `reevaluateReservoirSample` helper in both `RestirTemporal.metal` and `RestirSpatial.metal` to reconstruct/resample a stored light sample at the current surface, perform visibility checks, compute `target = luminance(radiance)`, compute canonical weight `w = target / pdf`, and return a candidate weight and sample data.
- Replaced the old merge logic with a new `mergeReservoir` variant that accepts the re-evaluated candidate and weight, scales the weight by the candidate count, computes selection probability by `scaledWeight / (current.wSum + scaledWeight)`, updates reservoir sample fields (including saved light metadata), and updates `wSum`/`m` accordingly.
- Bound the scene/material/acceleration buffers required for re-evaluation in `Renderer.cpp` for both temporal and spatial compute passes and guarded pass dispatches on their availability.

### Testing

- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697776b0e410832da6e6d5474d6ad633)