### PR TITLE
Store full proposal PDF in ReSTIR reservoir data

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -1505,14 +1505,14 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
           float spatialPrevWeightSums[kSpatialNeighborSlots];
           float spatialPrevSampleCounts[kSpatialNeighborSlots];
           float spatialPrevSelectedWeights[kSpatialNeighborSlots];
-          float spatialPrevLightPdfs[kSpatialNeighborSlots];
+          float spatialPrevProposalPdfs[kSpatialNeighborSlots];
           bool spatialValid[kSpatialNeighborSlots];
           for (uint i = 0; i < kSpatialNeighborSlots; ++i) {
             spatialValid[i] = false;
             spatialPrevWeightSums[i] = 0.0f;
             spatialPrevSampleCounts[i] = 0.0f;
             spatialPrevSelectedWeights[i] = 0.0f;
-            spatialPrevLightPdfs[i] = 0.0f;
+            spatialPrevProposalPdfs[i] = 0.0f;
           }
 
           for (uint i = 0; i < 4; ++i) {
@@ -1583,7 +1583,7 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
             spatialPrevWeightSums[i] = prevWeightSum;
             spatialPrevSampleCounts[i] = prevSampleCount;
             spatialPrevSelectedWeights[i] = prevSelectedWeight;
-            spatialPrevLightPdfs[i] = prev2.x;
+            spatialPrevProposalPdfs[i] = prev2.x;
             spatialValid[i] = true;
             totalSpatialSampleCount += prevSampleCount;
           }
@@ -1596,11 +1596,11 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
             float prevWeightSum = spatialPrevWeightSums[i];
             float prevSampleCount = spatialPrevSampleCounts[i];
             float prevSelectedWeight = spatialPrevSelectedWeights[i];
-            float prevLightPdf = spatialPrevLightPdfs[i];
+            float prevProposalPdf = spatialPrevProposalPdfs[i];
             float3 contribution = restirContribution(spatialCandidate);
             float target = restirTargetFromCandidate(spatialCandidate);
             float prevTarget =
-                prevSelectedWeight * max(prevLightPdf, RAY_EPS);
+                prevSelectedWeight * max(prevProposalPdf, RAY_EPS);
             float normalization =
                 (prevSampleCount > 0.0f) ? (prevWeightSum / prevSampleCount)
                                          : 0.0f;
@@ -1692,7 +1692,7 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
                        reservoir.sample.lightArea),
                 pixel);
             restirData2Out.write(
-                float4(reservoir.sample.lightPdf, reservoir.weightSum,
+                float4(reservoir.sample.pdf, reservoir.weightSum,
                        reservoir.sampleCount, reservoir.selectedWeight),
                 pixel);
           } else {


### PR DESCRIPTION
### Motivation
- Align ReSTIR reservoir bookkeeping with the canonical RIS/DI definition by storing the full proposal PDF (lightPdf * pdfSolid) instead of only the light selection PDF.
- Use the stored full proposal PDF when computing spatial reuse weights so p_hat_prev(y) = w_prev(y) * p_prev(y) is correct.
- Preserve correct candidate comparison by keeping `buildRestirCandidateFromStored` responsible for recomputing `candidate.pdf` from geometry.

### Description
- Write the full proposal PDF into `restirData2Out.x` by changing the stored value from `reservoir.sample.lightPdf` to `reservoir.sample.pdf`.
- Rename spatial bookkeeping variables from `spatialPrevLightPdfs` to `spatialPrevProposalPdfs` and initialize/assign accordingly.
- Use the stored proposal PDF in spatial reuse weight computation by replacing `prevLightPdf` with `prevProposalPdf` and computing `prevTarget = prevSelectedWeight * max(prevProposalPdf, RAY_EPS)`.
- Left `buildRestirCandidateFromStored` unchanged so `candidate.pdf` continues to be recomputed for comparison.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979e0622658832dabfc5c26a9b921e4)