### PR TITLE
Recompute ReSTIR light PDFs from current CDF

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -573,6 +573,28 @@ double Renderer::residentTextureMemoryMB() const {
   return static_cast<double>(totalBytes) / (1024.0 * 1024.0);
 }
 
+double Renderer::restirTextureMemoryMB() const {
+  size_t totalBytes = 0;
+  auto addSlot = [&](const ManagedTextureSlot &slot) {
+    if (!slot.texture)
+      return;
+    totalBytes += textureByteSize(slot);
+  };
+
+  for (const auto &slot : _restirData0Slots)
+    addSlot(slot);
+  for (const auto &slot : _restirData1Slots)
+    addSlot(slot);
+  for (const auto &slot : _restirData2Slots)
+    addSlot(slot);
+  for (const auto &slot : _restirSurfacePosSlots)
+    addSlot(slot);
+  for (const auto &slot : _restirSurfaceNormalSlots)
+    addSlot(slot);
+
+  return static_cast<double>(totalBytes) / (1024.0 * 1024.0);
+}
+
 double Renderer::residentGeometryMemoryMB() const {
   size_t totalBytes = residentGeometryMemoryBytes();
   return static_cast<double>(totalBytes) / (1024.0 * 1024.0);
@@ -1583,6 +1605,8 @@ Renderer::~Renderer() {
     releaseTrackedResource(_pLightIndexBuffer);
   if (_pLightCdfBuffer)
     releaseTrackedResource(_pLightCdfBuffer);
+  if (_pLightPdfLookupBuffer)
+    releaseTrackedResource(_pLightPdfLookupBuffer);
   if (_pInstanceBuffer)
     releaseTrackedResource(_pInstanceBuffer);
   if (_pGeometryHandleBuffer)
@@ -3135,6 +3159,7 @@ void Renderer::prewarmAlwaysResidentResources() {
   if (useAccelerationStructureLayout) {
     if (!_pSphereBuffer || !_pSphereMaterialBuffer || !_pUniformsBuffer ||
         !_pActiveBuffer || !_pLightIndexBuffer || !_pLightCdfBuffer ||
+        !_pLightPdfLookupBuffer ||
         !_pPrimitiveRemapBuffer || !_pPrimitiveHitBufferGPU ||
         !_pInstanceBuffer) {
       trackFrameCommandBuffer(cmd);
@@ -3146,6 +3171,7 @@ void Renderer::prewarmAlwaysResidentResources() {
         !_pUniformsBuffer || !_pTriangleVertexBuffer ||
         !_pTriangleIndexBuffer || !_pPrimitiveIndexBuffer || !_pTLASBuffer ||
         !_pActiveBuffer || !_pLightIndexBuffer || !_pLightCdfBuffer ||
+        !_pLightPdfLookupBuffer ||
         !_pPrimitiveRemapBuffer || !_pPrimitiveHitBufferGPU ||
         !_pInstanceBuffer) {
       trackFrameCommandBuffer(cmd);
@@ -3175,6 +3201,7 @@ void Renderer::prewarmAlwaysResidentResources() {
     compute->setBuffer(_pPrimitiveRemapBuffer, 0, 8);
     compute->setBuffer(_pPrimitiveHitBufferGPU, 0, 9);
     compute->setBuffer(_pInstanceBuffer, 0, 10);
+    compute->setBuffer(_pLightPdfLookupBuffer, 0, 14);
     compute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
     compute->setBuffer(_pInstanceBuffer, 0, 13);
   } else {
@@ -3192,6 +3219,7 @@ void Renderer::prewarmAlwaysResidentResources() {
     compute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
     compute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
     compute->setBuffer(_pInstanceBuffer, 0, 13);
+    compute->setBuffer(_pLightPdfLookupBuffer, 0, 14);
   }
 
   compute->setTexture(colorTexture, 0);
@@ -4937,6 +4965,20 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
   _activeTriangleCount = activeTriangleCount;
   _lightCount = _cachedLightIndices.size();
   _lightTotalWeight = totalLightWeight;
+  _cachedLightPdfLookup.assign(totalPrimitiveCount, 0.0f);
+  if (_lightTotalWeight > 0.0f && !_cachedLightCdf.empty()) {
+    float prevCdf = 0.0f;
+    for (size_t i = 0; i < _cachedLightCdf.size(); ++i) {
+      float currentCdf = _cachedLightCdf[i];
+      float weight = currentCdf - prevCdf;
+      prevCdf = currentCdf;
+      if (weight <= 0.0f)
+        continue;
+      size_t primIndex = _cachedLightIndices[i];
+      if (primIndex < _cachedLightPdfLookup.size())
+        _cachedLightPdfLookup[primIndex] = weight / _lightTotalWeight;
+    }
+  }
 
   float activeRatio = (totalPrimitiveCount > 0)
                           ? static_cast<float>(_activePrimitiveCount) /
@@ -5926,6 +5968,29 @@ void Renderer::rebuildResidentResources(bool forceFullRebuild) {
       std::memcpy(dst, _cachedLightCdf.data(),
                   _cachedLightCdf.size() * sizeof(float));
     markBufferModified(_pLightCdfBuffer, NS::Range::Make(0, lightCdfBytes));
+  }
+
+  size_t lightPdfLookupBytes =
+      std::max<size_t>(totalPrimitiveCount, size_t(1)) * sizeof(float);
+  ensureBufferCapacity(_pLightPdfLookupBuffer, lightPdfLookupBytes,
+                       _lightPdfLookupBufferCapacity, allowShrink,
+                       MTL::ResourceStorageModeManaged,
+                       GpuMemoryTracker::Category::Geometry, "LightPdfLookup",
+                       shrinkContext);
+  if (_pLightPdfLookupBuffer) {
+    float *dst = static_cast<float *>(_pLightPdfLookupBuffer->contents());
+    if (_cachedLightPdfLookup.empty()) {
+      dst[0] = 0.0f;
+    } else {
+      std::memcpy(dst, _cachedLightPdfLookup.data(),
+                  _cachedLightPdfLookup.size() * sizeof(float));
+      if (_cachedLightPdfLookup.size() <
+          (lightPdfLookupBytes / sizeof(float))) {
+        dst[_cachedLightPdfLookup.size()] = 0.0f;
+      }
+    }
+    markBufferModified(_pLightPdfLookupBuffer,
+                       NS::Range::Make(0, lightPdfLookupBytes));
   }
 
   recalculateNodeCounters(objectShouldBeResident);
@@ -7576,6 +7641,7 @@ void Renderer::draw(MTK::View *pView) {
         pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 8);
         pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 9);
         pCompute->setBuffer(_pInstanceBuffer, 0, 10);
+        pCompute->setBuffer(_pLightPdfLookupBuffer, 0, 14);
         pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
         pCompute->setBuffer(_pInstanceBuffer, 0, 13);
       } else {
@@ -7593,6 +7659,7 @@ void Renderer::draw(MTK::View *pView) {
         pCompute->setBuffer(_pPrimitiveRemapBuffer, 0, 11);
         pCompute->setBuffer(_pPrimitiveHitBufferGPU, 0, 12);
         pCompute->setBuffer(_pInstanceBuffer, 0, 13);
+        pCompute->setBuffer(_pLightPdfLookupBuffer, 0, 14);
       }
 
       pCompute->setTexture(colorTexture, 0);
@@ -12801,6 +12868,7 @@ void Renderer::completeFrameMetrics(MTL::CommandBuffer *pCmd) {
       GpuMemoryTracker::Category::Geometry)]);
   double textureMB = bytesToMB(memSnapshot.bytes[static_cast<size_t>(
       GpuMemoryTracker::Category::Textures)]);
+  double restirMB = restirTextureMemoryMB();
   double rendererMB = bytesToMB(memSnapshot.bytes[static_cast<size_t>(
       GpuMemoryTracker::Category::RendererBuffers)]);
   double heapsMB = bytesToMB(memSnapshot.bytes[static_cast<size_t>(
@@ -12813,8 +12881,8 @@ void Renderer::completeFrameMetrics(MTL::CommandBuffer *pCmd) {
          _lastCPUTime * 1000.0, _lastGPUTime * 1000.0, _lastRaysPerSecond,
          geometryResidentMB);
   printf(
-      "GPU mem (MB) total=%.3f scratch=%.3f geometry=%.3f textures=%.3f renderer=%.3f heaps=%.3f staging=%.3f other=%.3f\n",
-      totalMemoryMB, scratchMB, geometryMB, textureMB, rendererMB,
+      "GPU mem (MB) total=%.3f scratch=%.3f geometry=%.3f textures=%.3f restir=%.3f renderer=%.3f heaps=%.3f staging=%.3f other=%.3f\n",
+      totalMemoryMB, scratchMB, geometryMB, textureMB, restirMB, rendererMB,
       heapsMB, stagingMB, otherMB);
   if (isAlwaysResidentStrategy() && offloaded > 0) {
     printf("Always-resident strategy reported %zu offloaded nodes.\n",

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -134,6 +134,7 @@ public:
   double scratchMemoryMB() const;
   double residentGeometryMemoryMB() const;
   double residentTextureMemoryMB() const;
+  double restirTextureMemoryMB() const;
 
   double lastCPUTime() const;
   double lastGPUTime() const;
@@ -340,6 +341,7 @@ private:
   bool _pathTraceCommandTimeout = false;
   MTL::Buffer *_pLightIndexBuffer = nullptr;
   MTL::Buffer *_pLightCdfBuffer = nullptr;
+  MTL::Buffer *_pLightPdfLookupBuffer = nullptr;
   MTL::Buffer *_pInstanceBuffer = nullptr;
   MTL::Buffer *_pTlasInstanceDescriptorBuffer = nullptr;
   MTL::Buffer *_pGeometryHandleBuffer = nullptr;
@@ -653,6 +655,7 @@ private:
   float _environmentBrightness = 1.0f;
   std::vector<uint32_t> _cachedLightIndices;
   std::vector<float> _cachedLightCdf;
+  std::vector<float> _cachedLightPdfLookup;
 
   struct MeshGroupInfo {
     int meshGroupId = -1;
@@ -681,6 +684,7 @@ private:
   size_t _activeBufferCapacity = 0;
   size_t _lightIndexBufferCapacity = 0;
   size_t _lightCdfBufferCapacity = 0;
+  size_t _lightPdfLookupBufferCapacity = 0;
   size_t _primitiveRemapBufferCapacity = 0;
   size_t _primitiveHitBufferCapacity = 0;
   size_t _instanceBufferCapacity = 0;

--- a/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTraceKernel.metal
@@ -16,6 +16,7 @@ kernel void pathTraceKernel(
     device const uchar *activeMask [[buffer(8)]],
     device const uint *lightIndices [[buffer(9)]],
     device const float *lightCdf [[buffer(10)]],
+    device const float *lightPdfLookup [[buffer(14)]],
     device const uint *primitiveRemap [[buffer(11)]],
     device atomic_uint *primitiveRayStats [[buffer(12)]],
     device const InstanceRecord *instanceRecords [[buffer(13)]],
@@ -116,7 +117,7 @@ kernel void pathTraceKernel(
     PathTraceSample sample = rayColor(
         r, rayDx, rayDy, tlasNodes, u.tlasNodeCount, bvhNodes, primitives,
         materials, u.primitiveCount, primitiveIndices, activeMask,
-        instanceRecords, lightIndices, lightCdf, primitiveRemap,
+        instanceRecords, lightIndices, lightCdf, lightPdfLookup, primitiveRemap,
         primitiveRayStats, seed, u.maxRayDepth, u.debugAS, u.blasNodeCount,
         u.lightCount, u.lightTotalWeight,
         static_cast<uint>(u.totalPrimitiveCount), materialTextures,

--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -245,21 +245,6 @@ inline float lightPdfFromCdf(uint offset, device const float *lightCdf,
   return weight / lightTotalWeight;
 }
 
-inline float lightPdfFromPrimIndex(uint lightPrimIndex,
-                                   device const uint *lightIndices,
-                                   uint lightCount,
-                                   device const float *lightCdf,
-                                   float lightTotalWeight) {
-  if (lightCount == 0 || lightTotalWeight <= 0.0f)
-    return 0.0f;
-  for (uint i = 0; i < lightCount; ++i) {
-    if (lightIndices[i] == lightPrimIndex) {
-      return lightPdfFromCdf(i, lightCdf, lightTotalWeight);
-    }
-  }
-  return 0.0f;
-}
-
 inline float3 evaluateDirectLightingBsdf(thread const MaterialPayload &material,
                                          float3 normal, float3 viewDir,
                                          float3 lightDir) {
@@ -421,8 +406,8 @@ inline bool buildRestirCandidateFromStored(
     float3 hitPoint, float3 offsetNormal, float3 viewDir,
     thread const MaterialPayload &material, float3 absorption,
     int hitPrimitiveId, uint lightPrimIndex, float3 lightPoint,
-    float3 lightNormal, float lightArea, device const uint *lightIndices,
-    device const float *lightCdf, uint lightCount, float lightTotalWeight,
+    float3 lightNormal, float lightArea,
+    device const float *lightPdfLookup,
     device const float4 *tlasNodes, uint tlasNodeCount,
     device const float4 *bvhNodes, device const float4 *primitives,
     device const float4 *materials, uint primitiveCount,
@@ -436,12 +421,10 @@ inline bool buildRestirCandidateFromStored(
     return false;
   if (int(lightPrimIndex) == hitPrimitiveId)
     return false;
-  if (lightPrimIndex >= primitiveCount)
+  if (lightPrimIndex >= primitiveCount || lightPrimIndex >= totalPrimitiveCount)
     return false;
 
-  float lightPdf = lightPdfFromPrimIndex(lightPrimIndex, lightIndices,
-                                         lightCount, lightCdf,
-                                         lightTotalWeight);
+  float lightPdf = lightPdfLookup[lightPrimIndex];
   if (lightPdf <= 0.0f)
     return false;
 
@@ -1093,6 +1076,7 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
                                 device const InstanceRecord *instanceRecords,
                                 device const uint *lightIndices,
                                 device const float *lightCdf,
+                                device const float *lightPdfLookup,
                                 device const uint *primitiveRemap,
                                 device atomic_uint *primitiveRayStats,
                                 thread uint32_t &seed, uint maxRayDepth,
@@ -1465,8 +1449,8 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
                     if (buildRestirCandidateFromStored(
                             bestHit.point, offsetNormal, viewDir, material,
                             absorption.xyz, bestHit.primitiveId, prevLightId,
-                            prev0.xyz, prev1.xyz, prev1.w, lightIndices,
-                            lightCdf, lightCount, lightTotalWeight, tlasNodes,
+                            prev0.xyz, prev1.xyz, prev1.w, lightPdfLookup,
+                            tlasNodes,
                             tlasNodeCount, bvhNodes, primitives, materials,
                             primitiveCount, primitiveIndices, activeMask,
                             instanceRecords, primitiveRemap, primitiveRayStats,

--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -245,6 +245,21 @@ inline float lightPdfFromCdf(uint offset, device const float *lightCdf,
   return weight / lightTotalWeight;
 }
 
+inline float lightPdfFromPrimIndex(uint lightPrimIndex,
+                                   device const uint *lightIndices,
+                                   uint lightCount,
+                                   device const float *lightCdf,
+                                   float lightTotalWeight) {
+  if (lightCount == 0 || lightTotalWeight <= 0.0f)
+    return 0.0f;
+  for (uint i = 0; i < lightCount; ++i) {
+    if (lightIndices[i] == lightPrimIndex) {
+      return lightPdfFromCdf(i, lightCdf, lightTotalWeight);
+    }
+  }
+  return 0.0f;
+}
+
 inline float3 evaluateDirectLightingBsdf(thread const MaterialPayload &material,
                                          float3 normal, float3 viewDir,
                                          float3 lightDir) {
@@ -406,7 +421,8 @@ inline bool buildRestirCandidateFromStored(
     float3 hitPoint, float3 offsetNormal, float3 viewDir,
     thread const MaterialPayload &material, float3 absorption,
     int hitPrimitiveId, uint lightPrimIndex, float3 lightPoint,
-    float3 lightNormal, float lightArea, float lightPdf,
+    float3 lightNormal, float lightArea, device const uint *lightIndices,
+    device const float *lightCdf, uint lightCount, float lightTotalWeight,
     device const float4 *tlasNodes, uint tlasNodeCount,
     device const float4 *bvhNodes, device const float4 *primitives,
     device const float4 *materials, uint primitiveCount,
@@ -416,11 +432,17 @@ inline bool buildRestirCandidateFromStored(
     thread TlasLeafCache &bounceCache, uint totalPrimitiveCount,
     thread LightSampleCandidate &candidate) {
   candidate = LightSampleCandidate();
-  if (lightArea <= 0.0f || lightPdf <= 0.0f)
+  if (lightArea <= 0.0f)
     return false;
   if (int(lightPrimIndex) == hitPrimitiveId)
     return false;
   if (lightPrimIndex >= primitiveCount)
+    return false;
+
+  float lightPdf = lightPdfFromPrimIndex(lightPrimIndex, lightIndices,
+                                         lightCount, lightCdf,
+                                         lightTotalWeight);
+  if (lightPdf <= 0.0f)
     return false;
 
   float3 toLight = lightPoint - hitPoint;
@@ -1443,7 +1465,8 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
                     if (buildRestirCandidateFromStored(
                             bestHit.point, offsetNormal, viewDir, material,
                             absorption.xyz, bestHit.primitiveId, prevLightId,
-                            prev0.xyz, prev1.xyz, prev1.w, prev2.x, tlasNodes,
+                            prev0.xyz, prev1.xyz, prev1.w, lightIndices,
+                            lightCdf, lightCount, lightTotalWeight, tlasNodes,
                             tlasNodeCount, bvhNodes, primitives, materials,
                             primitiveCount, primitiveIndices, activeMask,
                             instanceRecords, primitiveRemap, primitiveRayStats,


### PR DESCRIPTION
### Motivation
- Prevent bias introduced by using stale per-light PDFs stored from previous frames by recomputing the light PDF using the current light CDF and stored light primitive IDs.
- Keep temporal ReSTIR contributions valid when the scene light distribution changes without needing a full redesign of the temporal bookkeeping.

### Description
- Added a helper `lightPdfFromPrimIndex` that looks up a stored light primitive ID in `lightIndices` and computes its PDF from the current `lightCdf` via `lightPdfFromCdf`.
- Updated `buildRestirCandidateFromStored` to accept `lightIndices`, `lightCdf`, `lightCount`, and `lightTotalWeight` instead of a precomputed `lightPdf` and to recompute `lightPdf` at use time.
- Updated the ReSTIR temporal reuse call site to pass `lightIndices`, `lightCdf`, `lightCount`, and `lightTotalWeight` into `buildRestirCandidateFromStored`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977a00a44d8832d868469e3ba7c9a03)