### PR TITLE
Fix AppKit bridge types for renderer content view

### DIFF
--- a/Nomad Path Tracer/Window/ApplicationDelegate.cpp
+++ b/Nomad Path Tracer/Window/ApplicationDelegate.cpp
@@ -5,8 +5,8 @@
 using namespace NomadPathTracer;
 
 ApplicationDelegate::~ApplicationDelegate() {
-  if (_pRendererViewController)
-    _pRendererViewController->release();
+  if (_pRendererView)
+    _pRendererView->release();
   if (_pWindow)
     _pWindow->release();
   if (_pDevice)
@@ -44,8 +44,8 @@ void ApplicationDelegate::applicationDidFinishLaunching(
 
   _pDevice = MTL::CreateSystemDefaultDevice();
 
-  _pRendererViewController = _rendererViewController.get(frame, _pDevice);
-  _pWindow->setContentViewController(_pRendererViewController);
+  _pRendererView = _rendererViewController.get(frame, _pDevice);
+  _pWindow->setContentView(_pRendererView);
   // Window title updated to reflect the new application name.
   _pWindow->setTitle(
       NS::String::string("Nomad", NS::StringEncoding::UTF8StringEncoding));

--- a/Nomad Path Tracer/Window/ApplicationDelegate.h
+++ b/Nomad Path Tracer/Window/ApplicationDelegate.h
@@ -23,9 +23,9 @@ public:
       NS::Application *pSender) override;
 
 private:
-  NS::Window *_pWindow;
-  MTL::Device *_pDevice;
-  NS::ViewController *_pRendererViewController = nullptr;
+  NS::Window *_pWindow = nullptr;
+  MTL::Device *_pDevice = nullptr;
+  NS::View *_pRendererView = nullptr;
   RendererViewController _rendererViewController;
   bool _initialized = false;
 };

--- a/Nomad Path Tracer/Window/RendererViewController.hpp
+++ b/Nomad Path Tracer/Window/RendererViewController.hpp
@@ -8,7 +8,11 @@ namespace NomadPathTracer {
 
 class RendererViewController {
 public:
-  NS::ViewController *get(CGRect frame, MTL::Device *device);
+  ~RendererViewController();
+  NS::View *get(CGRect frame, MTL::Device *device);
+
+private:
+  class ViewDelegate *_viewDelegate = nullptr;
 };
 
 } // namespace NomadPathTracer

--- a/Nomad Path Tracer/Window/RendererViewController.mm
+++ b/Nomad Path Tracer/Window/RendererViewController.mm
@@ -12,7 +12,6 @@
 
 @implementation RendererViewControllerBridge {
   MTKView *_mtkView;
-  NomadPathTracer::ViewDelegate *_viewDelegate;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame device:(MTL::Device *)device {
@@ -29,19 +28,14 @@
   cppView->setPreferredFramesPerSecond(60);
   cppView->setEnableSetNeedsDisplay(false);
 
-  _viewDelegate = new NomadPathTracer::ViewDelegate(device);
-  viewFactory.setViewDelegate(_viewDelegate);
-  cppView->setDelegate(_viewDelegate);
+  viewFactory.setViewDelegate(nullptr);
+  cppView->setDelegate(nullptr);
   cppView->setPaused(false);
   return self;
 }
 
 - (void)dealloc {
   [_mtkView setDelegate:nil];
-  if (_viewDelegate) {
-    delete _viewDelegate;
-    _viewDelegate = nullptr;
-  }
   [super dealloc];
 }
 
@@ -51,9 +45,32 @@
 
 @end
 
-NS::ViewController *NomadPathTracer::RendererViewController::get(
+NomadPathTracer::RendererViewController::~RendererViewController() {
+  if (_viewDelegate) {
+    delete _viewDelegate;
+    _viewDelegate = nullptr;
+  }
+}
+
+NS::View *NomadPathTracer::RendererViewController::get(
     CGRect frame, MTL::Device *device) {
   RendererViewControllerBridge *controller =
       [[RendererViewControllerBridge alloc] initWithFrame:frame device:device];
-  return (__bridge NS::ViewController *)controller;
+
+  MTKView *mtkView = [controller view];
+  MTK::View *cppView = (__bridge MTK::View *)mtkView;
+
+  if (_viewDelegate) {
+    delete _viewDelegate;
+  }
+  _viewDelegate = new NomadPathTracer::ViewDelegate(device);
+
+  NomadPathTracer::ControllerView viewFactory;
+  viewFactory.setViewDelegate(_viewDelegate);
+  cppView->setDelegate(_viewDelegate);
+
+  NS::View *contentView = (__bridge NS::View *)mtkView;
+  [mtkView retain];
+  [controller release];
+  return contentView;
 }


### PR DESCRIPTION
### Motivation
- Recent changes introduced `NS::ViewController` and `setContentViewController(...)` usage but the project's metal-cpp AppKit bridge only exposes `NS::View`/`setContentView`, causing type errors and delegate mismatches.
- The objective was to align the C++/Objective-C++ bridge to the available AppKit C++ surface and make ownership of the renderer delegate clear and safe.

### Description
- Replace `RendererViewController::get(...)` to return `NS::View*` and add a destructor plus an owned `ViewDelegate` pointer to manage delegate lifetime (`Window/RendererViewController.hpp`).
- Refactor the Objective-C++ bridge so it creates a temporary `NSViewController`, extracts and retains the bridged `MTKView`, installs the C++ `ViewDelegate`, and releases the temporary controller (`Window/RendererViewController.mm`).
- Update `ApplicationDelegate` to store `NS::View*` (initialized to `nullptr`) instead of `NS::ViewController*`, use `setContentView(...)` to attach the renderer, and adjust destructor cleanup (`Window/ApplicationDelegate.h` and `Window/ApplicationDelegate.cpp`).

### Testing
- Searched for problematic symbols with `rg -n "ViewController|ApplicationDelegate|RendererViewController|NS::Application" -S .` and `rg -n "NS::ViewController|setContentViewController" 'Nomad Path Tracer/Window' -S` which showed the replaced occurrences as expected.
- Ran a local syntax check with `clang++ -std=c++17 -fsyntax-only 'Nomad Path Tracer/main.cpp'` including project include paths, which failed in this environment due to missing macOS Objective-C runtime headers like `objc/runtime.h`, so a full compile could not be validated here.
- Verified the modified source files contain the intended changes and that the runtime ownership pattern for the view and delegate is now consistent with the metal-cpp AppKit bridge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994818d36e0832d837bd1a3a5af82d4)