### PR TITLE
Align ReSTIR candidates with direct lighting BSDF

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -227,19 +227,19 @@ kernel void pathTraceKernel(
           }
         }
 
-        accumulatedAlbedo += material.diffuseColor;
+        accumulatedAlbedo += material.diffuseColor * material.opacity;
         accumulatedNormal += shadingNormal;
         accumulatedPosition += bestHit.point;
         accumulatedRoughness += clamp(material.roughness, 0.0f, 1.0f);
 
-        float3 diffuseColor = material.diffuseColor * material.opacity;
-        if (luminance(diffuseColor) > 0.0f && u.lightCount > 0 &&
+        float3 directLightingBsdf = directLightingBsdfFromMaterial(material);
+        if (luminance(directLightingBsdf) > 0.0f && u.lightCount > 0 &&
             u.lightTotalWeight > 0.0f) {
           for (uint candidateIdx = 0u; candidateIdx < restirCandidateCount;
                ++candidateIdx) {
             LightSampleCandidate candidate;
             if (sampleDirectLightCandidate(
-                    bestHit.point, shadingNormal, diffuseColor,
+                    bestHit.point, shadingNormal, directLightingBsdf,
                     bestHit.primitiveId, tlasNodes, u.tlasNodeCount, bvhNodes,
                     primitives, materials, u.primitiveCount, primitiveIndices,
                     activeMask, instanceRecords, lightIndices, lightCdf,

--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -219,6 +219,15 @@ inline float3 restirTargetContribution(thread const RestirReservoir &reservoir) 
   return restirTargetContribution(reservoir.sampleRadiance, reservoir.geometryFactor);
 }
 
+inline float3 directLightingBsdfFromAlbedo(float3 albedo) {
+  float3 clamped = max(albedo, float3(0.0f));
+  return clamped / M_PI;
+}
+
+inline float3 directLightingBsdfFromMaterial(thread const MaterialPayload &material) {
+  return directLightingBsdfFromAlbedo(material.diffuseColor * material.opacity);
+}
+
 inline void updateReservoir(thread RestirReservoir &reservoir,
                             thread const LightSampleCandidate &candidate,
                             float weight, float xi) {
@@ -268,7 +277,7 @@ inline bool isLightVisible(
     uint totalPrimitiveCount, device atomic_uint *primitiveRayStats);
 
 inline bool sampleDirectLightCandidate(
-    float3 hitPoint, float3 offsetNormal, float3 diffuseColor,
+    float3 hitPoint, float3 offsetNormal, float3 directLightingBsdf,
     int hitPrimitiveId, device const float4 *tlasNodes, uint tlasNodeCount,
     device const float4 *bvhNodes, device const float4 *primitives,
     device const float4 *materials, uint primitiveCount,
@@ -349,7 +358,7 @@ inline bool sampleDirectLightCandidate(
   MaterialPayload lightMaterial = decodeMaterial(lightMatIndex, materials, 1.0f);
   float3 lightRadiance =
       lightMaterial.emissionColor * lightMaterial.emissionPower;
-  float3 throughput = diffuseColor / M_PI;
+  float3 throughput = directLightingBsdf;
   float geometryFactor = cosLight / max(dist2, RAY_EPS);
   candidate.radiance = throughput * lightRadiance * cosTheta;
   candidate.geometryFactor = geometryFactor;
@@ -1285,8 +1294,8 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
                             decodeMaterial(lightMatIndex, materials, 1.0f);
                         float3 lightRadiance = lightMaterial.emissionColor *
                                               lightMaterial.emissionPower;
-                        float3 throughput =
-                            absorption.xyz * (diffuseColor / M_PI);
+    float3 throughput =
+        absorption.xyz * directLightingBsdfFromAlbedo(diffuseColor);
                         float3 contribution =
                             throughput * lightRadiance * (cosTheta / totalPdf);
                         light.xyz += contribution;

--- a/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
@@ -110,7 +110,7 @@ inline bool reevaluateReservoirSample(
     MaterialPayload lightMaterial = decodeMaterial(lightMatIndex, materials, 1.0f);
     float3 lightRadiance =
         lightMaterial.emissionColor * lightMaterial.emissionPower;
-    float3 throughput = currentAlbedo / M_PI;
+    float3 throughput = directLightingBsdfFromAlbedo(currentAlbedo);
     float3 radiance = throughput * lightRadiance * cosTheta;
     float geometryFactor = cosLight / max(dist2, RAY_EPS);
     float target = luminance(restirTargetContribution(radiance, geometryFactor));

--- a/Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal
@@ -117,7 +117,7 @@ inline bool reevaluateReservoirSample(
     MaterialPayload lightMaterial = decodeMaterial(lightMatIndex, materials, 1.0f);
     float3 lightRadiance =
         lightMaterial.emissionColor * lightMaterial.emissionPower;
-    float3 throughput = currentAlbedo / M_PI;
+    float3 throughput = directLightingBsdfFromAlbedo(currentAlbedo);
     float3 radiance = throughput * lightRadiance * cosTheta;
     float geometryFactor = cosLight / max(dist2, RAY_EPS);
     float target = luminance(restirTargetContribution(radiance, geometryFactor));


### PR DESCRIPTION
### Motivation
- Ensure ReSTIR reservoirs represent the same direct-illumination quantity the path tracer uses by including the BSDF (or a clearly defined DI estimator) in candidates so weights and final estimates are consistent.

### Description
- Add `directLightingBsdfFromAlbedo` and `directLightingBsdfFromMaterial` helpers to `PathTracing.h` to define the direct-lighting BSDF used by the path tracer and ReSTIR.
- Change `sampleDirectLightCandidate` to accept a precomputed `directLightingBsdf` and use it as the candidate throughput instead of dividing by `M_PI` inside the function in `PathTracing.h`.
- Update `PathTraceKernel.metal` to accumulate opacity-adjusted albedo (`material.diffuseColor * material.opacity`) and to compute/pass `directLightingBsdf` to `sampleDirectLightCandidate` when generating ReSTIR candidates.
- Make temporal and spatial re-evaluation (`RestirTemporal.metal` and `RestirSpatial.metal`) reuse `directLightingBsdfFromAlbedo` so re-evaluated sample weights match the path tracer's DI estimator.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69777c7d9028832da4497ca59276fef3)