### PR TITLE
Clamp ReSTIR temporal Jacobian for stability

### DIFF
--- a/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
+++ b/Nomad Path Tracer/Renderer/Shaders/PathTracing.h
@@ -1676,6 +1676,11 @@ inline PathTraceSample rayColor(Ray r, float3 rayDx, float3 rayDy,
               temporalJacobian =
                   (prevDist2 / currentDist2) *
                   (cosCurrent / max(cosPrev, RAY_EPS));
+              if (!isfinite(temporalJacobian) || temporalJacobian < 0.0f) {
+                temporalJacobian = 0.0f;
+              } else {
+                temporalJacobian = min(temporalJacobian, 32.0f);
+              }
             }
             float temporalWeight =
                 (prevTarget > 0.0f)


### PR DESCRIPTION
### Motivation
- Prevent extreme or non-finite `temporalJacobian` values used by ReSTIR DI temporal reuse that can create runaway weights and contribute to GPU command buffer aborts in heavy scenes.
- Improve numerical robustness of the temporal reuse path by ensuring the Jacobian stays finite and non-negative.

### Description
- Added a clamp after the `temporalJacobian` computation in `Nomad Path Tracer/Renderer/Shaders/PathTracing.h` so that non-finite or negative values are set to `0.0f` and large values are capped at `32.0f`.
- The change is a small guard around the existing Jacobian computation and does not alter other ReSTIR logic or control flow.

### Testing
- No automated tests were run on this change (no CI/build steps invoked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979e50d9fb0832da098984c8d387400)