### PR TITLE
Use material-aware GGX BSDF for direct lighting and ReSTIR evaluation

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -232,14 +232,17 @@ kernel void pathTraceKernel(
         accumulatedPosition += bestHit.point;
         accumulatedRoughness += clamp(material.roughness, 0.0f, 1.0f);
 
-        float3 directLightingBsdf = directLightingBsdfFromMaterial(material);
-        if (luminance(directLightingBsdf) > 0.0f && u.lightCount > 0 &&
+        float3 viewDir = -rayDirection;
+        float materialEnergy =
+            luminance(material.diffuseColor * material.opacity) +
+            luminance(material.specularColor * material.opacity);
+        if (materialEnergy > 0.0f && u.lightCount > 0 &&
             u.lightTotalWeight > 0.0f) {
           for (uint candidateIdx = 0u; candidateIdx < restirCandidateCount;
                ++candidateIdx) {
             LightSampleCandidate candidate;
             if (sampleDirectLightCandidate(
-                    bestHit.point, shadingNormal, directLightingBsdf,
+                    bestHit.point, shadingNormal, viewDir, material,
                     bestHit.primitiveId, tlasNodes, u.tlasNodeCount, bvhNodes,
                     primitives, materials, u.primitiveCount, primitiveIndices,
                     activeMask, instanceRecords, lightIndices, lightCdf,

--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -225,13 +225,70 @@ inline float restirTargetWeight(float3 radiance, float geometryFactor, float pdf
   return target / max(pdf, RAY_EPS);
 }
 
-inline float3 directLightingBsdfFromAlbedo(float3 albedo) {
-  float3 clamped = max(albedo, float3(0.0f));
-  return clamped / M_PI;
+inline float3 evaluateDirectLightingBsdf(thread const MaterialPayload &material,
+                                         float3 normal, float3 viewDir,
+                                         float3 lightDir) {
+  float3 n = normalize(normal);
+  float3 v = normalize(viewDir);
+  float3 l = normalize(lightDir);
+  if (!all(isfinite(n)) || !all(isfinite(v)) || !all(isfinite(l))) {
+    return float3(0.0f);
+  }
+  float nDotL = max(dot(n, l), 0.0f);
+  float nDotV = max(dot(n, v), 0.0f);
+  if (nDotL <= 0.0f || nDotV <= 0.0f) {
+    return float3(0.0f);
+  }
+
+  float3 diffuseColor =
+      max(material.diffuseColor, float3(0.0f)) * material.opacity;
+  float3 specularColor =
+      clamp(material.specularColor * material.opacity, 0.0f, 1.0f);
+
+  float roughness = clamp(material.roughness, 0.0f, 1.0f);
+  float alpha = max(roughness * roughness, 0.001f);
+  float alpha2 = alpha * alpha;
+
+  float3 h = normalize(v + l);
+  float nDotH = max(dot(n, h), 0.0f);
+  float vDotH = max(dot(v, h), 0.0f);
+
+  float denom = nDotH * nDotH * (alpha2 - 1.0f) + 1.0f;
+  float D = alpha2 / max(M_PI * denom * denom, RAY_EPS);
+
+  float k = (alpha + 1.0f);
+  k = (k * k) / 8.0f;
+  float Gv = nDotV / (nDotV * (1.0f - k) + k);
+  float Gl = nDotL / (nDotL * (1.0f - k) + k);
+  float G = Gv * Gl;
+
+  float Fc = pow(max(1.0f - vDotH, 0.0f), 5.0f);
+  float3 F = specularColor + (float3(1.0f) - specularColor) * Fc;
+
+  float3 specular =
+      (D * G) * F / max(4.0f * nDotL * nDotV, RAY_EPS);
+  float3 diffuse = diffuseColor / M_PI;
+  return diffuse + specular;
 }
 
-inline float3 directLightingBsdfFromMaterial(thread const MaterialPayload &material) {
-  return directLightingBsdfFromAlbedo(material.diffuseColor * material.opacity);
+inline MaterialPayload restirMaterialFromGBuffer(float3 albedo,
+                                                 float roughness) {
+  MaterialPayload material;
+  material.diffuseColor = max(albedo, float3(0.0f));
+  material.opacity = 1.0f;
+  material.specularColor = float3(0.04f);
+  material.shininess = 1.0f;
+  material.emissionColor = float3(0.0f);
+  material.emissionPower = 0.0f;
+  material.transmissionColor = float3(0.0f);
+  material.indexOfRefraction = 1.0f;
+  material.roughness = clamp(roughness, 0.0f, 1.0f);
+  material.pad0 = 0.0f;
+  material.diffuseTextureIndex = -1;
+  material.specularTextureIndex = -1;
+  material.normalTextureIndex = -1;
+  material.pad1 = 0;
+  return material;
 }
 
 inline void updateReservoir(thread RestirReservoir &reservoir,
@@ -283,7 +340,8 @@ inline bool isLightVisible(
     uint totalPrimitiveCount, device atomic_uint *primitiveRayStats);
 
 inline bool sampleDirectLightCandidate(
-    float3 hitPoint, float3 offsetNormal, float3 directLightingBsdf,
+    float3 hitPoint, float3 offsetNormal, float3 viewDir,
+    thread const MaterialPayload &material,
     int hitPrimitiveId, device const float4 *tlasNodes, uint tlasNodeCount,
     device const float4 *bvhNodes, device const float4 *primitives,
     device const float4 *materials, uint primitiveCount,
@@ -364,7 +422,8 @@ inline bool sampleDirectLightCandidate(
   MaterialPayload lightMaterial = decodeMaterial(lightMatIndex, materials, 1.0f);
   float3 lightRadiance =
       lightMaterial.emissionColor * lightMaterial.emissionPower;
-  float3 throughput = directLightingBsdf;
+  float3 throughput =
+      evaluateDirectLightingBsdf(material, offsetNormal, viewDir, wi);
   float geometryFactor = cosLight / max(dist2, RAY_EPS);
   candidate.radiance = throughput * lightRadiance * cosTheta;
   candidate.geometryFactor = geometryFactor;
@@ -1300,8 +1359,10 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
                             decodeMaterial(lightMatIndex, materials, 1.0f);
                         float3 lightRadiance = lightMaterial.emissionColor *
                                               lightMaterial.emissionPower;
-    float3 throughput =
-        absorption.xyz * directLightingBsdfFromAlbedo(diffuseColor);
+                        float3 viewDir = normalize(-r.direction);
+                        float3 bsdf = evaluateDirectLightingBsdf(
+                            material, offsetNormal, viewDir, wi);
+                        float3 throughput = absorption.xyz * bsdf;
                         float3 contribution =
                             throughput * lightRadiance * (cosTheta / totalPdf);
                         light.xyz += contribution;

--- a/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
@@ -38,6 +38,7 @@ inline bool reevaluateReservoirSample(
     float3 currentPosition,
     float3 currentNormal,
     float3 currentAlbedo,
+    float currentRoughness,
     constant UniformsData &uniforms,
     device const float4 *materials,
     device const float4 *tlasNodes,
@@ -110,7 +111,14 @@ inline bool reevaluateReservoirSample(
     MaterialPayload lightMaterial = decodeMaterial(lightMatIndex, materials, 1.0f);
     float3 lightRadiance =
         lightMaterial.emissionColor * lightMaterial.emissionPower;
-    float3 throughput = directLightingBsdfFromAlbedo(currentAlbedo);
+    MaterialPayload surfaceMaterial =
+        restirMaterialFromGBuffer(currentAlbedo, currentRoughness);
+    float3 viewDir = uniforms.cameraPosition - currentPosition;
+    if (dot(viewDir, viewDir) <= RAY_EPS) {
+        viewDir = normalUnit;
+    }
+    float3 throughput =
+        evaluateDirectLightingBsdf(surfaceMaterial, normalUnit, viewDir, wi);
     float3 radiance = throughput * lightRadiance * cosTheta;
     float geometryFactor = cosLight / max(dist2, RAY_EPS);
     float weight = restirTargetWeight(radiance, geometryFactor, totalPdf);
@@ -194,7 +202,9 @@ kernel void restirSpatialMain(
     RestirReservoir current = reservoirBuffer[index];
 
     float3 currentPosition = positionAccum.read(gid).xyz;
-    float3 currentNormal = normalAccum.read(gid).xyz;
+    float4 currentNormalSample = normalAccum.read(gid);
+    float3 currentNormal = currentNormalSample.xyz;
+    float currentRoughness = clamp(currentNormalSample.w, 0.0f, 1.0f);
     float3 currentAlbedo = albedoAccum.read(gid).xyz;
 
     if (!isFinite3(currentPosition) || !isFinite3(currentNormal) ||
@@ -261,6 +271,7 @@ kernel void restirSpatialMain(
         float candidateWeight = 0.0f;
         if (reevaluateReservoirSample(
                 neighbor, currentPosition, currentNormal, currentAlbedo,
+                currentRoughness,
                 uniforms, materials, tlasNodes, bvhNodes, primitives,
                 primitiveIndices, activeMask, instanceRecords, primitiveRemap,
                 primitiveRayStats, candidate, candidateWeight)) {

--- a/Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal
@@ -45,6 +45,7 @@ inline bool reevaluateReservoirSample(
     float3 currentPosition,
     float3 currentNormal,
     float3 currentAlbedo,
+    float currentRoughness,
     constant UniformsData &uniforms,
     device const float4 *materials,
     device const float4 *tlasNodes,
@@ -117,7 +118,14 @@ inline bool reevaluateReservoirSample(
     MaterialPayload lightMaterial = decodeMaterial(lightMatIndex, materials, 1.0f);
     float3 lightRadiance =
         lightMaterial.emissionColor * lightMaterial.emissionPower;
-    float3 throughput = directLightingBsdfFromAlbedo(currentAlbedo);
+    MaterialPayload surfaceMaterial =
+        restirMaterialFromGBuffer(currentAlbedo, currentRoughness);
+    float3 viewDir = uniforms.cameraPosition - currentPosition;
+    if (dot(viewDir, viewDir) <= RAY_EPS) {
+        viewDir = normalUnit;
+    }
+    float3 throughput =
+        evaluateDirectLightingBsdf(surfaceMaterial, normalUnit, viewDir, wi);
     float3 radiance = throughput * lightRadiance * cosTheta;
     float geometryFactor = cosLight / max(dist2, RAY_EPS);
     float weight = restirTargetWeight(radiance, geometryFactor, totalPdf);
@@ -205,7 +213,9 @@ kernel void restirTemporalMain(
     RestirReservoir current = currentReservoir[index];
 
     float3 currentPosition = positionAccum.read(gid).xyz;
-    float3 currentNormal = normalAccum.read(gid).xyz;
+    float4 currentNormalSample = normalAccum.read(gid);
+    float3 currentNormal = currentNormalSample.xyz;
+    float currentRoughness = clamp(currentNormalSample.w, 0.0f, 1.0f);
     float3 currentAlbedo = albedoAccum.read(gid).xyz;
 
     if (!isFinite3(currentPosition) || !isFinite3(currentNormal) ||
@@ -291,6 +301,7 @@ kernel void restirTemporalMain(
         float candidateWeight = 0.0f;
         if (reevaluateReservoirSample(
                 history, currentPosition, currentNormal, currentAlbedo,
+                currentRoughness,
                 uniforms, materials, tlasNodes, bvhNodes, primitives,
                 primitiveIndices, activeMask, instanceRecords, primitiveRemap,
                 primitiveRayStats, candidate, candidateWeight)) {


### PR DESCRIPTION
### Motivation
- Replace the simplistic albedo-based throughput used for ReSTIR and direct-light sampling with a view-dependent BSDF that accounts for diffuse, specular and roughness so candidate weighting and reuse reflect the true surface response.
- Ensure candidate sampling in `sampleDirectLightCandidate` and reuse / reevaluation helpers use the identical BSDF evaluation to avoid mismatch between sampling and scoring.
- Read normal-map and roughness information from the G-buffer so temporal/spatial reuse can evaluate a consistent material response even when only G-buffer data is available.

### Description
- Added a shared BSDF evaluation helper `evaluateDirectLightingBsdf` that implements a GGX-like microfacet specular term plus Lambertian diffuse and uses `MaterialPayload` inputs in `PathTracing.h` (new function and `restirMaterialFromGBuffer` helper).
- Changed `sampleDirectLightCandidate` signature to accept `viewDir` and the `MaterialPayload` and switched candidate throughput to call `evaluateDirectLightingBsdf` (in `PathTracing.h`).
- Updated the path tracing kernel (`PathTraceKernel.metal`) to compute `viewDir`, only sample candidates for materials with non-zero energy and pass the `material` + `viewDir` into `sampleDirectLightCandidate`, and to use the new BSDF when accumulating direct lighting for hard-sampled lights.
- Updated `RestirTemporal.metal` and `RestirSpatial.metal` to read roughness out of the packed `normalAccum` `.w` channel, reconstruct a lightweight `MaterialPayload` via `restirMaterialFromGBuffer`, compute a `viewDir` from the camera position, and evaluate the same `evaluateDirectLightingBsdf` when reevaluating reservoir samples so reuse scoring matches candidate sampling.

### Testing
- No automated tests or shader build/validation were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697780fdb870832daf66eadd998526c2)