### PR TITLE
Opt-in GPU heap shrinking for low-utilization Metal heaps

### DIFF
--- a/Nomad Path Tracer/README.md
+++ b/Nomad Path Tracer/README.md
@@ -33,3 +33,10 @@ For the memory-budget study, `totalGpuMemoryCapMB` is now the single authoritati
 To prevent eviction scheduling deadlocks, the renderer estimates a minimum resident footprint (mandatory buffers + essential geometry). If the configured total cap remains below this footprint for several frames, it logs a warning, disables texture history, and temporarily relaxes the effective total cap to the minimum footprint. Benchmark metrics report the minimum footprint, relaxed cap, and whether the frame is in eviction-stall mode.
 
 See `StudyNotes.md` for the study-specific memory budget notes and recommended interpretation of the new metrics.
+
+## Optional heap shrinking (opt-in)
+
+The renderer can optionally shrink per-object Metal heaps when utilization stays low for multiple consecutive frames and no heap-backed resources are in flight. This is disabled by default to preserve current allocation behavior.
+
+- **Environment variable:** set `MPT_HEAP_SHRINK=1` to enable heap shrinking.
+- **Behavior:** the heap is only resized after a sustained low-utilization period; shrinking is deferred until it is safe to destroy the existing heap-backed buffers/AS.

--- a/Nomad Path Tracer/Renderer/GpuHeapResources.h
+++ b/Nomad Path Tracer/Renderer/GpuHeapResources.h
@@ -25,6 +25,10 @@ public:
 
   void ensureHeapCapacity(NS::UInteger requiredBytes);
   NS::UInteger alignedHeapSize(NS::UInteger size) const;
+  NS::UInteger currentRequiredBytes() const;
+  void maybeShrinkHeap(NS::UInteger requiredBytes, bool hasInFlight);
+  void setHeapShrinkEnabled(bool enabled);
+  bool heapShrinkEnabled() const { return _shrinkEnabled; }
 
   void releaseAllAllocations();
   void makeResourcesPurgeable();
@@ -90,6 +94,10 @@ private:
   GpuMemoryTracker *_memoryTracker = nullptr;
   MTL::StorageMode _storageMode = MTL::StorageMode::StorageModePrivate;
   MTL::HazardTrackingMode _hazardMode = MTL::HazardTrackingModeTracked;
+  bool _shrinkEnabled = false;
+  bool _shrinkPending = false;
+  NS::UInteger _pendingShrinkSize = 0;
+  size_t _lowUtilizationFrames = 0;
 };
 
 } // namespace NomadPathTracer

--- a/Nomad Path Tracer/Renderer/GpuHeapResources.mm
+++ b/Nomad Path Tracer/Renderer/GpuHeapResources.mm
@@ -2,6 +2,7 @@
 
 #include <Foundation/Foundation.hpp>
 #include <algorithm>
+#include <cstdio>
 
 #include "../Scene/Primitive.h"
 #include "GpuMemoryTracker.h"
@@ -11,6 +12,8 @@ namespace NomadPathTracer {
 namespace {
 constexpr NS::UInteger kDefaultHeapSizeBytes = 4 * 1024 * 1024; // 4 MB
 constexpr NS::UInteger kHeapAlignment = 256;
+constexpr double kShrinkUtilizationThreshold = 0.5;
+constexpr size_t kShrinkFrameThreshold = 60;
 
 NS::UInteger alignUp(NS::UInteger value, NS::UInteger alignment) {
   if (alignment == 0)
@@ -62,6 +65,9 @@ void GpuHeapResources::destroy() {
   _heapSize = 0;
   _defaultHeapSize = 0;
   _accelerationSize = 0;
+  _shrinkPending = false;
+  _pendingShrinkSize = 0;
+  _lowUtilizationFrames = 0;
 }
 
 void GpuHeapResources::ensureHeapCapacity(NS::UInteger requiredBytes) {
@@ -87,6 +93,61 @@ void GpuHeapResources::ensureHeapCapacity(NS::UInteger requiredBytes) {
 
 NS::UInteger GpuHeapResources::alignedHeapSize(NS::UInteger size) const {
   return alignForHeap(size);
+}
+
+NS::UInteger GpuHeapResources::currentRequiredBytes() const {
+  return _vertex.capacity + _index.capacity + _accelerationSize;
+}
+
+void GpuHeapResources::maybeShrinkHeap(NS::UInteger requiredBytes,
+                                       bool hasInFlight) {
+  if (!_shrinkEnabled || !_heap || _heapSize == 0)
+    return;
+  if (hasInFlight) {
+    _lowUtilizationFrames = 0;
+    return;
+  }
+
+  if (requiredBytes == 0)
+    requiredBytes = currentRequiredBytes();
+
+  const double utilization =
+      static_cast<double>(requiredBytes) / static_cast<double>(_heapSize);
+  if (utilization >= kShrinkUtilizationThreshold) {
+    _lowUtilizationFrames = 0;
+    _shrinkPending = false;
+    _pendingShrinkSize = 0;
+    return;
+  }
+
+  ++_lowUtilizationFrames;
+  if (_lowUtilizationFrames < kShrinkFrameThreshold)
+    return;
+
+  NS::UInteger targetSize = alignForHeap(requiredBytes);
+  if (targetSize == 0) {
+    targetSize =
+        _defaultHeapSize == 0 ? kDefaultHeapSizeBytes : _defaultHeapSize;
+  }
+  targetSize = alignUp(targetSize, kHeapAlignment);
+  NS::UInteger minimumSize =
+      _defaultHeapSize == 0 ? kDefaultHeapSizeBytes : _defaultHeapSize;
+  minimumSize = alignUp(minimumSize, kHeapAlignment);
+  targetSize = std::max(targetSize, minimumSize);
+  if (targetSize >= _heapSize)
+    return;
+
+  _pendingShrinkSize = targetSize;
+  _shrinkPending = true;
+}
+
+void GpuHeapResources::setHeapShrinkEnabled(bool enabled) {
+  _shrinkEnabled = enabled;
+  if (!_shrinkEnabled) {
+    _shrinkPending = false;
+    _pendingShrinkSize = 0;
+    _lowUtilizationFrames = 0;
+  }
 }
 
 void GpuHeapResources::releaseAllAllocations() {
@@ -293,6 +354,9 @@ void GpuHeapResources::recreateHeap(NS::UInteger newSize) {
   desc->release();
 
   _heapSize = _heap ? _heap->size() : 0;
+  _shrinkPending = false;
+  _pendingShrinkSize = 0;
+  _lowUtilizationFrames = 0;
 }
 
 void GpuHeapResources::tryDestroyHeap() {
@@ -300,6 +364,24 @@ void GpuHeapResources::tryDestroyHeap() {
     return;
   if (_vertex.buffer || _index.buffer || _accelerationStructure)
     return;
+  if (_shrinkPending && _pendingShrinkSize > 0 &&
+      _pendingShrinkSize < _heapSize) {
+    const NS::UInteger oldSize = _heapSize;
+    _heap->release();
+    _heap = nullptr;
+    _heapSize = 0;
+    recreateHeap(_pendingShrinkSize);
+    _shrinkPending = false;
+    _pendingShrinkSize = 0;
+    _lowUtilizationFrames = 0;
+    if (_heap && oldSize != _heapSize) {
+      std::printf("[GpuHeapResources] Shrunk heap from %llu to %llu bytes.\n",
+                  static_cast<unsigned long long>(oldSize),
+                  static_cast<unsigned long long>(_heapSize));
+    }
+    return;
+  }
+
   _heap->release();
   _heap = nullptr;
   _heapSize = 0;

--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -1641,6 +1641,8 @@ Renderer::Renderer(MTL::Device *pDevice)
   _dummyBlasResources.setMemoryTracker(&_gpuMemoryTracker);
   _tlasHeap.initialize(_pDevice);
   _dummyBlasResources.initialize(_pDevice);
+  _tlasHeap.setHeapShrinkEnabled(_heapShrinkEnabled);
+  _dummyBlasResources.setHeapShrinkEnabled(_heapShrinkEnabled);
 
   Camera::reset();
   _primaryCameraState = Camera::captureState();
@@ -1865,34 +1867,59 @@ void Renderer::initializeBenchmarking() {
   const char *primaryEnv = std::getenv("METALPT_BENCH");
   const char *legacyEnv = std::getenv("METALAPT_BENCH");
   const char *probabilityEnv = std::getenv("METALPT_BENCH_LOG_PROBABILITIES");
+  const char *heapShrinkEnv = std::getenv("MPT_HEAP_SHRINK");
   const char *env = primaryEnv ? primaryEnv : legacyEnv;
   if (!env)
-    return;
+    env = nullptr;
 
   if (!primaryEnv && legacyEnv) {
     printf("METALAPT_BENCH detected; please update to METALPT_BENCH for future runs.\n");
   }
 
-  std::string value(env);
-  std::transform(value.begin(), value.end(), value.begin(),
-                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-
-  bool enable = value == "1" || value == "true" || value == "yes" || value == "on";
-  if (probabilityEnv) {
-    std::string probabilityValue(probabilityEnv);
-    std::transform(probabilityValue.begin(), probabilityValue.end(),
-                   probabilityValue.begin(), [](unsigned char c) {
+  auto parseBoolEnv = [](const char *value) -> bool {
+    if (!value)
+      return false;
+    std::string normalized(value);
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                   [](unsigned char c) {
                      return static_cast<char>(std::tolower(c));
                    });
-    bool logProbabilities = probabilityValue == "1" ||
-                            probabilityValue == "true" ||
-                            probabilityValue == "yes" ||
-                            probabilityValue == "on";
-    _benchmarkLogProbabilities = logProbabilities;
-  } else {
-    _benchmarkLogProbabilities = true;
+    return normalized == "1" || normalized == "true" || normalized == "yes" ||
+           normalized == "on";
+  };
+
+  if (env) {
+    bool enable = parseBoolEnv(env);
+    if (probabilityEnv) {
+      _benchmarkLogProbabilities = parseBoolEnv(probabilityEnv);
+    } else {
+      _benchmarkLogProbabilities = true;
+    }
+    setBenchmarkMode(enable);
   }
-  setBenchmarkMode(enable);
+
+  if (heapShrinkEnv) {
+    applyHeapShrinkSetting(parseBoolEnv(heapShrinkEnv));
+  }
+}
+
+void Renderer::applyHeapShrinkSetting(bool enabled) {
+  _heapShrinkEnabled = enabled;
+  _tlasHeap.setHeapShrinkEnabled(enabled);
+  _dummyBlasResources.setHeapShrinkEnabled(enabled);
+  for (auto &resident : _residentObjectGpuResources) {
+    resident.resources.setHeapShrinkEnabled(enabled);
+  }
+}
+
+void Renderer::updateHeapShrinkCandidates() {
+  if (!_heapShrinkEnabled)
+    return;
+  for (auto &resident : _residentObjectGpuResources) {
+    bool hasInFlight = resident.hasPendingCommands();
+    NS::UInteger requiredBytes = resident.resources.currentRequiredBytes();
+    resident.resources.maybeShrinkHeap(requiredBytes, hasInFlight);
+  }
 }
 
 void Renderer::ensureBenchmarkStream() {
@@ -3145,6 +3172,7 @@ void Renderer::updateVisibleScene() {
     resident.lastStateChange = std::chrono::steady_clock::now();
     resident.resources.setMemoryTracker(&_gpuMemoryTracker);
     resident.resources.initialize(_pDevice);
+    resident.resources.setHeapShrinkEnabled(_heapShrinkEnabled);
   }
 
   for (size_t objectIndex = 0; objectIndex < objectCount; ++objectIndex) {
@@ -4154,6 +4182,7 @@ bool Renderer::ensureDummyBlas() {
     return false;
 
   _dummyBlasResources.initialize(_pDevice);
+  _dummyBlasResources.setHeapShrinkEnabled(_heapShrinkEnabled);
 
   MTL::AccelerationStructureTriangleGeometryDescriptor *geometryDesc =
       MTL::AccelerationStructureTriangleGeometryDescriptor::alloc()->init();
@@ -4563,6 +4592,7 @@ void Renderer::updateTopLevelAccelerationStructure(
     return;
 
   _tlasHeap.initialize(_pDevice);
+  _tlasHeap.setHeapShrinkEnabled(_heapShrinkEnabled);
 
   std::vector<MTL::AccelerationStructure *> instancedStructures;
   instancedStructures.reserve(structures.size() + 1);
@@ -8093,6 +8123,8 @@ void Renderer::updateResidency(bool forceAllToggles, bool forceFullRebuild) {
   if (_pendingAlwaysResidentPrewarm &&
       strategy == ResidencyStrategy::AlwaysResident)
     prewarmAlwaysResidentResources();
+
+  updateHeapShrinkCandidates();
 }
 
 bool Renderer::updateAlwaysResident(bool forceAllToggles) {

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -210,6 +210,8 @@ private:
   bool updatePredictiveResidency(bool forceAllToggles);
   bool updateAlwaysResident(bool forceAllToggles);
   void prewarmAlwaysResidentResources();
+  void applyHeapShrinkSetting(bool enabled);
+  void updateHeapShrinkCandidates();
   void flushResidencyChanges(bool forceFullRebuild);
   void beginFrameMetrics();
   void completeFrameMetrics(MTL::CommandBuffer *pCmd);
@@ -722,6 +724,7 @@ private:
   bool _benchmarkEnabled = false;
   bool _benchmarkLogProbabilities = true;
   bool _benchmarkHeaderWritten = false;
+  bool _heapShrinkEnabled = false;
   std::ofstream _benchmarkStream;
   std::string _benchmarkFilePath;
   size_t _benchmarkFrameCounter = 0;


### PR DESCRIPTION
### Motivation
- Reduce per-object GPU heap footprint when heap utilization stays low across multiple frames while preserving current behavior by keeping shrinking opt-in.

### Description
- Add shrink-tracking and decision APIs to `GpuHeapResources` (`currentRequiredBytes()`, `maybeShrinkHeap()`, `setHeapShrinkEnabled()`) and new state fields to track pending shrinks and consecutive low-utilization frames.
- Implement utilization-based logic with constants `kShrinkUtilizationThreshold = 0.5` and `kShrinkFrameThreshold = 60` that marks a heap for shrink after sustained low utilization and defers the actual resize until it is safe to destroy the existing heap-backed buffers/AS in `tryDestroyHeap()`; shrinking is bounded to a minimum default heap size and aligned.
- Plumb an opt-in environment toggle `MPT_HEAP_SHRINK` through `Renderer::initializeBenchmarking()` into `Renderer::applyHeapShrinkSetting()` and propagate the setting to `_tlasHeap`, `_dummyBlasResources`, and all `ResidentObjectGpuResources`; evaluate candidates each frame with `updateHeapShrinkCandidates()` called from `updateResidency()`.
- Add logging on actual shrink operations (`[GpuHeapResources] Shrunk heap from old -> new bytes`) and document the opt-in behavior in `Nomad Path Tracer/README.md`.

### Testing
- No automated tests were run against these code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c0f249148832d842ba0051c586284)