### PR TITLE
Align ReSTIR target with estimator (include geometry term)

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -246,7 +246,7 @@ kernel void pathTraceKernel(
                     primitiveRemap, primitiveRayStats, bounceCache, seed,
                     u.lightCount, u.lightTotalWeight,
                     static_cast<uint>(u.totalPrimitiveCount), candidate)) {
-              float weight = luminance(candidate.radiance) /
+              float weight = luminance(restirTargetContribution(candidate)) /
                              max(candidate.pdf, RAY_EPS);
               float xi = randomFloat(seed);
               seed = random(seed);

--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -46,6 +46,7 @@ struct LightSampleCandidate {
   float3 radiance = float3(0.0f);
   float3 wi = float3(0.0f);
   float pdf = 0.0f;
+  float geometryFactor = 0.0f;
   uint lightId = 0u;
   float3 lightPosition = float3(0.0f);
   float3 lightNormal = float3(0.0f);
@@ -195,6 +196,7 @@ inline RestirReservoir initReservoir() {
   reservoir.sampleRadiance = float3(0.0f);
   reservoir.wi = float3(0.0f);
   reservoir.pdf = 0.0f;
+  reservoir.geometryFactor = 0.0f;
   reservoir.wSum = 0.0f;
   reservoir.m = 0u;
   reservoir.packedLightId = 0xffffffffu;
@@ -203,6 +205,18 @@ inline RestirReservoir initReservoir() {
   reservoir.lightArea = 0.0f;
   reservoir.lightPdf = 0.0f;
   return reservoir;
+}
+
+inline float3 restirTargetContribution(float3 radiance, float geometryFactor) {
+  return radiance * max(geometryFactor, 0.0f);
+}
+
+inline float3 restirTargetContribution(thread const LightSampleCandidate &candidate) {
+  return restirTargetContribution(candidate.radiance, candidate.geometryFactor);
+}
+
+inline float3 restirTargetContribution(thread const RestirReservoir &reservoir) {
+  return restirTargetContribution(reservoir.sampleRadiance, reservoir.geometryFactor);
 }
 
 inline void updateReservoir(thread RestirReservoir &reservoir,
@@ -218,6 +232,7 @@ inline void updateReservoir(thread RestirReservoir &reservoir,
     reservoir.sampleRadiance = candidate.radiance;
     reservoir.wi = candidate.wi;
     reservoir.pdf = candidate.pdf;
+    reservoir.geometryFactor = candidate.geometryFactor;
     reservoir.packedLightId = candidate.lightId;
     reservoir.lightPosition = candidate.lightPosition;
     reservoir.lightNormal = candidate.lightNormal;
@@ -230,8 +245,8 @@ inline float3 finalizeReservoir(thread const RestirReservoir &reservoir) {
   if (reservoir.m == 0u || reservoir.pdf <= 0.0f) {
     return float3(0.0f);
   }
-  float weightSelected =
-      luminance(reservoir.sampleRadiance) / max(reservoir.pdf, RAY_EPS);
+  float3 target = restirTargetContribution(reservoir);
+  float weightSelected = luminance(target) / max(reservoir.pdf, RAY_EPS);
   if (weightSelected <= 0.0f) {
     return float3(0.0f);
   }
@@ -335,7 +350,9 @@ inline bool sampleDirectLightCandidate(
   float3 lightRadiance =
       lightMaterial.emissionColor * lightMaterial.emissionPower;
   float3 throughput = diffuseColor / M_PI;
+  float geometryFactor = cosLight / max(dist2, RAY_EPS);
   candidate.radiance = throughput * lightRadiance * cosTheta;
+  candidate.geometryFactor = geometryFactor;
   candidate.wi = wi;
   candidate.pdf = totalPdf;
   candidate.lightId = lightPrimIndex;

--- a/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
@@ -25,6 +25,7 @@ struct RestirSampleData {
     float3 radiance = float3(0.0f);
     float3 wi = float3(0.0f);
     float pdf = 0.0f;
+    float geometryFactor = 0.0f;
     uint packedLightId = 0u;
     float3 lightPosition = float3(0.0f);
     float3 lightNormal = float3(0.0f);
@@ -111,7 +112,8 @@ inline bool reevaluateReservoirSample(
         lightMaterial.emissionColor * lightMaterial.emissionPower;
     float3 throughput = currentAlbedo / M_PI;
     float3 radiance = throughput * lightRadiance * cosTheta;
-    float target = luminance(radiance);
+    float geometryFactor = cosLight / max(dist2, RAY_EPS);
+    float target = luminance(restirTargetContribution(radiance, geometryFactor));
     float weight = target / max(totalPdf, RAY_EPS);
     if (weight <= 0.0f || !isfinite(weight)) {
         return false;
@@ -120,6 +122,7 @@ inline bool reevaluateReservoirSample(
     outSample.radiance = radiance;
     outSample.wi = wi;
     outSample.pdf = totalPdf;
+    outSample.geometryFactor = geometryFactor;
     outSample.packedLightId = source.packedLightId;
     outSample.lightPosition = source.lightPosition;
     outSample.lightNormal = source.lightNormal;
@@ -151,6 +154,7 @@ inline void mergeReservoir(thread RestirReservoir &current,
         current.sampleRadiance = candidate.radiance;
         current.wi = candidate.wi;
         current.pdf = candidate.pdf;
+        current.geometryFactor = candidate.geometryFactor;
         current.packedLightId = candidate.packedLightId;
         current.lightPosition = candidate.lightPosition;
         current.lightNormal = candidate.lightNormal;

--- a/Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal
@@ -32,6 +32,7 @@ struct RestirSampleData {
     float3 radiance = float3(0.0f);
     float3 wi = float3(0.0f);
     float pdf = 0.0f;
+    float geometryFactor = 0.0f;
     uint packedLightId = 0u;
     float3 lightPosition = float3(0.0f);
     float3 lightNormal = float3(0.0f);
@@ -118,7 +119,8 @@ inline bool reevaluateReservoirSample(
         lightMaterial.emissionColor * lightMaterial.emissionPower;
     float3 throughput = currentAlbedo / M_PI;
     float3 radiance = throughput * lightRadiance * cosTheta;
-    float target = luminance(radiance);
+    float geometryFactor = cosLight / max(dist2, RAY_EPS);
+    float target = luminance(restirTargetContribution(radiance, geometryFactor));
     float weight = target / max(totalPdf, RAY_EPS);
     if (weight <= 0.0f || !isfinite(weight)) {
         return false;
@@ -127,6 +129,7 @@ inline bool reevaluateReservoirSample(
     outSample.radiance = radiance;
     outSample.wi = wi;
     outSample.pdf = totalPdf;
+    outSample.geometryFactor = geometryFactor;
     outSample.packedLightId = source.packedLightId;
     outSample.lightPosition = source.lightPosition;
     outSample.lightNormal = source.lightNormal;
@@ -158,6 +161,7 @@ inline void mergeReservoir(thread RestirReservoir &current,
         current.sampleRadiance = candidate.radiance;
         current.wi = candidate.wi;
         current.pdf = candidate.pdf;
+        current.geometryFactor = candidate.geometryFactor;
         current.packedLightId = candidate.packedLightId;
         current.lightPosition = candidate.lightPosition;
         current.lightNormal = candidate.lightNormal;

--- a/Nomad Path Tracer/Renderer/Shaders/Structs.h
+++ b/Nomad Path Tracer/Renderer/Shaders/Structs.h
@@ -113,6 +113,7 @@ struct RestirReservoir
     float3 sampleRadiance = float3(0.0f);
     float3 wi = float3(0.0f);
     float pdf = 0.0f;
+    float geometryFactor = 0.0f;
     float wSum = 0.0f;
     uint m = 0u;
     uint packedLightId = 0u;


### PR DESCRIPTION
### Motivation
- ReSTIR candidate weights and reservoir normalization must reflect the actual estimator contribution (BSDF * geometry * visibility * emission) so selection and normalization are consistent with the final shading estimator. 
- Propagate the geometry factor through candidate/reservoir data so temporal/spatial reevaluation and merging use the same target definition.

### Description
- Added a `geometryFactor` field to `RestirReservoir`, `LightSampleCandidate`, and `RestirSampleData` in `Structs.h`, `PathTracing.h`, `RestirSpatial.metal`, and `RestirTemporal.metal` respectively. 
- Introduced `restirTargetContribution(...)` helpers in `PathTracing.h` and used them to define the ReSTIR target as `radiance * max(geometryFactor, 0.0)` so the geometry term is included in target evaluation. 
- Compute and store geometry factor (`geometryFactor = cosLight / max(dist2, RAY_EPS)`) when sampling direct lights in `sampleDirectLightCandidate` (in `PathTracing.h`) and when re-evaluating history/spatial samples in `RestirTemporal.metal` and `RestirSpatial.metal`. 
- Use the new target when computing candidate weights in the path-tracing kernel (`PathTraceKernel.metal`) and when reevaluating candidates in spatial/temporal passes, and propagate `geometryFactor` during `updateReservoir` / `mergeReservoir` so `finalizeReservoir` can normalize using the same target definition. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69777a4d6328832d91266ea511fb620c)