### PR TITLE
Validate ReSTIR temporal reuse with surface position/normal/depth history

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -560,6 +560,10 @@ double Renderer::residentTextureMemoryMB() const {
     addSlot(slot);
   for (const auto &slot : _restirData2Slots)
     addSlot(slot);
+  for (const auto &slot : _restirSurfacePosSlots)
+    addSlot(slot);
+  for (const auto &slot : _restirSurfaceNormalSlots)
+    addSlot(slot);
 
   for (MTL::Texture *texture : _materialTextures) {
     totalBytes += textureByteSize(texture);
@@ -1627,6 +1631,10 @@ Renderer::~Renderer() {
   for (auto &slot : _restirData1Slots)
     releaseTextureSlot(slot);
   for (auto &slot : _restirData2Slots)
+    releaseTextureSlot(slot);
+  for (auto &slot : _restirSurfacePosSlots)
+    releaseTextureSlot(slot);
+  for (auto &slot : _restirSurfaceNormalSlots)
     releaseTextureSlot(slot);
 
   if (_pTextureClearBuffer)
@@ -3089,12 +3097,20 @@ void Renderer::prewarmAlwaysResidentResources() {
       ensureSlotReady(_restirData1Slots[restirWriteIndex]);
   MTL::Texture *restirData2Write =
       ensureSlotReady(_restirData2Slots[restirWriteIndex]);
+  MTL::Texture *restirSurfacePosWrite =
+      ensureSlotReady(_restirSurfacePosSlots[restirWriteIndex]);
+  MTL::Texture *restirSurfaceNormalWrite =
+      ensureSlotReady(_restirSurfaceNormalSlots[restirWriteIndex]);
   MTL::Texture *restirData0Read =
       ensureSlotReady(_restirData0Slots[restirReadIndex]);
   MTL::Texture *restirData1Read =
       ensureSlotReady(_restirData1Slots[restirReadIndex]);
   MTL::Texture *restirData2Read =
       ensureSlotReady(_restirData2Slots[restirReadIndex]);
+  MTL::Texture *restirSurfacePosRead =
+      ensureSlotReady(_restirSurfacePosSlots[restirReadIndex]);
+  MTL::Texture *restirSurfaceNormalRead =
+      ensureSlotReady(_restirSurfaceNormalSlots[restirReadIndex]);
 
   if (blit)
     blit->endEncoding();
@@ -3102,7 +3118,9 @@ void Renderer::prewarmAlwaysResidentResources() {
   bool haveAllTextures =
       colorTexture && albedoTexture && normalTexture && positionTexture &&
       restirData0Write && restirData1Write && restirData2Write &&
-      restirData0Read && restirData1Read && restirData2Read;
+      restirSurfacePosWrite && restirSurfaceNormalWrite && restirData0Read &&
+      restirData1Read && restirData2Read && restirSurfacePosRead &&
+      restirSurfaceNormalRead;
 
   bool useAccelerationStructureLayout =
       _useAccelerationStructureBindings && _pTlasStructure &&
@@ -3186,15 +3204,19 @@ void Renderer::prewarmAlwaysResidentResources() {
   compute->setTexture(restirData0Read, 7);
   compute->setTexture(restirData1Read, 8);
   compute->setTexture(restirData2Read, 9);
+  compute->setTexture(restirSurfacePosWrite, 10);
+  compute->setTexture(restirSurfaceNormalWrite, 11);
+  compute->setTexture(restirSurfacePosRead, 12);
+  compute->setTexture(restirSurfaceNormalRead, 13);
 
   for (uint32_t texIdx = 0; texIdx < kMaxMaterialTextureSlots; ++texIdx) {
     MTL::Texture *materialTex =
         (texIdx < _materialTextures.size()) ? _materialTextures[texIdx]
                                             : nullptr;
-    compute->setTexture(materialTex, 13 + texIdx);
+    compute->setTexture(materialTex, 14 + texIdx);
   }
 
-  compute->setTexture(_environmentTexture, 13 + kMaxMaterialTextureSlots);
+  compute->setTexture(_environmentTexture, 14 + kMaxMaterialTextureSlots);
   if (_environmentSampler)
     compute->setSamplerState(_environmentSampler, 0);
 
@@ -6333,6 +6355,14 @@ const char *Renderer::textureSlotLabel(const ManagedTextureSlot &slot) const {
     return "_restirData2Slot0";
   if (&slot == &_restirData2Slots[1])
     return "_restirData2Slot1";
+  if (&slot == &_restirSurfacePosSlots[0])
+    return "_restirSurfacePosSlot0";
+  if (&slot == &_restirSurfacePosSlots[1])
+    return "_restirSurfacePosSlot1";
+  if (&slot == &_restirSurfaceNormalSlots[0])
+    return "_restirSurfaceNormalSlot0";
+  if (&slot == &_restirSurfaceNormalSlots[1])
+    return "_restirSurfaceNormalSlot1";
   return "<unknown texture slot>";
 }
 
@@ -6418,6 +6448,10 @@ void Renderer::disableHistoryForMemoryCap() {
   for (auto &slot : _restirData1Slots)
     disableSlot(slot);
   for (auto &slot : _restirData2Slots)
+    disableSlot(slot);
+  for (auto &slot : _restirSurfacePosSlots)
+    disableSlot(slot);
+  for (auto &slot : _restirSurfaceNormalSlots)
     disableSlot(slot);
 }
 
@@ -6532,6 +6566,10 @@ void Renderer::updateTextureResidency(MTL::CommandBuffer *cmd) {
   for (auto &slot : _restirData1Slots)
     slots.push_back(&slot);
   for (auto &slot : _restirData2Slots)
+    slots.push_back(&slot);
+  for (auto &slot : _restirSurfacePosSlots)
+    slots.push_back(&slot);
+  for (auto &slot : _restirSurfaceNormalSlots)
     slots.push_back(&slot);
 
   struct ResidencyCandidate {
@@ -6912,6 +6950,10 @@ void Renderer::buildTextures() {
                          MTL::PixelFormat::PixelFormatRGBA32Float, usage);
     configureTextureSlot(_restirData2Slots[i], width, height,
                          MTL::PixelFormat::PixelFormatRGBA32Float, usage);
+    configureTextureSlot(_restirSurfacePosSlots[i], width, height,
+                         MTL::PixelFormat::PixelFormatRGBA32Float, usage);
+    configureTextureSlot(_restirSurfaceNormalSlots[i], width, height,
+                         MTL::PixelFormat::PixelFormatRGBA32Float, usage);
   }
 
 }
@@ -7222,9 +7264,17 @@ void Renderer::draw(MTK::View *pView) {
   MTL::Texture *restirData0Write = _restirData0Slots[restirWriteIndex].texture;
   MTL::Texture *restirData1Write = _restirData1Slots[restirWriteIndex].texture;
   MTL::Texture *restirData2Write = _restirData2Slots[restirWriteIndex].texture;
+  MTL::Texture *restirSurfacePosWrite =
+      _restirSurfacePosSlots[restirWriteIndex].texture;
+  MTL::Texture *restirSurfaceNormalWrite =
+      _restirSurfaceNormalSlots[restirWriteIndex].texture;
   MTL::Texture *restirData0Read = _restirData0Slots[restirReadIndex].texture;
   MTL::Texture *restirData1Read = _restirData1Slots[restirReadIndex].texture;
   MTL::Texture *restirData2Read = _restirData2Slots[restirReadIndex].texture;
+  MTL::Texture *restirSurfacePosRead =
+      _restirSurfacePosSlots[restirReadIndex].texture;
+  MTL::Texture *restirSurfaceNormalRead =
+      _restirSurfaceNormalSlots[restirReadIndex].texture;
   if (allowResidency) {
     colorTexture = requestResidentTexture(_colorSlot, prepCmd, restoreBlit);
     albedoTexture = requestResidentTexture(_albedoSlot, prepCmd, restoreBlit);
@@ -7237,12 +7287,24 @@ void Renderer::draw(MTK::View *pView) {
                                               prepCmd, restoreBlit);
     restirData2Write = requestResidentTexture(_restirData2Slots[restirWriteIndex],
                                               prepCmd, restoreBlit);
+    restirSurfacePosWrite =
+        requestResidentTexture(_restirSurfacePosSlots[restirWriteIndex],
+                               prepCmd, restoreBlit);
+    restirSurfaceNormalWrite =
+        requestResidentTexture(_restirSurfaceNormalSlots[restirWriteIndex],
+                               prepCmd, restoreBlit);
     restirData0Read = requestResidentTexture(_restirData0Slots[restirReadIndex],
                                              prepCmd, restoreBlit);
     restirData1Read = requestResidentTexture(_restirData1Slots[restirReadIndex],
                                              prepCmd, restoreBlit);
     restirData2Read = requestResidentTexture(_restirData2Slots[restirReadIndex],
                                              prepCmd, restoreBlit);
+    restirSurfacePosRead =
+        requestResidentTexture(_restirSurfacePosSlots[restirReadIndex],
+                               prepCmd, restoreBlit);
+    restirSurfaceNormalRead =
+        requestResidentTexture(_restirSurfaceNormalSlots[restirReadIndex],
+                               prepCmd, restoreBlit);
   }
 
   auto ensureSlotReady = [&](ManagedTextureSlot &slot, MTL::Texture *&handle) {
@@ -7262,9 +7324,16 @@ void Renderer::draw(MTK::View *pView) {
   ensureSlotReady(_restirData0Slots[restirWriteIndex], restirData0Write);
   ensureSlotReady(_restirData1Slots[restirWriteIndex], restirData1Write);
   ensureSlotReady(_restirData2Slots[restirWriteIndex], restirData2Write);
+  ensureSlotReady(_restirSurfacePosSlots[restirWriteIndex],
+                  restirSurfacePosWrite);
+  ensureSlotReady(_restirSurfaceNormalSlots[restirWriteIndex],
+                  restirSurfaceNormalWrite);
   ensureSlotReady(_restirData0Slots[restirReadIndex], restirData0Read);
   ensureSlotReady(_restirData1Slots[restirReadIndex], restirData1Read);
   ensureSlotReady(_restirData2Slots[restirReadIndex], restirData2Read);
+  ensureSlotReady(_restirSurfacePosSlots[restirReadIndex], restirSurfacePosRead);
+  ensureSlotReady(_restirSurfaceNormalSlots[restirReadIndex],
+                  restirSurfaceNormalRead);
 
   auto markSlotUsed = [&](ManagedTextureSlot &slot, MTL::Texture *handle) {
     if (handle)
@@ -7278,9 +7347,15 @@ void Renderer::draw(MTK::View *pView) {
   markSlotUsed(_restirData0Slots[restirWriteIndex], restirData0Write);
   markSlotUsed(_restirData1Slots[restirWriteIndex], restirData1Write);
   markSlotUsed(_restirData2Slots[restirWriteIndex], restirData2Write);
+  markSlotUsed(_restirSurfacePosSlots[restirWriteIndex], restirSurfacePosWrite);
+  markSlotUsed(_restirSurfaceNormalSlots[restirWriteIndex],
+               restirSurfaceNormalWrite);
   markSlotUsed(_restirData0Slots[restirReadIndex], restirData0Read);
   markSlotUsed(_restirData1Slots[restirReadIndex], restirData1Read);
   markSlotUsed(_restirData2Slots[restirReadIndex], restirData2Read);
+  markSlotUsed(_restirSurfacePosSlots[restirReadIndex], restirSurfacePosRead);
+  markSlotUsed(_restirSurfaceNormalSlots[restirReadIndex],
+               restirSurfaceNormalRead);
 
   if (restoreBlit)
     restoreBlit->endEncoding();
@@ -7288,7 +7363,9 @@ void Renderer::draw(MTK::View *pView) {
   bool haveAllTextures =
       colorTexture && albedoTexture && normalTexture && positionTexture &&
       restirData0Write && restirData1Write && restirData2Write &&
-      restirData0Read && restirData1Read && restirData2Read;
+      restirSurfacePosWrite && restirSurfaceNormalWrite && restirData0Read &&
+      restirData1Read && restirData2Read && restirSurfacePosRead &&
+      restirSurfaceNormalRead;
 
   prepCmd->commit();
 
@@ -7528,16 +7605,20 @@ void Renderer::draw(MTK::View *pView) {
       pCompute->setTexture(restirData0Read, 7);
       pCompute->setTexture(restirData1Read, 8);
       pCompute->setTexture(restirData2Read, 9);
+      pCompute->setTexture(restirSurfacePosWrite, 10);
+      pCompute->setTexture(restirSurfaceNormalWrite, 11);
+      pCompute->setTexture(restirSurfacePosRead, 12);
+      pCompute->setTexture(restirSurfaceNormalRead, 13);
 
       for (uint32_t texIdx = 0; texIdx < kMaxMaterialTextureSlots; ++texIdx) {
         MTL::Texture *materialTex =
             (texIdx < _materialTextures.size()) ? _materialTextures[texIdx]
                                                 : nullptr;
-        pCompute->setTexture(materialTex, 13 + texIdx);
+        pCompute->setTexture(materialTex, 14 + texIdx);
       }
 
       pCompute->setTexture(_environmentTexture,
-                            13 + kMaxMaterialTextureSlots);
+                            14 + kMaxMaterialTextureSlots);
       if (_environmentSampler)
         pCompute->setSamplerState(_environmentSampler, 0);
 

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -391,6 +391,8 @@ private:
   std::array<ManagedTextureSlot, 2> _restirData0Slots;
   std::array<ManagedTextureSlot, 2> _restirData1Slots;
   std::array<ManagedTextureSlot, 2> _restirData2Slots;
+  std::array<ManagedTextureSlot, 2> _restirSurfacePosSlots;
+  std::array<ManagedTextureSlot, 2> _restirSurfaceNormalSlots;
 
   struct PendingBlasBuild {
     Renderer *renderer = nullptr;

--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -29,10 +29,14 @@ kernel void pathTraceKernel(
     texture2d<float, access::read> restirData0Prev [[texture(7)]],
     texture2d<float, access::read> restirData1Prev [[texture(8)]],
     texture2d<float, access::read> restirData2Prev [[texture(9)]],
+    texture2d<float, access::write> restirSurfacePosOut [[texture(10)]],
+    texture2d<float, access::write> restirSurfaceNormalOut [[texture(11)]],
+    texture2d<float, access::read> restirSurfacePosPrev [[texture(12)]],
+    texture2d<float, access::read> restirSurfaceNormalPrev [[texture(13)]],
     array<texture2d<float, access::sample>, kMaxMaterialTextures>
-        materialTextures [[texture(13)]],
+        materialTextures [[texture(14)]],
     texture2d<float, access::sample> environmentMap
-        [[texture(13 + kMaxMaterialTextures)]],
+        [[texture(14 + kMaxMaterialTextures)]],
     sampler environmentSampler [[sampler(0)]],
     constant TileRegion &tile [[buffer(16)]],
     uint2 gid [[thread_position_in_grid]]) {
@@ -119,9 +123,10 @@ kernel void pathTraceKernel(
         u.textureCount, environmentMap, environmentSampler,
         u.environmentMapEnabled, u.environmentMapIntensity, pixel,
         restirData0Out, restirData1Out, restirData2Out, restirData0Prev,
-        restirData1Prev, restirData2Prev, u.restirEnabled,
-        u.restirCandidateCount, u.restirTemporalReuse, u.prevViewProjection,
-        u.cameraMotionMetric, restirWriteEnabled);
+        restirData1Prev, restirData2Prev, restirSurfacePosOut,
+        restirSurfaceNormalOut, restirSurfacePosPrev, restirSurfaceNormalPrev,
+        u.restirEnabled, u.restirCandidateCount, u.restirTemporalReuse,
+        u.prevViewProjection, u.cameraMotionMetric, restirWriteEnabled);
     accumulatedColor += sample.radiance;
     accumulatedAlbedo += sample.albedo;
     accumulatedNormal += sample.normal;

--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -77,6 +77,13 @@ inline void restirWriteDefaults(texture2d<float, access::write> out0,
   out2.write(float4(0.0f), pixel);
 }
 
+inline void restirWriteSurfaceDefaults(
+    texture2d<float, access::write> outSurfacePos,
+    texture2d<float, access::write> outSurfaceNormal, uint2 pixel) {
+  outSurfacePos.write(float4(0.0f), pixel);
+  outSurfaceNormal.write(float4(0.0f), pixel);
+}
+
 inline float3 restirContribution(thread const LightSampleCandidate &candidate) {
   if (candidate.pdf <= 0.0f)
     return float3(0.0f);
@@ -1081,6 +1088,12 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
                                 texture2d<float, access::read> restirData0Prev,
                                 texture2d<float, access::read> restirData1Prev,
                                 texture2d<float, access::read> restirData2Prev,
+                                texture2d<float, access::write> restirSurfacePosOut,
+                                texture2d<float, access::write>
+                                    restirSurfaceNormalOut,
+                                texture2d<float, access::read> restirSurfacePosPrev,
+                                texture2d<float, access::read>
+                                    restirSurfaceNormalPrev,
                                 uint restirEnabled, uint restirCandidateCount,
                                 uint restirTemporalReuse,
                                 float4x4 prevViewProjection,
@@ -1107,12 +1120,16 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
         if (restirWriteEnabled) {
           restirWriteDefaults(restirData0Out, restirData1Out, restirData2Out,
                               pixel);
+          restirWriteSurfaceDefaults(restirSurfacePosOut,
+                                     restirSurfaceNormalOut, pixel);
         }
         return sampleResult;
       }
     }
     if (restirWriteEnabled) {
       restirWriteDefaults(restirData0Out, restirData1Out, restirData2Out, pixel);
+      restirWriteSurfaceDefaults(restirSurfacePosOut, restirSurfaceNormalOut,
+                                 pixel);
     }
     return sampleResult;
   } else if (debugAS == 2) {
@@ -1127,11 +1144,15 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
       if (restirWriteEnabled) {
         restirWriteDefaults(restirData0Out, restirData1Out, restirData2Out,
                             pixel);
+        restirWriteSurfaceDefaults(restirSurfacePosOut, restirSurfaceNormalOut,
+                                   pixel);
       }
       return sampleResult;
     }
     if (restirWriteEnabled) {
       restirWriteDefaults(restirData0Out, restirData1Out, restirData2Out, pixel);
+      restirWriteSurfaceDefaults(restirSurfacePosOut, restirSurfaceNormalOut,
+                                 pixel);
     }
     return sampleResult;
   }
@@ -1219,6 +1240,8 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
       if (restirWriteEnabled) {
         restirWriteDefaults(restirData0Out, restirData1Out, restirData2Out,
                             pixel);
+        restirWriteSurfaceDefaults(restirSurfacePosOut, restirSurfaceNormalOut,
+                                   pixel);
       }
       return sampleResult;
     }
@@ -1334,6 +1357,16 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
       if (useRestir) {
         RestirReservoir reservoir;
         float3 viewDir = normalize(-r.direction);
+        float restirSurfaceDepth = 0.0f;
+        float3 restirSurfacePosition = float3(0.0f);
+        float3 restirSurfaceNormal = float3(0.0f);
+        bool restirSurfaceValid =
+            (depth == 0 && bestHit.primitiveId != -1);
+        if (restirSurfaceValid) {
+          restirSurfacePosition = bestHit.point;
+          restirSurfaceNormal = offsetNormal;
+          restirSurfaceDepth = length(bestHit.point - r.origin);
+        }
 
         uint candidateCount = max(restirCandidateCount, 1u);
         for (uint candidateIdx = 0; candidateIdx < candidateCount;
@@ -1370,33 +1403,62 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
                 uint prevY =
                     min(uint(prevUv.y * float(prevHeight)), prevHeight - 1);
                 uint2 prevPixel = uint2(prevX, prevY);
-                float4 prev0 = restirData0Prev.read(prevPixel);
-                float4 prev1 = restirData1Prev.read(prevPixel);
-                float4 prev2 = restirData2Prev.read(prevPixel);
-                float prevWeightSum = prev2.y;
-                float prevSampleCount = prev2.z;
-                float prevSelectedWeight = prev2.w;
-                if (prevWeightSum > 0.0f && prevSampleCount > 0.0f &&
-                    prevSelectedWeight > 0.0f) {
-                  uint prevLightId =
-                      static_cast<uint>(max(prev0.w, 0.0f));
-                  LightSampleCandidate temporalCandidate;
-                  if (buildRestirCandidateFromStored(
-                          bestHit.point, offsetNormal, viewDir, material,
-                          absorption.xyz, bestHit.primitiveId, prevLightId,
-                          prev0.xyz, prev1.xyz, prev1.w, prev2.x, tlasNodes,
-                          tlasNodeCount, bvhNodes, primitives, materials,
-                          primitiveCount, primitiveIndices, activeMask,
-                          instanceRecords, primitiveRemap, primitiveRayStats,
-                          bounceCache, totalPrimitiveCount,
-                          temporalCandidate)) {
-                    float3 contribution = restirContribution(temporalCandidate);
-                    float weight = restirWeightFromContribution(contribution);
-                    float temporalWeight =
-                        prevWeightSum * (weight / prevSelectedWeight);
-                    restirUpdateReservoir(reservoir, temporalCandidate,
-                                          contribution, temporalWeight,
-                                          prevSampleCount, seed);
+                float4 prevSurfacePos =
+                    restirSurfacePosPrev.read(prevPixel);
+                float4 prevSurfaceNormal =
+                    restirSurfaceNormalPrev.read(prevPixel);
+                float prevDepth = prevSurfacePos.w;
+                float prevNormalLen2 =
+                    dot(prevSurfaceNormal.xyz, prevSurfaceNormal.xyz);
+                float currentDepth = length(bestHit.point - r.origin);
+                float positionThreshold =
+                    max(0.01f * currentDepth, 0.02f);
+                float depthThreshold = max(0.02f * currentDepth, 0.05f);
+                float normalThreshold = 0.9f;
+                bool temporalSurfaceValid = false;
+                if (prevDepth > 0.0f && prevNormalLen2 > RAY_EPS) {
+                  float positionDelta =
+                      length(prevSurfacePos.xyz - bestHit.point);
+                  float depthDelta = abs(prevDepth - currentDepth);
+                  float3 prevNormal = normalize(prevSurfaceNormal.xyz);
+                  float3 currentNormal = normalize(offsetNormal);
+                  float normalDot = dot(prevNormal, currentNormal);
+                  temporalSurfaceValid =
+                      positionDelta <= positionThreshold &&
+                      depthDelta <= depthThreshold &&
+                      normalDot >= normalThreshold;
+                }
+                if (temporalSurfaceValid) {
+                  float4 prev0 = restirData0Prev.read(prevPixel);
+                  float4 prev1 = restirData1Prev.read(prevPixel);
+                  float4 prev2 = restirData2Prev.read(prevPixel);
+                  float prevWeightSum = prev2.y;
+                  float prevSampleCount = prev2.z;
+                  float prevSelectedWeight = prev2.w;
+                  if (prevWeightSum > 0.0f && prevSampleCount > 0.0f &&
+                      prevSelectedWeight > 0.0f) {
+                    uint prevLightId =
+                        static_cast<uint>(max(prev0.w, 0.0f));
+                    LightSampleCandidate temporalCandidate;
+                    if (buildRestirCandidateFromStored(
+                            bestHit.point, offsetNormal, viewDir, material,
+                            absorption.xyz, bestHit.primitiveId, prevLightId,
+                            prev0.xyz, prev1.xyz, prev1.w, prev2.x, tlasNodes,
+                            tlasNodeCount, bvhNodes, primitives, materials,
+                            primitiveCount, primitiveIndices, activeMask,
+                            instanceRecords, primitiveRemap, primitiveRayStats,
+                            bounceCache, totalPrimitiveCount,
+                            temporalCandidate)) {
+                      float3 contribution =
+                          restirContribution(temporalCandidate);
+                      float weight =
+                          restirWeightFromContribution(contribution);
+                      float temporalWeight =
+                          prevWeightSum * (weight / prevSelectedWeight);
+                      restirUpdateReservoir(reservoir, temporalCandidate,
+                                            contribution, temporalWeight,
+                                            prevSampleCount, seed);
+                    }
                   }
                 }
               }
@@ -1426,12 +1488,20 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
                 float4(reservoir.sample.lightPdf, reservoir.weightSum,
                        reservoir.sampleCount, reservoir.selectedWeight),
                 pixel);
-            restirOutputWritten = true;
           } else {
             restirWriteDefaults(restirData0Out, restirData1Out, restirData2Out,
                                 pixel);
-            restirOutputWritten = true;
           }
+          if (restirSurfaceValid) {
+            restirSurfacePosOut.write(
+                float4(restirSurfacePosition, restirSurfaceDepth), pixel);
+            restirSurfaceNormalOut.write(
+                float4(restirSurfaceNormal, 0.0f), pixel);
+          } else {
+            restirWriteSurfaceDefaults(restirSurfacePosOut,
+                                       restirSurfaceNormalOut, pixel);
+          }
+          restirOutputWritten = true;
         }
       } else {
         float lightXi = randomFloat(seed);
@@ -1565,6 +1635,8 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
 
   if (restirWriteEnabled && !restirOutputWritten) {
     restirWriteDefaults(restirData0Out, restirData1Out, restirData2Out, pixel);
+    restirWriteSurfaceDefaults(restirSurfacePosOut, restirSurfaceNormalOut,
+                               pixel);
   }
 
   sampleResult.radiance = clamp(light.xyz, 0.0, 1.0);


### PR DESCRIPTION
### Motivation
- Reduce ReSTIR temporal reuse artifacts by rejecting reprojected previous samples when the stored surface does not match the current hit (disocclusion / normal mismatch). 
- Preserve existing ReSTIR reservoir outputs while adding a light-weight surface history to gate temporal candidates before rebuilding a temporal candidate.

### Description
- Added surface-history helper `restirWriteSurfaceDefaults` and surface history reads/writes in `PathTracing.h` to store per-pixel surface position (xyz) + depth (w) and normal (xyz).
- During the ReSTIR temporal reuse path (the `restirTemporalReuse > 0 && cameraMotionMetric < 10.0f` block) the code now reprojects the previous pixel, reads the previous surface position/normal/depth and compares them to the current `bestHit.point` / `offsetNormal` using configurable thresholds (position threshold = `max(0.01 * depth, 0.02)`, depth threshold = `max(0.02 * depth, 0.05)`, normal dot threshold = `0.9`), and only accepts prev-data when deltas are within those bounds before calling `buildRestirCandidateFromStored`.
- Added new kernel bindings to `PathTraceKernel.metal` and shifted downstream material/environment texture indices to accommodate the new textures, and threaded the new textures through the `rayColor` call.
- Extended the renderer to manage two new `ManagedTextureSlot` arrays `_restirSurfacePosSlots` and `_restirSurfaceNormalSlots`, updated texture allocation/configuration, residency/ensure/mark logic, compute binding indices, and wrote/read the surface history together with ReSTIR reservoir outputs.

### Testing
- No automated tests or build were run as part of this change (no CI/build execution was requested in this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69779daf92c0832d9620bbf992f5bd54)