### PR TITLE
Run ReSTIR shade pass only in debug mode to avoid overwriting final frame

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -7708,7 +7708,8 @@ void Renderer::draw(MTK::View *pView) {
 
   const bool restirShadeValid =
       _pRestirReservoirBuffer && _restirSettings.enabled &&
-      (_restirSettings.enableTemporal || _restirSettings.enableSpatial);
+      (_restirSettings.enableTemporal || _restirSettings.enableSpatial) &&
+      _restirSettings.debugMode != 0;
   if (_pRestirShadePSO && colorTexture && restirShadeValid) {
     MTL::CommandBuffer *shadeCmd = _pCommandQueue->commandBuffer();
     if (shadeCmd) {

--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -277,7 +277,7 @@ kernel void pathTraceKernel(
       (totalSamples > 0.0f) ? accumulatedRoughness / totalSamples : 0.0f;
   averagedRoughness = clamp(averagedRoughness, 0.0f, 1.0f);
 
-  float3 outputColor = useRestir ? reservoirEstimate : averaged;
+  float3 outputColor = averaged;
   float4 result = float4(outputColor, 1.0f);
   currentFrame.write(result, pixel);
   albedoAccum.write(float4(averagedAlbedo, 1.0f), pixel);

--- a/Nomad Path Tracer/Renderer/Shaders/RestirShade.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirShade.metal
@@ -26,6 +26,9 @@ kernel void restirShadeMain(
   if (gid.x >= width || gid.y >= height)
     return;
 
+  if (uniforms.restirDebugMode == 0u)
+    return;
+
   uint index = gid.y * width + gid.x;
   RestirReservoir reservoir = reservoirBuffer[index];
   float3 reservoirEstimate = finalizeReservoir(reservoir);


### PR DESCRIPTION
### Motivation
- Prevent the ReSTIR shading pass from overwriting `currentFrame` with `reservoirEstimate` so the path tracer (`PathTraceKernel`) remains the final radiance estimator and ReSTIR is treated as a sampling/resampling step or debug visualization.

### Description
- Add an early exit in `RestirShade.metal` (`restirShadeMain`) when `uniforms.restirDebugMode == 0` and require `_restirSettings.debugMode != 0` before dispatching the ReSTIR shade kernel in `Renderer.cpp`, ensuring the ReSTIR shading compute pass only runs for debug modes and does not write to the frame during normal rendering.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697778b61508832dae7ad62428e99fff)