### PR TITLE
Move mergeReservoir helper to shared PathTracing.h

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -54,6 +54,18 @@ struct LightSampleCandidate {
   float lightPdf = 0.0f;
 };
 
+struct RestirSampleData {
+  float3 radiance = float3(0.0f);
+  float3 wi = float3(0.0f);
+  float pdf = 0.0f;
+  float geometryFactor = 0.0f;
+  uint packedLightId = 0u;
+  float3 lightPosition = float3(0.0f);
+  float3 lightNormal = float3(0.0f);
+  float lightArea = 0.0f;
+  float lightPdf = 0.0f;
+};
+
 #include "Intersect.h"
 #include "Random.h"
 #include "Scatter.h"
@@ -223,6 +235,39 @@ inline float restirTargetContribution(thread const RestirReservoir &reservoir) {
 inline float restirTargetWeight(float3 radiance, float geometryFactor, float pdf) {
   float target = restirTargetContribution(radiance, geometryFactor);
   return target / max(pdf, RAY_EPS);
+}
+
+inline void mergeReservoir(thread RestirReservoir &current,
+                           thread const RestirSampleData &candidate,
+                           float weight, uint candidateM, float xi) {
+  // ReSTIR DI: M is the number of candidates that built the incoming reservoir.
+  // We scale the candidate's weight by M and add it to wSum, while M accumulates.
+  if (candidateM == 0u || weight <= 0.0f || !isfinite(weight)) {
+    return;
+  }
+  float scaledWeight = weight * float(candidateM);
+  if (scaledWeight <= 0.0f || !isfinite(scaledWeight)) {
+    return;
+  }
+  float currentWeight = max(current.wSum, 0.0f);
+  float totalWeight = currentWeight + scaledWeight;
+  if (totalWeight <= 0.0f || !isfinite(totalWeight)) {
+    return;
+  }
+  float candidateProb = scaledWeight / totalWeight;
+  if (xi < candidateProb) {
+    current.sampleRadiance = candidate.radiance;
+    current.wi = candidate.wi;
+    current.pdf = candidate.pdf;
+    current.geometryFactor = candidate.geometryFactor;
+    current.packedLightId = candidate.packedLightId;
+    current.lightPosition = candidate.lightPosition;
+    current.lightNormal = candidate.lightNormal;
+    current.lightArea = candidate.lightArea;
+    current.lightPdf = candidate.lightPdf;
+  }
+  current.wSum = totalWeight;
+  current.m += candidateM;
 }
 
 inline float3 evaluateDirectLightingBsdf(thread const MaterialPayload &material,

--- a/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal
@@ -21,18 +21,6 @@ inline bool isFinite3(float3 v) {
     return all(isfinite(v));
 }
 
-struct RestirSampleData {
-    float3 radiance = float3(0.0f);
-    float3 wi = float3(0.0f);
-    float pdf = 0.0f;
-    float geometryFactor = 0.0f;
-    uint packedLightId = 0u;
-    float3 lightPosition = float3(0.0f);
-    float3 lightNormal = float3(0.0f);
-    float lightArea = 0.0f;
-    float lightPdf = 0.0f;
-};
-
 inline bool reevaluateReservoirSample(
     thread const RestirReservoir &source,
     float3 currentPosition,
@@ -137,41 +125,6 @@ inline bool reevaluateReservoirSample(
     outSample.lightPdf = source.lightPdf;
     outWeight = weight;
     return true;
-}
-
-inline void mergeReservoir(thread RestirReservoir &current,
-                           thread const RestirSampleData &candidate,
-                           float weight,
-                           uint candidateM,
-                           float xi) {
-    // ReSTIR DI: M is the number of candidates that built the incoming reservoir.
-    // We scale the candidate's weight by M and add it to wSum, while M accumulates.
-    if (candidateM == 0u || weight <= 0.0f || !isfinite(weight)) {
-        return;
-    }
-    float scaledWeight = weight * float(candidateM);
-    if (scaledWeight <= 0.0f || !isfinite(scaledWeight)) {
-        return;
-    }
-    float currentWeight = max(current.wSum, 0.0f);
-    float totalWeight = currentWeight + scaledWeight;
-    if (totalWeight <= 0.0f || !isfinite(totalWeight)) {
-        return;
-    }
-    float candidateProb = scaledWeight / totalWeight;
-    if (xi < candidateProb) {
-        current.sampleRadiance = candidate.radiance;
-        current.wi = candidate.wi;
-        current.pdf = candidate.pdf;
-        current.geometryFactor = candidate.geometryFactor;
-        current.packedLightId = candidate.packedLightId;
-        current.lightPosition = candidate.lightPosition;
-        current.lightNormal = candidate.lightNormal;
-        current.lightArea = candidate.lightArea;
-        current.lightPdf = candidate.lightPdf;
-    }
-    current.wSum = totalWeight;
-    current.m += candidateM;
 }
 
 kernel void restirSpatialMain(

--- a/Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal
@@ -28,18 +28,6 @@ inline float depthFromClip(float4 clip) {
     return clip.z / clip.w;
 }
 
-struct RestirSampleData {
-    float3 radiance = float3(0.0f);
-    float3 wi = float3(0.0f);
-    float pdf = 0.0f;
-    float geometryFactor = 0.0f;
-    uint packedLightId = 0u;
-    float3 lightPosition = float3(0.0f);
-    float3 lightNormal = float3(0.0f);
-    float lightArea = 0.0f;
-    float lightPdf = 0.0f;
-};
-
 inline bool reevaluateReservoirSample(
     thread const RestirReservoir &source,
     float3 currentPosition,
@@ -144,41 +132,6 @@ inline bool reevaluateReservoirSample(
     outSample.lightPdf = source.lightPdf;
     outWeight = weight;
     return true;
-}
-
-inline void mergeReservoir(thread RestirReservoir &current,
-                           thread const RestirSampleData &candidate,
-                           float weight,
-                           uint candidateM,
-                           float xi) {
-    // ReSTIR DI: M is the number of candidates that built the incoming reservoir.
-    // We scale the candidate's weight by M and add it to wSum, while M accumulates.
-    if (candidateM == 0u || weight <= 0.0f || !isfinite(weight)) {
-        return;
-    }
-    float scaledWeight = weight * float(candidateM);
-    if (scaledWeight <= 0.0f || !isfinite(scaledWeight)) {
-        return;
-    }
-    float currentWeight = max(current.wSum, 0.0f);
-    float totalWeight = currentWeight + scaledWeight;
-    if (totalWeight <= 0.0f || !isfinite(totalWeight)) {
-        return;
-    }
-    float candidateProb = scaledWeight / totalWeight;
-    if (xi < candidateProb) {
-        current.sampleRadiance = candidate.radiance;
-        current.wi = candidate.wi;
-        current.pdf = candidate.pdf;
-        current.geometryFactor = candidate.geometryFactor;
-        current.packedLightId = candidate.packedLightId;
-        current.lightPosition = candidate.lightPosition;
-        current.lightNormal = candidate.lightNormal;
-        current.lightArea = candidate.lightArea;
-        current.lightPdf = candidate.lightPdf;
-    }
-    current.wSum = totalWeight;
-    current.m += candidateM;
 }
 
 kernel void restirTemporalMain(


### PR DESCRIPTION
### Motivation
- Two shader files contained duplicated implementations of `mergeReservoir` and a local `RestirSampleData` struct, risking drift and making maintenance harder.
- The `M` semantics and weight-scaling comments should be authoritative and shared across ReSTIR passes to ensure consistent behavior.

### Description
- Added the `RestirSampleData` struct to the shared header `Nomad Path Tracer/Renderer/Shaders/PathTracing.h` as `RestirSampleData`.
- Moved the inline helper `mergeReservoir(thread RestirReservoir &current, thread const RestirSampleData &candidate, float weight, uint candidateM, float xi)` (including the original `M`/weight scaling comments) into `PathTracing.h` as a shared inline function.
- Removed the duplicated `RestirSampleData` and `mergeReservoir` implementations from `Nomad Path Tracer/Renderer/Shaders/RestirSpatial.metal` and `Nomad Path Tracer/Renderer/Shaders/RestirTemporal.metal` so both passes use the shared helper via the existing `#include "PathTracing.h"`.
- Updated three shader files: `PathTracing.h`, `RestirSpatial.metal`, and `RestirTemporal.metal` to centralize the logic.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697785839d30832da137d524a4c1df07)