### PR TITLE
Add opt-in aggressive ray-hit eviction toggle

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -9656,6 +9656,15 @@ bool Renderer::updateRayHitBudget(bool forceAllToggles) {
   if (_activePrimitive.empty())
     return false;
 
+  const bool aggressiveEvict = _residencyConfig.rayHitAggressiveEvict;
+  if (aggressiveEvict && !_rayHitAggressiveLogged) {
+    std::printf(
+        "[Renderer] Ray-hit aggressive eviction enabled; forcing residency toggles "
+        "and waits may stall GPU work.\n");
+    _rayHitAggressiveLogged = true;
+  }
+  const bool forceRayHitToggles = forceAllToggles || aggressiveEvict;
+
   if (_rayHitSortedIndices.size() != _activePrimitive.size()) {
     _rayHitSortedIndices.resize(_activePrimitive.size());
     std::iota(_rayHitSortedIndices.begin(), _rayHitSortedIndices.end(), size_t(0));
@@ -9664,7 +9673,7 @@ bool Renderer::updateRayHitBudget(bool forceAllToggles) {
     _primitiveHitScores.resize(_activePrimitive.size(), 0.0f);
 
   if (_rayHitRebuildCooldown > 0) {
-    if (forceAllToggles)
+    if (forceRayHitToggles)
       _rayHitRebuildCooldown = 0;
     else {
       --_rayHitRebuildCooldown;
@@ -9787,7 +9796,7 @@ bool Renderer::updateRayHitBudget(bool forceAllToggles) {
     bool shouldBeActive = desired[i];
     if (shouldBeActive == _activePrimitive[i])
       continue;
-    if (!forceAllToggles) {
+    if (!forceRayHitToggles) {
       if (i < _primitiveCooldown.size() && _primitiveCooldown[i] > 0)
         continue;
       if (toggles >= _residencyConfig.rayHitMaxTogglesPerFrame)
@@ -11897,6 +11906,7 @@ void Renderer::flushResidencyChanges(bool forceFullRebuild) {
   bool hasRecentChanges = !_recentlyActivated.empty() ||
                           !_recentlyDeactivated.empty() ||
                           !_dirtyResidentObjects.empty();
+  const bool aggressiveEvict = _residencyConfig.rayHitAggressiveEvict;
 
   if (!forceFullRebuild && !hasRecentChanges) {
     for (size_t objectIndex = 0;
@@ -11916,8 +11926,14 @@ void Renderer::flushResidencyChanges(bool forceFullRebuild) {
 
   std::chrono::steady_clock::time_point frameWaitSnapshot;
   if (!waitForPendingFrameCommands(kFrameCommandBufferWaitTimeout,
-                                   &frameWaitSnapshot))
+                                   &frameWaitSnapshot)) {
+    if (aggressiveEvict) {
+      std::printf(
+          "[Renderer] Ray-hit aggressive eviction: pending frame commands did not "
+          "finish in time; skipping residency rebuild to avoid GPU hazards.\n");
+    }
     return;
+  }
 
   rebuildResidentResources(forceFullRebuild);
   _lastResidentFlushCameraVersion = _cameraVersion;

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -717,6 +717,7 @@ private:
   size_t _animationFrame = 0;
 
   ResidencyParameters _residencyConfig;
+  bool _rayHitAggressiveLogged = false;
 
   bool _benchmarkEnabled = false;
   bool _benchmarkHeaderWritten = false;

--- a/Nomad Path Tracer/Scene/Scene.h
+++ b/Nomad Path Tracer/Scene/Scene.h
@@ -78,6 +78,7 @@ struct ResidencyParameters {
   bool enableRayHitPrior = true;
   float rayHitPriorScale = 0.5f;
   bool rayHitPriorFavorHighProbability = false;
+  bool rayHitAggressiveEvict = false;
 
   float probabilityDecay = 0.9f;
   float probabilityThreshold = 0.5f;

--- a/Nomad Path Tracer/Scene/SceneLoader.cpp
+++ b/Nomad Path Tracer/Scene/SceneLoader.cpp
@@ -765,6 +765,31 @@ bool SceneLoader::LoadSceneFromXML(const std::string& path, Scene* scene) {
         root->FloatAttribute("rayHitPriorScale", params.rayHitPriorScale);
     params.rayHitPriorFavorHighProbability = root->BoolAttribute(
         "rayHitPriorFavorHighProbability", params.rayHitPriorFavorHighProbability);
+    params.rayHitAggressiveEvict =
+        root->BoolAttribute("rayHitAggressiveEvict", params.rayHitAggressiveEvict);
+
+    auto parseRayHitAggressiveEnv = []() -> int {
+        const char *env = std::getenv("MPT_RAY_HIT_AGGRESSIVE_EVICT");
+        if (!env)
+            env = std::getenv("RAY_HIT_AGGRESSIVE_EVICT");
+        if (!env)
+            return -1;
+        std::string value(env);
+        std::transform(value.begin(), value.end(), value.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        if (value == "1" || value == "true" || value == "yes" || value == "on")
+            return 1;
+        if (value == "0" || value == "false" || value == "no" || value == "off")
+            return 0;
+        char *end = nullptr;
+        long parsed = std::strtol(env, &end, 10);
+        if (end == env)
+            return -1;
+        return parsed != 0 ? 1 : 0;
+    };
+    int aggressiveEnv = parseRayHitAggressiveEnv();
+    if (aggressiveEnv >= 0)
+        params.rayHitAggressiveEvict = aggressiveEnv > 0;
 
     params.probabilityDecay =
         root->FloatAttribute("probabilityDecay", params.probabilityDecay);


### PR DESCRIPTION
### Motivation
- Provide an opt-in switch to force more aggressive residency toggling for the RayHitBudget strategy while avoiding silently breaking GPU work or creating zero-active crashes.
- Allow enabling the mode from scene XML or environment variables so debugging/experimentation is easy without changing defaults.

### Description
- Add `rayHitAggressiveEvict` to `ResidencyParameters` (`Scene/Scene.h`) to expose the toggle in the scene config.
- Parse the scene attribute `rayHitAggressiveEvict` and environment variables `MPT_RAY_HIT_AGGRESSIVE_EVICT` / `RAY_HIT_AGGRESSIVE_EVICT` in `SceneLoader::LoadSceneFromXML` (`Scene/SceneLoader.cpp`) to set the flag (supports boolean/text and numeric values).
- In `Renderer::updateRayHitBudget` (`Renderer/Renderer.cpp`) treat aggressive mode as a per-strategy override that makes the function behave as if `forceAllToggles=true` for RayHitBudget only by bypassing per-primitive cooldown and `rayHitMaxTogglesPerFrame`, while preserving the "min active" fallback to avoid zero-active crashes; add a one-time log when aggressive mode is observed.
- In `Renderer::flushResidencyChanges` (`Renderer/Renderer.cpp`) when aggressive mode is enabled, detect if `waitForPendingFrameCommands` times out and log a clear warning then skip the resident resources rebuild to avoid interfering with in-flight GPU work.
- Add a small internal guard `_rayHitAggressiveLogged` to `Renderer` (`Renderer/Renderer.h`) to avoid repeated warning spam; keep behavior strictly opt-in and non-default.

### Testing
- No automated tests were run as part of this change (manual compilation/runtime testing recommended by consumer); commit contains only safe, opt-in changes and logging to aid debugging when enabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ba7b930c8832dbf4d4fd4ff432985)