### PR TITLE
Remove similarity weighting from ReSTIR spatial merge

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
@@ -258,12 +258,9 @@ kernel void restirSpatialMain(
 
         float normalWeight = max(dot(currentNormalUnit, normalize(neighborNormal)), 0.0f);
         float positionDelta = length(currentPosition - neighborPosition);
-        float positionWeight = 1.0f / (1.0f + positionDelta);
         float albedoDiff = length(currentAlbedo - neighborAlbedo);
-        float albedoWeight = 1.0f / (1.0f + albedoDiff * 4.0f);
-        float similarity = normalWeight * positionWeight * albedoWeight;
-
-        if (similarity <= 0.0f || !isfinite(similarity)) {
+        if (normalWeight <= 0.0f || !isfinite(positionDelta) ||
+            !isfinite(albedoDiff) || albedoDiff > 0.5f) {
             continue;
         }
 
@@ -276,8 +273,7 @@ kernel void restirSpatialMain(
                 primitiveIndices, activeMask, instanceRecords, primitiveRemap,
                 primitiveRayStats, candidate, candidateWeight)) {
             float xi = hashToFloat(seed);
-            mergeReservoir(current, candidate, candidateWeight * similarity,
-                           neighbor.m, xi);
+            mergeReservoir(current, candidate, candidateWeight, neighbor.m, xi);
         }
     }
 


### PR DESCRIPTION
### Motivation

- Simplify the spatial reuse weighting by removing the multiplicative `similarity` factor so candidate weights come solely from the re-evaluated target/pdf.
- Replace soft similarity scaling with hard validity checks to avoid unstable weighting while still rejecting dissimilar neighbors.

### Description

- Edited `Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal` to remove `positionWeight`, `albedoWeight`, and the combined `similarity` multiplier used when calling `mergeReservoir`.
- Added hard rejection checks that skip neighbors when `normalWeight <= 0.0`, when `positionDelta` or `albedoDiff` are non-finite, or when `albedoDiff > 0.5`.
- Updated the `mergeReservoir` invocation to pass `candidateWeight` directly instead of `candidateWeight * similarity`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977837ecba8832db086175ebb5ae53a)