### PR TITLE
macOS App target with MTKView controller, scene loader UI and renderer controls

### DIFF
--- a/Nomad Path Tracer.xcodeproj/project.pbxproj
+++ b/Nomad Path Tracer.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 
 /* Begin PBXFileReference section */
 		C732586D2CAE13B300C3476F /* readme.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = readme.md; sourceTree = "<group>"; };
-		C7D2757E2CA61CED00C6A77F /* Nomad Path Tracer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "Nomad Path Tracer"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C7D2757E2CA61CED00C6A77F /* Nomad Path Tracer */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Nomad Path Tracer.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7D275892CA61CFE00C6A77F /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		C7D2758B2CA61D0400C6A77F /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
 		C7D2758D2CA61D0900C6A77F /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -131,7 +131,7 @@
 			);
 			productName = "Nomad Path Tracer";
 			productReference = C7D2757E2CA61CED00C6A77F /* Nomad Path Tracer */;
-			productType = "com.apple.product-type.tool";
+			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
@@ -296,7 +296,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = NO;
 				HEADER_SEARCH_PATHS = "\"Nomad Path Tracer\"/**";
+				INFOPLIST_FILE = "Nomad Path Tracer/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.nomad.pathtracer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -305,7 +308,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = NO;
 				HEADER_SEARCH_PATHS = "\"Nomad Path Tracer\"/**";
+				INFOPLIST_FILE = "Nomad Path Tracer/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.nomad.pathtracer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/Nomad Path Tracer/Info.plist
+++ b/Nomad Path Tracer/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+</dict>
+</plist>

--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -1648,7 +1648,7 @@ Renderer::Renderer(MTL::Device *pDevice)
   _primaryCameraState = Camera::captureState();
   _observerCameraState = _primaryCameraState;
 
-  updateVisibleScene();
+  loadScene(_scenePath);
   buildShaders();
   buildTextures();
   rebuildEnvironmentTexture();
@@ -1862,6 +1862,28 @@ void Renderer::setMaxRayDepth(uint32_t depth) {
 }
 
 uint32_t Renderer::maxRayDepth() const { return _pScene ? _pScene->maxRayDepth : 0; }
+
+void Renderer::setSamplesPerPixel(uint32_t minSamples, uint32_t maxSamples) {
+  _minSamplesPerPixel = std::max(minSamples, 1u);
+  _maxSamplesPerPixel = std::max(maxSamples, 1u);
+}
+
+uint32_t Renderer::minSamplesPerPixel() const { return _minSamplesPerPixel; }
+
+uint32_t Renderer::maxSamplesPerPixel() const { return _maxSamplesPerPixel; }
+
+void Renderer::setResidencyStrategy(ResidencyStrategy strategy) {
+  if (_pScene)
+    _pScene->setResidencyStrategy(strategy);
+}
+
+ResidencyStrategy Renderer::residencyStrategy() const {
+  if (!_pScene)
+    return ResidencyStrategy::DistanceLOD;
+  return _pScene->getResidencyStrategy();
+}
+
+const std::string &Renderer::scenePath() const { return _scenePath; }
 
 void Renderer::initializeBenchmarking() {
   const char *primaryEnv = std::getenv("METALPT_BENCH");
@@ -2883,12 +2905,16 @@ Renderer::buildSceneAccelerationStructures(size_t primitiveCount,
   return result;
 }
 
-void Renderer::updateVisibleScene() {
+bool Renderer::loadScene(const std::string &path) {
+  _scenePath = path.empty() ? "scene.xml" : path;
   resetProbabilisticResidencyState();
-  if (!SceneLoader::LoadSceneFromXML("scene.xml", _pScene)) {
+  bool loaded = SceneLoader::LoadSceneFromXML(_scenePath, _pScene);
+  if (!loaded) {
     std::filesystem::path alt =
         std::filesystem::path(__FILE__).parent_path() / "../scene_bistro_test_v2.xml";
-    SceneLoader::LoadSceneFromXML(alt.string(), _pScene);
+    loaded = SceneLoader::LoadSceneFromXML(alt.string(), _pScene);
+    if (loaded)
+      _scenePath = alt.string();
   }
 
   Camera::screenSize = _pScene->screenSize;
@@ -3221,7 +3247,11 @@ void Renderer::updateVisibleScene() {
 
   updateResidency(true, true);
   rebuildEnvironmentTexture();
+
+  return loaded;
 }
+
+void Renderer::updateVisibleScene() { loadScene(_scenePath); }
 
 void Renderer::prewarmAlwaysResidentResources() {
   if (!_pScene ||

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -112,6 +112,7 @@ public:
   Renderer(MTL::Device *pDevice);
   ~Renderer();
 
+  bool loadScene(const std::string &path);
   void updateVisibleScene();
   void buildShaders();
   void buildTextures();
@@ -129,6 +130,12 @@ public:
   void setFrameCaptureInterval(size_t interval);
   void setMaxRayDepth(uint32_t depth);
   uint32_t maxRayDepth() const;
+  void setSamplesPerPixel(uint32_t minSamples, uint32_t maxSamples);
+  uint32_t minSamplesPerPixel() const;
+  uint32_t maxSamplesPerPixel() const;
+  void setResidencyStrategy(ResidencyStrategy strategy);
+  ResidencyStrategy residencyStrategy() const;
+  const std::string &scenePath() const;
 
   bool hasKeyframes() const;
   bool setPrimitiveActive(size_t index, bool active);
@@ -773,6 +780,7 @@ private:
 
   uint32_t _minSamplesPerPixel = 1;
   uint32_t _maxSamplesPerPixel = 4;
+  std::string _scenePath = "scene.xml";
   MTL::Buffer *_pTextureClearBuffer = nullptr;
   size_t _textureClearBufferCapacity = 0;
 

--- a/Nomad Path Tracer/Window/ApplicationDelegate.cpp
+++ b/Nomad Path Tracer/Window/ApplicationDelegate.cpp
@@ -5,14 +5,12 @@
 using namespace NomadPathTracer;
 
 ApplicationDelegate::~ApplicationDelegate() {
-  if (_pMtkView)
-    _pMtkView->release();
+  if (_pRendererViewController)
+    _pRendererViewController->release();
   if (_pWindow)
     _pWindow->release();
   if (_pDevice)
     _pDevice->release();
-  if (_pViewDelegate)
-    delete _pViewDelegate;
 }
 
 void ApplicationDelegate::applicationWillFinishLaunching(
@@ -46,18 +44,8 @@ void ApplicationDelegate::applicationDidFinishLaunching(
 
   _pDevice = MTL::CreateSystemDefaultDevice();
 
-  _pMtkView = _controllerView.get(frame);
-  _pMtkView->setDevice(_pDevice);
-  _pMtkView->setColorPixelFormat(MTL::PixelFormat::PixelFormatRGBA16Float);
-  _pMtkView->setClearColor(MTL::ClearColor::Make(0.0, 0.0, 0.0, 1.0));
-  _pMtkView->setPreferredFramesPerSecond(60);
-  _pMtkView->setEnableSetNeedsDisplay(false);
-  _pViewDelegate = new ViewDelegate(_pDevice);
-  _controllerView.setViewDelegate(_pViewDelegate);
-  _pMtkView->setDelegate(_pViewDelegate);
-  _pMtkView->setPaused(false);
-
-  _pWindow->setContentView(_pMtkView);
+  _pRendererViewController = _rendererViewController.get(frame, _pDevice);
+  _pWindow->setContentViewController(_pRendererViewController);
   // Window title updated to reflect the new application name.
   _pWindow->setTitle(
       NS::String::string("Nomad", NS::StringEncoding::UTF8StringEncoding));

--- a/Nomad Path Tracer/Window/ApplicationDelegate.h
+++ b/Nomad Path Tracer/Window/ApplicationDelegate.h
@@ -6,8 +6,7 @@
 #include <Metal/Metal.hpp>
 #include <MetalKit/MetalKit.hpp>
 
-#include "ControllerView.hpp"
-#include "ViewDelegate.h"
+#include "RendererViewController.hpp"
 
 namespace NomadPathTracer {
 
@@ -25,10 +24,9 @@ public:
 
 private:
   NS::Window *_pWindow;
-  MTK::View *_pMtkView;
   MTL::Device *_pDevice;
-  ViewDelegate *_pViewDelegate = nullptr;
-  ControllerView _controllerView;
+  NS::ViewController *_pRendererViewController = nullptr;
+  RendererViewController _rendererViewController;
   bool _initialized = false;
 };
 

--- a/Nomad Path Tracer/Window/ControllerView.mm
+++ b/Nomad Path Tracer/Window/ControllerView.mm
@@ -16,6 +16,11 @@
  + (void)updateControlValues;
  + (void)refreshRateChanged:(NSSlider *)sender;
  + (void)maxRayDepthChanged:(NSSlider *)sender;
+ + (void)minSamplesChanged:(NSSlider *)sender;
+ + (void)maxSamplesChanged:(NSSlider *)sender;
+ + (void)residencyStrategyChanged:(NSPopUpButton *)sender;
+ + (void)openScenePressed:(id)sender;
+ + (void)reloadScenePressed:(id)sender;
 @end
 
 static NomadPathTracer::ViewDelegate *renderDelegate = nullptr;
@@ -24,6 +29,30 @@ static NSSlider *refreshRateSlider;
 static NSTextField *refreshRateLabel;
 static NSSlider *maxRayDepthSlider;
 static NSTextField *maxRayDepthLabel;
+static NSSlider *minSamplesSlider;
+static NSTextField *minSamplesLabel;
+static NSSlider *maxSamplesSlider;
+static NSTextField *maxSamplesLabel;
+static NSPopUpButton *strategyPopup;
+static NSTextField *scenePathLabel;
+
+static NSArray<NSString *> *residencyStrategyNames() {
+    return @[@"Distance LOD", @"Energy", @"Ray-hit", @"Screen-space", @"Probabilistic", @"Always Resident", @"Environment", @"Predictive Env", @"Unified"];
+}
+
+static NomadPathTracer::ResidencyStrategy strategyFromIndex(NSInteger idx) {
+    switch (idx) {
+        case 1: return NomadPathTracer::ResidencyStrategy::EnergyImportance;
+        case 2: return NomadPathTracer::ResidencyStrategy::RayHitBudget;
+        case 3: return NomadPathTracer::ResidencyStrategy::ScreenSpaceFootprint;
+        case 4: return NomadPathTracer::ResidencyStrategy::Probabilistic;
+        case 5: return NomadPathTracer::ResidencyStrategy::AlwaysResident;
+        case 6: return NomadPathTracer::ResidencyStrategy::EnvironmentHit;
+        case 7: return NomadPathTracer::ResidencyStrategy::PredictiveEnvironment;
+        case 8: return NomadPathTracer::ResidencyStrategy::UnifiedScore;
+        default: return NomadPathTracer::ResidencyStrategy::DistanceLOD;
+    }
+}
 
 static NSTextField *createLabel(NSRect frame, NSString *text) {
     NSTextField *label = [[NSTextField alloc] initWithFrame:frame];
@@ -46,6 +75,18 @@ static void updateRefreshLabel(NSInteger fps) {
 static void updateRayDepthLabel(uint32_t depth) {
     if (maxRayDepthLabel) {
         [maxRayDepthLabel setStringValue:[NSString stringWithFormat:@"Max Ray Depth: %u", depth]];
+    }
+}
+
+static void updateMinSamplesLabel(uint32_t value) {
+    if (minSamplesLabel) {
+        [minSamplesLabel setStringValue:[NSString stringWithFormat:@"Min Samples: %u", value]];
+    }
+}
+
+static void updateMaxSamplesLabel(uint32_t value) {
+    if (maxSamplesLabel) {
+        [maxSamplesLabel setStringValue:[NSString stringWithFormat:@"Max Samples: %u", value]];
     }
 }
 
@@ -87,14 +128,29 @@ void NomadPathTracer::ControllerView::setViewDelegate(ViewDelegate *delegate) {
     [memoryLabel setStringValue:@"GPU: 0.0 MB"];
     [adapter addSubview:memoryLabel];
 
-    NSView *controlPanel = [[NSView alloc] initWithFrame:NSMakeRect(10, 10, 220, 120)];
+    NSView *controlPanel = [[NSView alloc] initWithFrame:NSMakeRect(10, 10, 300, 300)];
     [controlPanel setWantsLayer:YES];
     controlPanel.layer.backgroundColor = [[NSColor colorWithCalibratedWhite:0 alpha:0.5] CGColor];
     controlPanel.layer.cornerRadius = 6.0;
 
-    refreshRateLabel = createLabel(NSMakeRect(10, 80, 180, 18), @"Refresh: 60 FPS");
+    NSButton *openButton = [[NSButton alloc] initWithFrame:NSMakeRect(10, 264, 120, 26)];
+    [openButton setTitle:@"Open Scene…"];
+    [openButton setTarget:self];
+    [openButton setAction:@selector(openScenePressed:)];
+    [controlPanel addSubview:openButton];
+
+    NSButton *reloadButton = [[NSButton alloc] initWithFrame:NSMakeRect(170, 264, 120, 26)];
+    [reloadButton setTitle:@"Run / Reload"];
+    [reloadButton setTarget:self];
+    [reloadButton setAction:@selector(reloadScenePressed:)];
+    [controlPanel addSubview:reloadButton];
+
+    scenePathLabel = createLabel(NSMakeRect(10, 242, 280, 18), @"Scene: scene.xml");
+    [controlPanel addSubview:scenePathLabel];
+
+    refreshRateLabel = createLabel(NSMakeRect(10, 216, 220, 18), @"Refresh: 60 FPS");
     [controlPanel addSubview:refreshRateLabel];
-    refreshRateSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(10, 58, 200, 20)];
+    refreshRateSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(10, 196, 280, 20)];
     [refreshRateSlider setMinValue:24];
     [refreshRateSlider setMaxValue:240];
     [refreshRateSlider setIntegerValue:60];
@@ -102,15 +158,41 @@ void NomadPathTracer::ControllerView::setViewDelegate(ViewDelegate *delegate) {
     [refreshRateSlider setAction:@selector(refreshRateChanged:)];
     [controlPanel addSubview:refreshRateSlider];
 
-    maxRayDepthLabel = createLabel(NSMakeRect(10, 32, 180, 18), @"Max Ray Depth: 8");
+    maxRayDepthLabel = createLabel(NSMakeRect(10, 170, 220, 18), @"Max Ray Depth: 8");
     [controlPanel addSubview:maxRayDepthLabel];
-    maxRayDepthSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(10, 10, 200, 20)];
+    maxRayDepthSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(10, 150, 280, 20)];
     [maxRayDepthSlider setMinValue:1];
     [maxRayDepthSlider setMaxValue:64];
     [maxRayDepthSlider setIntegerValue:8];
     [maxRayDepthSlider setTarget:self];
     [maxRayDepthSlider setAction:@selector(maxRayDepthChanged:)];
     [controlPanel addSubview:maxRayDepthSlider];
+
+    minSamplesLabel = createLabel(NSMakeRect(10, 124, 220, 18), @"Min Samples: 1");
+    [controlPanel addSubview:minSamplesLabel];
+    minSamplesSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(10, 104, 280, 20)];
+    [minSamplesSlider setMinValue:1];
+    [minSamplesSlider setMaxValue:16];
+    [minSamplesSlider setIntegerValue:1];
+    [minSamplesSlider setTarget:self];
+    [minSamplesSlider setAction:@selector(minSamplesChanged:)];
+    [controlPanel addSubview:minSamplesSlider];
+
+    maxSamplesLabel = createLabel(NSMakeRect(10, 78, 220, 18), @"Max Samples: 4");
+    [controlPanel addSubview:maxSamplesLabel];
+    maxSamplesSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(10, 58, 280, 20)];
+    [maxSamplesSlider setMinValue:1];
+    [maxSamplesSlider setMaxValue:32];
+    [maxSamplesSlider setIntegerValue:4];
+    [maxSamplesSlider setTarget:self];
+    [maxSamplesSlider setAction:@selector(maxSamplesChanged:)];
+    [controlPanel addSubview:maxSamplesSlider];
+
+    strategyPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(10, 24, 280, 28) pullsDown:NO];
+    [strategyPopup addItemsWithTitles:residencyStrategyNames()];
+    [strategyPopup setTarget:self];
+    [strategyPopup setAction:@selector(residencyStrategyChanged:)];
+    [controlPanel addSubview:strategyPopup];
 
     [adapter addSubview:controlPanel];
     [self updateControlValues];
@@ -144,6 +226,19 @@ void NomadPathTracer::ControllerView::setViewDelegate(ViewDelegate *delegate) {
         uint32_t depth = renderDelegate->maxRayDepth();
         [maxRayDepthSlider setIntegerValue:static_cast<NSInteger>(depth)];
         updateRayDepthLabel(depth);
+
+        uint32_t minSamples = renderDelegate->minSamplesPerPixel();
+        uint32_t maxSamples = renderDelegate->maxSamplesPerPixel();
+        [minSamplesSlider setIntegerValue:static_cast<NSInteger>(minSamples)];
+        [maxSamplesSlider setIntegerValue:static_cast<NSInteger>(maxSamples)];
+        updateMinSamplesLabel(minSamples);
+        updateMaxSamplesLabel(maxSamples);
+
+        auto strategy = renderDelegate->residencyStrategy();
+        [strategyPopup selectItemAtIndex:static_cast<NSInteger>(strategy)];
+
+        std::string scenePath = renderDelegate->scenePath();
+        [scenePathLabel setStringValue:[NSString stringWithFormat:@"Scene: %s", scenePath.c_str()]];
     }
 }
 
@@ -161,6 +256,63 @@ void NomadPathTracer::ControllerView::setViewDelegate(ViewDelegate *delegate) {
     if (renderDelegate) {
         renderDelegate->setMaxRayDepth(depth);
     }
+}
+
++ (void)minSamplesChanged:(NSSlider *)sender {
+    if (!renderDelegate)
+        return;
+    uint32_t minSamples = static_cast<uint32_t>(sender.integerValue);
+    uint32_t maxSamples = renderDelegate->maxSamplesPerPixel();
+    if (minSamples > maxSamples) {
+        maxSamples = minSamples;
+        [maxSamplesSlider setIntegerValue:static_cast<NSInteger>(maxSamples)];
+    }
+    renderDelegate->setSamplesPerPixel(minSamples, maxSamples);
+    updateMinSamplesLabel(minSamples);
+    updateMaxSamplesLabel(maxSamples);
+}
+
++ (void)maxSamplesChanged:(NSSlider *)sender {
+    if (!renderDelegate)
+        return;
+    uint32_t maxSamples = static_cast<uint32_t>(sender.integerValue);
+    uint32_t minSamples = renderDelegate->minSamplesPerPixel();
+    if (maxSamples < minSamples) {
+        minSamples = maxSamples;
+        [minSamplesSlider setIntegerValue:static_cast<NSInteger>(minSamples)];
+    }
+    renderDelegate->setSamplesPerPixel(minSamples, maxSamples);
+    updateMinSamplesLabel(minSamples);
+    updateMaxSamplesLabel(maxSamples);
+}
+
++ (void)residencyStrategyChanged:(NSPopUpButton *)sender {
+    if (!renderDelegate)
+        return;
+    renderDelegate->setResidencyStrategy(strategyFromIndex(sender.indexOfSelectedItem));
+}
+
++ (void)openScenePressed:(id)sender {
+    if (!renderDelegate)
+        return;
+    NSOpenPanel *panel = [NSOpenPanel openPanel];
+    [panel setAllowsMultipleSelection:NO];
+    [panel setCanChooseDirectories:NO];
+    [panel setAllowedFileTypes:@[@"xml", @"obj", @"gltf", @"glb"]];
+    if ([panel runModal] == NSModalResponseOK) {
+        NSURL *url = panel.URL;
+        if (url.path) {
+            renderDelegate->loadScene(std::string(url.path.UTF8String));
+            [self updateControlValues];
+        }
+    }
+}
+
++ (void)reloadScenePressed:(id)sender {
+    if (!renderDelegate)
+        return;
+    renderDelegate->reloadScene();
+    [self updateControlValues];
 }
 
 - (id)init {

--- a/Nomad Path Tracer/Window/RendererViewController.hpp
+++ b/Nomad Path Tracer/Window/RendererViewController.hpp
@@ -1,0 +1,16 @@
+#ifndef RENDERER_VIEW_CONTROLLER_HPP
+#define RENDERER_VIEW_CONTROLLER_HPP
+
+#include <AppKit/AppKit.hpp>
+#include <Metal/Metal.hpp>
+
+namespace NomadPathTracer {
+
+class RendererViewController {
+public:
+  NS::ViewController *get(CGRect frame, MTL::Device *device);
+};
+
+} // namespace NomadPathTracer
+
+#endif

--- a/Nomad Path Tracer/Window/RendererViewController.mm
+++ b/Nomad Path Tracer/Window/RendererViewController.mm
@@ -1,0 +1,59 @@
+#import "RendererViewController.hpp"
+
+#import <AppKit/AppKit.h>
+#import <MetalKit/MetalKit.h>
+
+#include "ControllerView.hpp"
+#include "ViewDelegate.h"
+
+@interface RendererViewControllerBridge : NSViewController
+- (instancetype)initWithFrame:(CGRect)frame device:(MTL::Device *)device;
+@end
+
+@implementation RendererViewControllerBridge {
+  MTKView *_mtkView;
+  NomadPathTracer::ViewDelegate *_viewDelegate;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame device:(MTL::Device *)device {
+  self = [super initWithNibName:nil bundle:nil];
+  if (!self)
+    return nil;
+
+  NomadPathTracer::ControllerView viewFactory;
+  _mtkView = (__bridge MTKView *)viewFactory.get(frame);
+  MTK::View *cppView = (__bridge MTK::View *)_mtkView;
+  cppView->setDevice(device);
+  cppView->setColorPixelFormat(MTL::PixelFormat::PixelFormatRGBA16Float);
+  cppView->setClearColor(MTL::ClearColor::Make(0.0, 0.0, 0.0, 1.0));
+  cppView->setPreferredFramesPerSecond(60);
+  cppView->setEnableSetNeedsDisplay(false);
+
+  _viewDelegate = new NomadPathTracer::ViewDelegate(device);
+  viewFactory.setViewDelegate(_viewDelegate);
+  cppView->setDelegate(_viewDelegate);
+  cppView->setPaused(false);
+  return self;
+}
+
+- (void)dealloc {
+  [_mtkView setDelegate:nil];
+  if (_viewDelegate) {
+    delete _viewDelegate;
+    _viewDelegate = nullptr;
+  }
+  [super dealloc];
+}
+
+- (void)loadView {
+  self.view = _mtkView;
+}
+
+@end
+
+NS::ViewController *NomadPathTracer::RendererViewController::get(
+    CGRect frame, MTL::Device *device) {
+  RendererViewControllerBridge *controller =
+      [[RendererViewControllerBridge alloc] initWithFrame:frame device:device];
+  return (__bridge NS::ViewController *)controller;
+}

--- a/Nomad Path Tracer/Window/ViewDelegate.cpp
+++ b/Nomad Path Tracer/Window/ViewDelegate.cpp
@@ -119,8 +119,36 @@ void ViewDelegate::drawableSizeWillChange(MTK::View *pView, CGSize size) {
   _pRenderer->drawableSizeWillChange(pView, size);
 }
 
+bool ViewDelegate::loadScene(const std::string &path) {
+  return _pRenderer->loadScene(path);
+}
+
+bool ViewDelegate::reloadScene() { return _pRenderer->loadScene(_pRenderer->scenePath()); }
+
+const std::string &ViewDelegate::scenePath() const { return _pRenderer->scenePath(); }
+
 void ViewDelegate::setMaxRayDepth(uint32_t depth) {
   _pRenderer->setMaxRayDepth(depth);
 }
 
 uint32_t ViewDelegate::maxRayDepth() const { return _pRenderer->maxRayDepth(); }
+
+void ViewDelegate::setSamplesPerPixel(uint32_t minSamples, uint32_t maxSamples) {
+  _pRenderer->setSamplesPerPixel(minSamples, maxSamples);
+}
+
+uint32_t ViewDelegate::minSamplesPerPixel() const {
+  return _pRenderer->minSamplesPerPixel();
+}
+
+uint32_t ViewDelegate::maxSamplesPerPixel() const {
+  return _pRenderer->maxSamplesPerPixel();
+}
+
+void ViewDelegate::setResidencyStrategy(ResidencyStrategy strategy) {
+  _pRenderer->setResidencyStrategy(strategy);
+}
+
+ResidencyStrategy ViewDelegate::residencyStrategy() const {
+  return _pRenderer->residencyStrategy();
+}

--- a/Nomad Path Tracer/Window/ViewDelegate.h
+++ b/Nomad Path Tracer/Window/ViewDelegate.h
@@ -18,8 +18,16 @@ public:
   virtual ~ViewDelegate() override;
   virtual void drawInMTKView(MTK::View *pView) override;
   virtual void drawableSizeWillChange(MTK::View *pView, CGSize size) override;
+  bool loadScene(const std::string &path);
+  bool reloadScene();
+  const std::string &scenePath() const;
   void setMaxRayDepth(uint32_t depth);
   uint32_t maxRayDepth() const;
+  void setSamplesPerPixel(uint32_t minSamples, uint32_t maxSamples);
+  uint32_t minSamplesPerPixel() const;
+  uint32_t maxSamplesPerPixel() const;
+  void setResidencyStrategy(ResidencyStrategy strategy);
+  ResidencyStrategy residencyStrategy() const;
 
 private:
   Renderer *_pRenderer;


### PR DESCRIPTION
### Motivation
- Turn the existing command-line Metal target into a macOS App-hosted renderer so users can open scenes and tweak renderer settings at runtime. 
- Move scene loading and UI-driven renderer configuration out of startup-only code so scenes can be opened/reloaded from the UI. 
- Expose key renderer controls (samples, max ray depth, residency strategy) so the app can be used interactively for experimentation.

### Description
- Convert the product to an application bundle and add an `Info.plist`, updating the Xcode project settings so the target is an App (`project.pbxproj`, `Info.plist`).
- Add `RendererViewController` to own the `MTKView` lifecycle and wire it into `ApplicationDelegate` via `setContentViewController(...)`, replacing the previous direct view wiring.
- Refactor `Renderer` by extracting scene loading into `bool Renderer::loadScene(const std::string &path)`, adding `_scenePath` and getters/setters: `setSamplesPerPixel`, `minSamplesPerPixel`, `maxSamplesPerPixel`, `setResidencyStrategy`, `residencyStrategy`, and `scenePath` (files: `Renderer.h`, `Renderer.cpp`).
- Add pass-through APIs on `ViewDelegate` to call the new `Renderer` methods and added UI in `ControllerView.mm` for: open-scene (`NSOpenPanel`), Run/Reload button, min/max samples sliders, residency strategy popup, and scene path label; controls update renderer state live and refresh UI values from `ViewDelegate`.
- Wire everything together: controller view -> `ViewDelegate` -> `Renderer`, and created `RendererViewController.*` to bridge the controller and the existing `ControllerView` factory.

### Testing
- Attempted `xcodebuild -list -project "Nomad Path Tracer.xcodeproj"` to validate the Xcode target, but it failed in this environment because `xcodebuild` is not available (`xcodebuild: command not found`).
- Verified repository edits and created files were staged and a commit was created successfully (commit operation succeeded).
- Performed local textual inspections of modified files to ensure method/field names and UI wiring are consistent; runtime macOS UI validation was not possible in this Linux container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69947b98bc40832d82ab6ba27d535208)