### PR TITLE
Guard ReSTIR usage when no light candidates are available

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -65,7 +65,8 @@ kernel void pathTraceKernel(
   float accumulatedRoughness = 0.0f;
   RestirReservoir reservoir = initReservoir();
   uint restirCandidateCount = max(u.restirCandidateCount, 1u);
-  bool useRestir = (u.restirEnabled != 0u);
+  bool useRestir = (u.restirEnabled != 0u) && (reservoirBuffer != nullptr) &&
+                   (u.lightCount > 0u) && (u.lightTotalWeight > 0.0f);
 
   float3 rayDx = u.rayDx;
   float3 rayDy = u.rayDy;


### PR DESCRIPTION
### Motivation
- Prevent black/glitchy output when ReSTIR is enabled but no valid reservoir or light sampling inputs exist (e.g. no emissive primitives or missing reservoir buffer).

### Description
- Gate ReSTIR usage in `Renderer/Shaders/PathTraceKernel.metal` by making `useRestir` require `reservoirBuffer != nullptr` and both `u.lightCount > 0u` and `u.lightTotalWeight > 0.0f`, so the shader falls back to regular path tracing when those conditions are not met.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69778942db18832da2e0ee0df9f7f592)