### PR TITLE
Use ReSTIR reservoir output for direct lighting

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -277,7 +277,7 @@ kernel void pathTraceKernel(
       (totalSamples > 0.0f) ? accumulatedRoughness / totalSamples : 0.0f;
   averagedRoughness = clamp(averagedRoughness, 0.0f, 1.0f);
 
-  float3 outputColor = averaged;
+  float3 outputColor = useRestir ? reservoirEstimate : averaged;
   float4 result = float4(outputColor, 1.0f);
   currentFrame.write(result, pixel);
   albedoAccum.write(float4(averagedAlbedo, 1.0f), pixel);


### PR DESCRIPTION
### Motivation
- Ensure that when ReSTIR is enabled the pixel direct lighting is produced from the selected reservoir sample instead of only storing the reservoir for debugging.

### Description
- Route the frame output through the ReSTIR estimate by using `finalizeReservoir(reservoir)` (the `reservoirEstimate`) when `useRestir` is true, replacing `float3 outputColor = averaged;` with `float3 outputColor = useRestir ? reservoirEstimate : averaged;` in `PathTraceKernel.metal`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69777fa19d50832d9ac42407c8c23fc6)