### PR TITLE
Move ReSTIR helpers after Random/Scatter includes

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -54,6 +54,11 @@ struct LightSampleCandidate {
   float lightPdf = 0.0f;
 };
 
+#include "Intersect.h"
+#include "Random.h"
+#include "Scatter.h"
+#include "Structs.h"
+
 struct RestirReservoir {
   LightSampleCandidate sample;
   float3 selectedContribution = float3(0.0f);
@@ -100,11 +105,6 @@ inline void restirUpdateReservoir(thread RestirReservoir &reservoir,
     reservoir.valid = true;
   }
 }
-
-#include "Intersect.h"
-#include "Random.h"
-#include "Scatter.h"
-#include "Structs.h"
 
 template <typename T> inline void swap(thread T &a, thread T &b) {
   T tmp = a;


### PR DESCRIPTION
### Motivation
- Ensure functions like `luminance`, `randomFloat`, and `random` are declared before the ReSTIR helpers to avoid implicit forward-declaration and circular dependency issues while keeping the helpers visible to `rayColor`.

### Description
- Relocated the `RestirReservoir` struct and helper functions `restirWriteDefaults`, `restirContribution`, `restirWeightFromContribution`, and `restirUpdateReservoir` to appear after the `#include "Random.h"` and `#include "Scatter.h"` lines in `Renderer/Shaders/PathTracing.h`.
- Preserved the original include ordering and ensured callers such as `rayColor` and `buildRestirCandidateFromStored` retain visibility of the helpers without changing their implementations.
- No changes were made to the logic of the moved functions or their signatures.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69779bef3b2c832d87649d9c0053dbf7)