### PR TITLE
Pack BVH node indices into float4 bounds for Metal ABI compatibility

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -750,11 +750,11 @@ struct UniformsData {
 constexpr uint32_t kChunkResidentFlag = 1u;
 
 struct BVHNodeGPU {
-  simd::packed_float3 boundsMin;
-  int32_t leftFirst;
-  simd::packed_float3 boundsMax;
-  int32_t count;
+  simd::float4 boundsMin;
+  simd::float4 boundsMax;
 };
+
+static_assert(sizeof(BVHNodeGPU) == 32, "BVHNodeGPU must stay 32 bytes.");
 
 struct ChunkEntry {
   uint32_t chunkId;
@@ -5672,6 +5672,11 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       std::memcpy(&value, &packed, sizeof(int));
       return value;
     };
+    auto encodeInt = [](int value) -> float {
+      float packed = 0.0f;
+      std::memcpy(&packed, &value, sizeof(int));
+      return packed;
+    };
 
     for (size_t i = 0; i < blasNodeCount; ++i) {
       const simd::float4 &minPacked = (*bvhSource)[2 * i + 0];
@@ -5680,33 +5685,27 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       int count = decodeInt(maxPacked.w);
 
       BVHNodeGPU node{};
-      node.boundsMin =
-          simd::packed_float3{minPacked.x, minPacked.y, minPacked.z};
-      node.boundsMax =
-          simd::packed_float3{maxPacked.x, maxPacked.y, maxPacked.z};
+      node.boundsMin = simd::float4{minPacked.x, minPacked.y, minPacked.z, 0.0f};
+      node.boundsMax = simd::float4{maxPacked.x, maxPacked.y, maxPacked.z, 0.0f};
       if (count > 0) {
         uint32_t chunkIndex = static_cast<uint32_t>(chunkUpload.size());
-        node.leftFirst = static_cast<int32_t>(chunkIndex);
-        node.count = count;
+        leftFirst = static_cast<int32_t>(chunkIndex);
         ChunkEntry entry{};
         entry.chunkId = chunkIndex;
         entry.primitiveOffset = static_cast<uint32_t>(leftFirst);
         entry.primitiveCount = static_cast<uint32_t>(count);
         entry.flags = kChunkResidentFlag;
         chunkUpload.push_back(entry);
-      } else {
-        node.leftFirst = leftFirst;
-        node.count = count;
       }
+      node.boundsMin.w = encodeInt(leftFirst);
+      node.boundsMax.w = encodeInt(count);
       bvhUpload.push_back(node);
     }
 
     if (bvhUpload.empty()) {
       BVHNodeGPU node{};
-      node.boundsMin = simd::packed_float3{0.0f, 0.0f, 0.0f};
-      node.boundsMax = simd::packed_float3{0.0f, 0.0f, 0.0f};
-      node.leftFirst = 0;
-      node.count = 0;
+      node.boundsMin = simd::float4{0.0f, 0.0f, 0.0f, encodeInt(0)};
+      node.boundsMax = simd::float4{0.0f, 0.0f, 0.0f, encodeInt(0)};
       bvhUpload.push_back(node);
     }
     if (chunkUpload.empty()) {

--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -573,8 +573,8 @@ inline intersection firstHitBVH(thread const Ray &r,
     BVHNodeGPU node = bvhNodes[nodeIdx];
     float3 bmin = float3(node.boundsMin);
     float3 bmax = float3(node.boundsMax);
-    int leftFirst = node.leftFirst;
-    int second = node.count;
+    int leftFirst = as_type<int>(node.boundsMin.w);
+    int second = as_type<int>(node.boundsMax.w);
 
     if (!intersectAABB(r, bmin, bmax, RAY_EPS, in.t))
       continue;

--- a/Nomad Path Tracer/Renderer/Shaders/Structs.h
+++ b/Nomad Path Tracer/Renderer/Shaders/Structs.h
@@ -37,10 +37,8 @@ struct InstanceRecord
 
 struct BVHNodeGPU
 {
-    packed_float3 boundsMin;
-    int leftFirst;
-    packed_float3 boundsMax;
-    int count;
+    float4 boundsMin;
+    float4 boundsMax;
 };
 
 struct ChunkEntry


### PR DESCRIPTION
### Motivation
- Ensure the CPU `BVHNodeGPU` struct matches the Metal shader layout so GPU buffer uploads remain ABI-compatible when `simd::packed_float3` is undesirable.

### Description
- Replaced `simd::packed_float3` fields in `BVHNodeGPU` with `simd::float4` bounds and added `static_assert(sizeof(BVHNodeGPU) == 32)` in `Renderer.cpp` to enforce the 32-byte layout.
- Pack `leftFirst` and `count` into the `.w` components of `boundsMin` and `boundsMax` respectively when building the BVH upload, adding an `encodeInt` helper and using the existing `decodeInt` helper for packing/unpacking in the CPU code (`Renderer.cpp`).
- Mirrored the layout change in the Metal headers by updating `Renderer/Shaders/Structs.h` to use `float4` for `BVHNodeGPU` and updated traversal to extract the indices with `as_type<int>(node.boundsMin.w)` / `as_type<int>(node.boundsMax.w)` in `Renderer/Shaders/PathTracing.h`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977920b8148832dbda6882f8bbf78d6)