### PR TITLE
Add BVH chunk-table indirection to support resident chunk streaming

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -747,6 +747,22 @@ struct UniformsData {
   simd::float4x4 prevViewProjection{};
 };
 
+constexpr uint32_t kChunkResidentFlag = 1u;
+
+struct BVHNodeGPU {
+  simd::packed_float3 boundsMin;
+  int32_t leftFirst;
+  simd::packed_float3 boundsMax;
+  int32_t count;
+};
+
+struct ChunkEntry {
+  uint32_t chunkId;
+  uint32_t primitiveOffset;
+  uint32_t primitiveCount;
+  uint32_t flags;
+};
+
 struct TileDispatchRegion {
   uint32_t originX;
   uint32_t originY;
@@ -1552,6 +1568,8 @@ Renderer::~Renderer() {
     releaseTrackedResource(_pUniformsBuffer);
   if (_pBVHBuffer)
     releaseTrackedResource(_pBVHBuffer);
+  if (_pChunkTableBuffer)
+    releaseTrackedResource(_pChunkTableBuffer);
   if (_pPrimitiveIndexBuffer)
     releaseTrackedResource(_pPrimitiveIndexBuffer);
   if (_pTLASBuffer)
@@ -3092,12 +3110,12 @@ void Renderer::prewarmAlwaysResidentResources() {
       return;
     }
   } else {
-    if (!_pBVHBuffer || !_pSphereBuffer || !_pSphereMaterialBuffer ||
-        !_pUniformsBuffer || !_pTriangleVertexBuffer ||
-        !_pTriangleIndexBuffer || !_pPrimitiveIndexBuffer || !_pTLASBuffer ||
-        !_pActiveBuffer || !_pLightIndexBuffer || !_pLightCdfBuffer ||
-        !_pPrimitiveRemapBuffer || !_pPrimitiveHitBufferGPU ||
-        !_pInstanceBuffer) {
+    if (!_pBVHBuffer || !_pChunkTableBuffer || !_pSphereBuffer ||
+        !_pSphereMaterialBuffer || !_pUniformsBuffer ||
+        !_pTriangleVertexBuffer || !_pTriangleIndexBuffer ||
+        !_pPrimitiveIndexBuffer || !_pTLASBuffer || !_pActiveBuffer ||
+        !_pLightIndexBuffer || !_pLightCdfBuffer || !_pPrimitiveRemapBuffer ||
+        !_pPrimitiveHitBufferGPU || !_pInstanceBuffer) {
       trackFrameCommandBuffer(cmd);
       cmd->commit();
       return;
@@ -3142,6 +3160,7 @@ void Renderer::prewarmAlwaysResidentResources() {
     compute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
     compute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
     compute->setBuffer(_pInstanceBuffer, 0, 13);
+    compute->setBuffer(_pChunkTableBuffer, 0, 14);
   }
 
   compute->setTexture(colorTexture, 0);
@@ -5642,25 +5661,90 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
                          NS::Range::Make(0, primitiveIndexBytes));
     }
 
-    size_t blasFloat4Count = bvhSource->size();
+    size_t blasNodeCount = bvhSource->size() / 2;
+    std::vector<BVHNodeGPU> bvhUpload;
+    std::vector<ChunkEntry> chunkUpload;
+    bvhUpload.reserve(blasNodeCount);
+    chunkUpload.reserve(blasNodeCount);
+
+    auto decodeInt = [](float packed) -> int {
+      int value = 0;
+      std::memcpy(&value, &packed, sizeof(int));
+      return value;
+    };
+
+    for (size_t i = 0; i < blasNodeCount; ++i) {
+      const simd::float4 &minPacked = (*bvhSource)[2 * i + 0];
+      const simd::float4 &maxPacked = (*bvhSource)[2 * i + 1];
+      int leftFirst = decodeInt(minPacked.w);
+      int count = decodeInt(maxPacked.w);
+
+      BVHNodeGPU node{};
+      node.boundsMin =
+          simd::packed_float3{minPacked.x, minPacked.y, minPacked.z};
+      node.boundsMax =
+          simd::packed_float3{maxPacked.x, maxPacked.y, maxPacked.z};
+      if (count > 0) {
+        uint32_t chunkIndex = static_cast<uint32_t>(chunkUpload.size());
+        node.leftFirst = static_cast<int32_t>(chunkIndex);
+        node.count = count;
+        ChunkEntry entry{};
+        entry.chunkId = chunkIndex;
+        entry.primitiveOffset = static_cast<uint32_t>(leftFirst);
+        entry.primitiveCount = static_cast<uint32_t>(count);
+        entry.flags = kChunkResidentFlag;
+        chunkUpload.push_back(entry);
+      } else {
+        node.leftFirst = leftFirst;
+        node.count = count;
+      }
+      bvhUpload.push_back(node);
+    }
+
+    if (bvhUpload.empty()) {
+      BVHNodeGPU node{};
+      node.boundsMin = simd::packed_float3{0.0f, 0.0f, 0.0f};
+      node.boundsMax = simd::packed_float3{0.0f, 0.0f, 0.0f};
+      node.leftFirst = 0;
+      node.count = 0;
+      bvhUpload.push_back(node);
+    }
+    if (chunkUpload.empty()) {
+      ChunkEntry entry{};
+      entry.chunkId = 0;
+      entry.primitiveOffset = 0;
+      entry.primitiveCount = 0;
+      entry.flags = 0;
+      chunkUpload.push_back(entry);
+    }
+
     size_t bvhBytes =
-        std::max<size_t>(blasFloat4Count, size_t(1)) * sizeof(simd::float4);
+        std::max<size_t>(bvhUpload.size(), size_t(1)) * sizeof(BVHNodeGPU);
     ensureBufferCapacity(_pBVHBuffer, bvhBytes, _bvhBufferCapacity, allowShrink,
                          MTL::ResourceStorageModeManaged,
                          GpuMemoryTracker::Category::Geometry, "BLASNodes",
                          shrinkContext);
     if (_pBVHBuffer) {
-      simd::float4 *dst =
-          static_cast<simd::float4 *>(_pBVHBuffer->contents());
-      if (blasFloat4Count > 0)
-        std::memcpy(dst, bvhSource->data(),
-                    blasFloat4Count * sizeof(simd::float4));
-      else {
-        dst[0] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-        if (bvhBytes >= 2 * sizeof(simd::float4))
-          dst[1] = simd::float4{0.0f, 0.0f, 0.0f, 0.0f};
-      }
+      BVHNodeGPU *dst =
+          static_cast<BVHNodeGPU *>(_pBVHBuffer->contents());
+      std::memcpy(dst, bvhUpload.data(), bvhUpload.size() * sizeof(BVHNodeGPU));
       markBufferModified(_pBVHBuffer, NS::Range::Make(0, bvhBytes));
+    }
+
+    size_t chunkBytes = std::max<size_t>(chunkUpload.size(), size_t(1)) *
+                        sizeof(ChunkEntry);
+    ensureBufferCapacity(_pChunkTableBuffer, chunkBytes,
+                         _chunkTableBufferCapacity, allowShrink,
+                         MTL::ResourceStorageModeManaged,
+                         GpuMemoryTracker::Category::Geometry, "ChunkTable",
+                         shrinkContext);
+    if (_pChunkTableBuffer) {
+      ChunkEntry *dst =
+          static_cast<ChunkEntry *>(_pChunkTableBuffer->contents());
+      std::memcpy(dst, chunkUpload.data(),
+                  chunkUpload.size() * sizeof(ChunkEntry));
+      markBufferModified(_pChunkTableBuffer,
+                         NS::Range::Make(0, chunkBytes));
     }
 
     size_t tlasFloat4Count = tlasSource->size();
@@ -7393,10 +7477,10 @@ void Renderer::draw(MTK::View *pView) {
         pCompute->setBuffer(_pInstanceBuffer, 0, 10);
         pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
         pCompute->setBuffer(_pInstanceBuffer, 0, 13);
-      } else {
-        pCompute->setBuffer(_pBVHBuffer, 0, 0);
-        pCompute->setBuffer(_pSphereBuffer, 0, 1);
-        pCompute->setBuffer(_pSphereMaterialBuffer, 0, 2);
+    } else {
+      pCompute->setBuffer(_pBVHBuffer, 0, 0);
+      pCompute->setBuffer(_pSphereBuffer, 0, 1);
+      pCompute->setBuffer(_pSphereMaterialBuffer, 0, 2);
         pCompute->setBuffer(_pUniformsBuffer, 0, 3);
         pCompute->setBuffer(_pTriangleVertexBuffer, 0, 4);
         pCompute->setBuffer(_pTriangleIndexBuffer, 0, 5);
@@ -7404,11 +7488,12 @@ void Renderer::draw(MTK::View *pView) {
         pCompute->setBuffer(_pTLASBuffer, 0, 7);
         pCompute->setBuffer(_pActiveBuffer, 0, 8);
         pCompute->setBuffer(_pLightIndexBuffer, 0, 9);
-        pCompute->setBuffer(_pLightCdfBuffer, 0, 10);
-        pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
-        pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
-        pCompute->setBuffer(_pInstanceBuffer, 0, 13);
-      }
+      pCompute->setBuffer(_pLightCdfBuffer, 0, 10);
+      pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
+      pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
+      pCompute->setBuffer(_pInstanceBuffer, 0, 13);
+      pCompute->setBuffer(_pChunkTableBuffer, 0, 14);
+    }
 
       pCompute->setTexture(colorTexture, 0);
       pCompute->setTexture(albedoTexture, 1);

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -319,6 +319,7 @@ private:
   MTL::Buffer *_pTriangleIndexBuffer = nullptr;
   MTL::Buffer *_pUniformsBuffer = nullptr;
   MTL::Buffer *_pBVHBuffer = nullptr;
+  MTL::Buffer *_pChunkTableBuffer = nullptr;
   MTL::Buffer *_pPrimitiveIndexBuffer = nullptr;
   MTL::Buffer *_pTLASBuffer = nullptr;
   MTL::Buffer *_pActiveBuffer = nullptr;
@@ -671,6 +672,7 @@ private:
   size_t _triangleVertexBufferCapacity = 0;
   size_t _triangleIndexBufferCapacity = 0;
   size_t _bvhBufferCapacity = 0;
+  size_t _chunkTableBufferCapacity = 0;
   size_t _tlasBufferCapacity = 0;
   size_t _primitiveIndexBufferCapacity = 0;
   size_t _activeBufferCapacity = 0;

--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -5,7 +5,7 @@ using namespace metal;
 #include "PathTracing.h"
 
 kernel void pathTraceKernel(
-    device const float4 *bvhNodes [[buffer(0)]],
+    device const BVHNodeGPU *bvhNodes [[buffer(0)]],
     device const float4 *primitives [[buffer(1)]],
     device const float4 *materials [[buffer(2)]],
     device const UniformsData *uniforms [[buffer(3)]],
@@ -19,6 +19,7 @@ kernel void pathTraceKernel(
     device const uint *primitiveRemap [[buffer(11)]],
     device atomic_uint *primitiveRayStats [[buffer(12)]],
     device const InstanceRecord *instanceRecords [[buffer(13)]],
+    device const ChunkEntry *chunkTable [[buffer(14)]],
     texture2d<float, access::write> currentFrame [[texture(0)]],
     texture2d<float, access::write> albedoAccum [[texture(1)]],
     texture2d<float, access::write> normalAccum [[texture(2)]],
@@ -102,9 +103,9 @@ kernel void pathTraceKernel(
     r.minDistance = 0.0001f;
     r.maxDistance = INFINITY;
 
-    PathTraceSample sample = rayColor(
-        r, rayDx, rayDy, tlasNodes, u.tlasNodeCount, bvhNodes, primitives,
-        materials, u.primitiveCount, primitiveIndices, activeMask,
+  PathTraceSample sample = rayColor(
+        r, rayDx, rayDy, tlasNodes, u.tlasNodeCount, bvhNodes, chunkTable,
+        primitives, materials, u.primitiveCount, primitiveIndices, activeMask,
         instanceRecords, lightIndices, lightCdf, primitiveRemap,
         primitiveRayStats, seed, u.maxRayDepth, u.debugAS, u.blasNodeCount,
         u.lightCount, u.lightTotalWeight,

--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -11,6 +11,7 @@ using namespace metal;
 constant uint kMaterialFloat4Count = 5;
 constant uint kPrimitiveFloat4Count = 7;
 constant uint kMaxMaterialTextures = 64;
+constant uint kChunkResidentFlag = 1u;
 
 constant sampler kMaterialTextureSampler(address::repeat, filter::linear);
 
@@ -244,7 +245,8 @@ inline bool isLightVisible(
     float3 origin, float3 offsetNormal, float3 wi, float dist,
     uint lightPrimIndex, thread TlasLeafCache &bounceCache,
     device const float4 *tlasNodes, uint tlasNodeCount,
-    device const float4 *bvhNodes, device const float4 *primitives,
+    device const BVHNodeGPU *bvhNodes, device const ChunkEntry *chunkTable,
+    device const float4 *primitives,
     device const int *primitiveIndices, device const uchar *activeMask,
     device const InstanceRecord *instanceRecords,
     device const uint *primitiveRemap, uint primitiveCount,
@@ -254,7 +256,8 @@ inline bool sampleDirectLightCandidate(
     float3 hitPoint, float3 offsetNormal, float3 viewDir,
     thread const MaterialPayload &material,
     int hitPrimitiveId, device const float4 *tlasNodes, uint tlasNodeCount,
-    device const float4 *bvhNodes, device const float4 *primitives,
+    device const BVHNodeGPU *bvhNodes, device const ChunkEntry *chunkTable,
+    device const float4 *primitives,
     device const float4 *materials, uint primitiveCount,
     device const int *primitiveIndices, device const uchar *activeMask,
     device const InstanceRecord *instanceRecords,
@@ -319,9 +322,9 @@ inline bool sampleDirectLightCandidate(
 
   bool visible = isLightVisible(
       hitPoint, offsetNormal, wi, dist, lightPrimIndex, bounceCache, tlasNodes,
-      tlasNodeCount, bvhNodes, primitives, primitiveIndices, activeMask,
-      instanceRecords, primitiveRemap, primitiveCount, totalPrimitiveCount,
-      primitiveRayStats);
+      tlasNodeCount, bvhNodes, chunkTable, primitives, primitiveIndices,
+      activeMask, instanceRecords, primitiveRemap, primitiveCount,
+      totalPrimitiveCount, primitiveRayStats);
   if (!visible)
     return false;
 
@@ -351,7 +354,8 @@ inline bool sampleDirectLightCandidate(
 inline bool intersectAABB(thread const Ray &r, float3 bmin, float3 bmax,
                           float tMin, float tMax);
 inline intersection firstHitBVH(thread const Ray &r,
-                                device const float4 *bvhNodes,
+                                device const BVHNodeGPU *bvhNodes,
+                                device const ChunkEntry *chunkTable,
                                 device const float4 *primitives,
                                 device const int *primitiveIndices,
                                 device const uchar *activeMask,
@@ -362,7 +366,8 @@ inline intersection firstHitBVH(thread const Ray &r,
                                 int startNode);
 inline intersection firstHitTLAS(
     thread const Ray &r, device const float4 *tlasNodes, uint tlasNodeCount,
-    device const float4 *bvhNodes, device const float4 *primitives,
+    device const BVHNodeGPU *bvhNodes, device const ChunkEntry *chunkTable,
+    device const float4 *primitives,
     device const int *primitiveIndices, device const uchar *activeMask,
     device const InstanceRecord *instanceRecords,
     device const uint *primitiveRemap, uint residentPrimitiveCount,
@@ -373,7 +378,8 @@ inline bool isLightVisible(
     float3 origin, float3 offsetNormal, float3 wi, float dist,
     uint lightPrimIndex, thread TlasLeafCache &bounceCache,
     device const float4 *tlasNodes, uint tlasNodeCount,
-    device const float4 *bvhNodes, device const float4 *primitives,
+    device const BVHNodeGPU *bvhNodes, device const ChunkEntry *chunkTable,
+    device const float4 *primitives,
     device const int *primitiveIndices, device const uchar *activeMask,
     device const InstanceRecord *instanceRecords,
     device const uint *primitiveRemap, uint primitiveCount,
@@ -397,9 +403,9 @@ inline bool isLightVisible(
                       shadowRay.minDistance, shadowRay.maxDistance);
     if (intersectsCached && bounceCache.blasRootIndex >= 0) {
       intersection cachedHit =
-          firstHitBVH(shadowRay, bvhNodes, primitives, primitiveIndices,
-                      activeMask, primitiveRemap, primitiveCount,
-                      totalPrimitiveCount, primitiveRayStats,
+          firstHitBVH(shadowRay, bvhNodes, chunkTable, primitives,
+                      primitiveIndices, activeMask, primitiveRemap,
+                      primitiveCount, totalPrimitiveCount, primitiveRayStats,
                       bounceCache.blasRootIndex);
       if (cachedHit.primitiveId != -1 &&
           cachedHit.primitiveId != int(lightPrimIndex) &&
@@ -411,7 +417,7 @@ inline bool isLightVisible(
   }
   if (!usedCache) {
     shadowHit = firstHitTLAS(
-        shadowRay, tlasNodes, tlasNodeCount, bvhNodes, primitives,
+        shadowRay, tlasNodes, tlasNodeCount, bvhNodes, chunkTable, primitives,
         primitiveIndices, activeMask, instanceRecords, primitiveRemap,
         primitiveCount, totalPrimitiveCount, primitiveRayStats, nullptr);
   }
@@ -426,7 +432,8 @@ inline bool isLightVisible(
 
 inline bool isVisibleToLight(
     float3 hitPoint, float3 hitNormal, float3 lightPos,
-    device const float4 *bvhNodes, device const float4 *primitives,
+    device const BVHNodeGPU *bvhNodes, device const ChunkEntry *chunkTable,
+    device const float4 *primitives,
     device const int *primitiveIndices, device const uchar *activeMask,
     device const uint *primitiveRemap, uint residentPrimitiveCount,
     uint totalPrimitiveCount, device atomic_uint *primitiveRayStats,
@@ -441,10 +448,10 @@ inline bool isVisibleToLight(
   shadowRay.direction = dir / dist;
   shadowRay.minDistance = RAY_EPS;
   shadowRay.maxDistance = dist - RAY_EPS;
-  intersection shadowHit =
-      firstHitBVH(shadowRay, bvhNodes, primitives, primitiveIndices, activeMask,
-                  primitiveRemap, residentPrimitiveCount, totalPrimitiveCount,
-                  primitiveRayStats, startNode);
+  intersection shadowHit = firstHitBVH(
+      shadowRay, bvhNodes, chunkTable, primitives, primitiveIndices, activeMask,
+      primitiveRemap, residentPrimitiveCount, totalPrimitiveCount,
+      primitiveRayStats, startNode);
   return shadowHit.primitiveId == -1;
 }
 
@@ -537,7 +544,8 @@ inline bool intersectAABB(thread const Ray &r, float3 bmin, float3 bmax,
 
 // BVH traversal version of firstHit
 inline intersection firstHitBVH(thread const Ray &r,
-                                device const float4 *bvhNodes,
+                                device const BVHNodeGPU *bvhNodes,
+                                device const ChunkEntry *chunkTable,
                                 device const float4 *primitives,
                                 device const int *primitiveIndices,
                                 device const uchar *activeMask,
@@ -562,20 +570,27 @@ inline intersection firstHitBVH(thread const Ray &r,
   while (stackPtr > 0) {
     int nodeIdx = stack[--stackPtr];
 
-    float3 bmin = bvhNodes[2 * nodeIdx + 0].xyz;
-    float3 bmax = bvhNodes[2 * nodeIdx + 1].xyz;
-    int leftFirst = as_type<int>(bvhNodes[2 * nodeIdx + 0].w);
-    int second = as_type<int>(bvhNodes[2 * nodeIdx + 1].w);
+    BVHNodeGPU node = bvhNodes[nodeIdx];
+    float3 bmin = float3(node.boundsMin);
+    float3 bmax = float3(node.boundsMax);
+    int leftFirst = node.leftFirst;
+    int second = node.count;
 
     if (!intersectAABB(r, bmin, bmax, RAY_EPS, in.t))
       continue;
 
     if (second > 0) {
-      int count = second;
-      if (count <= 0 || leftFirst < 0)
+      if (!chunkTable || leftFirst < 0)
         continue;
-      for (int i = 0; i < count; ++i) {
-        int primIdx = primitiveIndices[leftFirst + i];
+      ChunkEntry entry = chunkTable[leftFirst];
+      if ((entry.flags & kChunkResidentFlag) == 0u)
+        continue;
+      uint primitiveOffset = entry.primitiveOffset;
+      uint primitiveCount = entry.primitiveCount;
+      if (primitiveCount == 0u)
+        continue;
+      for (uint i = 0; i < primitiveCount; ++i) {
+        int primIdx = primitiveIndices[primitiveOffset + i];
         if (primIdx < 0)
           continue;
 
@@ -829,7 +844,8 @@ inline intersection firstHitBVH(thread const Ray &r,
 
 inline intersection firstHitTLAS(
     thread const Ray &r, device const float4 *tlasNodes, uint tlasNodeCount,
-    device const float4 *bvhNodes, device const float4 *primitives,
+    device const BVHNodeGPU *bvhNodes, device const ChunkEntry *chunkTable,
+    device const float4 *primitives,
     device const int *primitiveIndices, device const uchar *activeMask,
     device const InstanceRecord *instanceRecords,
     device const uint *primitiveRemap, uint residentPrimitiveCount,
@@ -874,7 +890,7 @@ inline intersection firstHitTLAS(
         int blasRoot = record.blasRootIndex;
         if (blasRoot >= 0) {
           intersection hit = firstHitBVH(
-              r, bvhNodes, primitives, primitiveIndices, activeMask,
+              r, bvhNodes, chunkTable, primitives, primitiveIndices, activeMask,
               primitiveRemap, residentPrimitiveCount, totalPrimitiveCount,
               primitiveRayStats, blasRoot);
           if (hit.primitiveId != -1 && hit.t < bestHit.t) {
@@ -937,7 +953,9 @@ inline intersection firstHitTLAS(
 template <typename TextureArray>
 inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
                                 device const float4 *tlasNodes,
-                                uint tlasNodeCount, device const float4 *bvhNodes,
+                                uint tlasNodeCount,
+                                device const BVHNodeGPU *bvhNodes,
+                                device const ChunkEntry *chunkTable,
                                 device const float4 *primitives,
                                 device const float4 *materials,
                                 uint primitiveCount,
@@ -980,8 +998,9 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
     return sampleResult;
   } else if (debugAS == 2) {
     intersection bestHit = firstHitTLAS(
-        r, tlasNodes, tlasNodeCount, bvhNodes, primitives, primitiveIndices,
-        activeMask, instanceRecords, nullptr, 0u, 0u, nullptr, nullptr);
+        r, tlasNodes, tlasNodeCount, bvhNodes, chunkTable, primitives,
+        primitiveIndices, activeMask, instanceRecords, nullptr, 0u, 0u,
+        nullptr, nullptr);
     if (bestHit.primitiveId != -1) {
       float t = (blasNodeCount > 1)
                     ? float(bestHit.nodeIndex) / float(blasNodeCount - 1)
@@ -1008,8 +1027,9 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
     TlasLeafCache bounceCache;
     bounceCache.valid = false;
     intersection bestHit = firstHitTLAS(
-        r, tlasNodes, tlasNodeCount, bvhNodes, primitives, primitiveIndices,
-        activeMask, instanceRecords, primitiveRemap, primitiveCount,
+        r, tlasNodes, tlasNodeCount, bvhNodes, chunkTable, primitives,
+        primitiveIndices, activeMask, instanceRecords, primitiveRemap,
+        primitiveCount,
         totalPrimitiveCount, primitiveRayStats, &bounceCache);
 
     if (bestHit.primitiveId == -1) {
@@ -1067,9 +1087,9 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
               ? bounceCache.blasRootIndex
               : 0;
       bool visible = isVisibleToLight(
-          bestHit.point, hitNormal, debugLightPos, bvhNodes, primitives,
-          primitiveIndices, activeMask, primitiveRemap, primitiveCount,
-          totalPrimitiveCount, primitiveRayStats, rootIndex);
+          bestHit.point, hitNormal, debugLightPos, bvhNodes, chunkTable,
+          primitives, primitiveIndices, activeMask, primitiveRemap,
+          primitiveCount, totalPrimitiveCount, primitiveRayStats, rootIndex);
       sampleResult.radiance =
           visible ? float3(0.0f, 1.0f, 0.0f) : float3(1.0f, 0.0f, 0.0f);
       return sampleResult;
@@ -1235,9 +1255,10 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
                           shadowRay.maxDistance);
                       if (intersectsCached && bounceCache.blasRootIndex >= 0) {
                         intersection cachedHit = firstHitBVH(
-                            shadowRay, bvhNodes, primitives, primitiveIndices,
-                            activeMask, primitiveRemap, primitiveCount,
-                            totalPrimitiveCount, primitiveRayStats,
+                            shadowRay, bvhNodes, chunkTable, primitives,
+                            primitiveIndices, activeMask, primitiveRemap,
+                            primitiveCount, totalPrimitiveCount,
+                            primitiveRayStats,
                             bounceCache.blasRootIndex);
                         if (cachedHit.primitiveId != -1 &&
                             cachedHit.primitiveId != int(lightPrimIndex) &&
@@ -1250,7 +1271,7 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
                     if (!usedCache) {
                       shadowHit = firstHitTLAS(
                           shadowRay, tlasNodes, tlasNodeCount, bvhNodes,
-                          primitives, primitiveIndices, activeMask,
+                          chunkTable, primitives, primitiveIndices, activeMask,
                           instanceRecords, primitiveRemap, primitiveCount,
                           totalPrimitiveCount, primitiveRayStats, nullptr);
                     }

--- a/Nomad Path Tracer/Renderer/Shaders/Structs.h
+++ b/Nomad Path Tracer/Renderer/Shaders/Structs.h
@@ -35,6 +35,22 @@ struct InstanceRecord
     uint primitiveIndexBase;
 };
 
+struct BVHNodeGPU
+{
+    packed_float3 boundsMin;
+    int leftFirst;
+    packed_float3 boundsMax;
+    int count;
+};
+
+struct ChunkEntry
+{
+    uint chunkId;
+    uint primitiveOffset;
+    uint primitiveCount;
+    uint flags;
+};
+
 struct GeometryHandle
 {
     uint64_t vertexBufferAddress = 0;


### PR DESCRIPTION
### Motivation
- Introduce a small GPU-resident indirection table (chunk table) to map BLAS leaf IDs to resident chunk slots so leaf geometry can be streamed/evicted without rebuilding the whole BVH.
- Make the shader traversal cheaply detect non-resident leaves and return misses or sample fallbacks, enabling tile-based streaming and residency management.
- Prepare renderer-side wiring to upload BVH nodes in an explicit, safe format and to populate a compact chunk table that can be updated atomically for eviction/residency changes.

### Description
- Added GPU-side structs and flags: `BVHNodeGPU`, `ChunkEntry` and `kChunkResidentFlag` in shader headers and matching C++ types/constants in `Renderer.cpp`/`Structs.h` to represent an explicit node + chunk table layout.
- Changed shader traversal and helpers in `PathTracing.h` to take `device const BVHNodeGPU *bvhNodes` and `device const ChunkEntry *chunkTable`; `firstHitBVH`, `firstHitTLAS`, visibility helpers and light-sampling code now consult the chunk table for leaf ranges and skip non-resident chunks.
- Converted the BVH upload path in `Renderer::rebuildResidentResources` to decode the existing packed float4 BLAS layout into `BVHNodeGPU` entries and build a `chunkUpload` table for leaves, uploading both `_pBVHBuffer` and a new `_pChunkTableBuffer` (with capacity tracking `_chunkTableBufferCapacity`).
- Wired the new chunk table buffer into compute dispatches and the Metal kernel: `PathTraceKernel.metal` now accepts `device const BVHNodeGPU *bvhNodes` and `device const ChunkEntry *chunkTable` and `Renderer` binds the chunk table as buffer slot 14 for both prewarm and draw paths.
- Kept a safe fallback for empty uploads (ensure at least one node/entry is present) and preserved existing primitive remap/active mask/statistics handling.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69778df90b68832d9cdaa67e9b766b49)