### PR TITLE
Use scalar targets for ReSTIR weights

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -246,8 +246,9 @@ kernel void pathTraceKernel(
                     primitiveRemap, primitiveRayStats, bounceCache, seed,
                     u.lightCount, u.lightTotalWeight,
                     static_cast<uint>(u.totalPrimitiveCount), candidate)) {
-              float weight = luminance(restirTargetContribution(candidate)) /
-                             max(candidate.pdf, RAY_EPS);
+              float weight = restirTargetWeight(candidate.radiance,
+                                                candidate.geometryFactor,
+                                                candidate.pdf);
               float xi = randomFloat(seed);
               seed = random(seed);
               updateReservoir(reservoir, candidate, weight, xi);

--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -207,16 +207,22 @@ inline RestirReservoir initReservoir() {
   return reservoir;
 }
 
-inline float3 restirTargetContribution(float3 radiance, float geometryFactor) {
-  return radiance * max(geometryFactor, 0.0f);
+inline float restirTargetContribution(float3 radiance, float geometryFactor) {
+  float3 contribution = radiance * max(geometryFactor, 0.0f);
+  return max(luminance(contribution), 0.0f);
 }
 
-inline float3 restirTargetContribution(thread const LightSampleCandidate &candidate) {
+inline float restirTargetContribution(thread const LightSampleCandidate &candidate) {
   return restirTargetContribution(candidate.radiance, candidate.geometryFactor);
 }
 
-inline float3 restirTargetContribution(thread const RestirReservoir &reservoir) {
+inline float restirTargetContribution(thread const RestirReservoir &reservoir) {
   return restirTargetContribution(reservoir.sampleRadiance, reservoir.geometryFactor);
+}
+
+inline float restirTargetWeight(float3 radiance, float geometryFactor, float pdf) {
+  float target = restirTargetContribution(radiance, geometryFactor);
+  return target / max(pdf, RAY_EPS);
 }
 
 inline float3 directLightingBsdfFromAlbedo(float3 albedo) {
@@ -254,8 +260,8 @@ inline float3 finalizeReservoir(thread const RestirReservoir &reservoir) {
   if (reservoir.m == 0u || reservoir.pdf <= 0.0f) {
     return float3(0.0f);
   }
-  float3 target = restirTargetContribution(reservoir);
-  float weightSelected = luminance(target) / max(reservoir.pdf, RAY_EPS);
+  float target = restirTargetContribution(reservoir);
+  float weightSelected = target / max(reservoir.pdf, RAY_EPS);
   if (weightSelected <= 0.0f) {
     return float3(0.0f);
   }

--- a/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
@@ -113,8 +113,7 @@ inline bool reevaluateReservoirSample(
     float3 throughput = directLightingBsdfFromAlbedo(currentAlbedo);
     float3 radiance = throughput * lightRadiance * cosTheta;
     float geometryFactor = cosLight / max(dist2, RAY_EPS);
-    float target = luminance(restirTargetContribution(radiance, geometryFactor));
-    float weight = target / max(totalPdf, RAY_EPS);
+    float weight = restirTargetWeight(radiance, geometryFactor, totalPdf);
     if (weight <= 0.0f || !isfinite(weight)) {
         return false;
     }

--- a/Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal
@@ -120,8 +120,7 @@ inline bool reevaluateReservoirSample(
     float3 throughput = directLightingBsdfFromAlbedo(currentAlbedo);
     float3 radiance = throughput * lightRadiance * cosTheta;
     float geometryFactor = cosLight / max(dist2, RAY_EPS);
-    float target = luminance(restirTargetContribution(radiance, geometryFactor));
-    float weight = target / max(totalPdf, RAY_EPS);
+    float weight = restirTargetWeight(radiance, geometryFactor, totalPdf);
     if (weight <= 0.0f || !isfinite(weight)) {
         return false;
     }


### PR DESCRIPTION
### Motivation
- Make ReSTIR weighting and normalization unbiased by using a scalar target (luminance/energy proxy) instead of a vector contribution so the same target can be reused consistently across candidate generation and re-evaluation. 
- Ensure temporal and spatial re-evaluation use the identical target and weight formula so reservoir normalization stays correct.

### Description
- Change `restirTargetContribution` to return a scalar `float` representing `max(luminance(radiance * max(geometryFactor, 0.0)), 0.0)` instead of a `float3` contribution. 
- Add `restirTargetWeight(float3 radiance, float geometryFactor, float pdf)` which computes `target / max(pdf, RAY_EPS)` and centralizes target-to-weight conversion. 
- Use `restirTargetWeight` in candidate generation (`PathTraceKernel.metal`) and in temporal/spatial re-evaluation (`RestirTemporal.metal`, `RestirSpatial.metal`). 
- Update `finalizeReservoir` to normalize using the scalar target/weight selected (replace `luminance` of a vector target with the scalar target). 

### Testing
- No automated tests or builds were executed as part of this change set (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977802b080c832d81b116b88eaf9cf4)