### PR TITLE
Launch with no preloaded scene; require explicit scene selection

### DIFF
--- a/Nomad Path Tracer/Renderer/Renderer.cpp
+++ b/Nomad Path Tracer/Renderer/Renderer.cpp
@@ -1648,10 +1648,8 @@ Renderer::Renderer(MTL::Device *pDevice)
   _primaryCameraState = Camera::captureState();
   _observerCameraState = _primaryCameraState;
 
-  loadScene(_scenePath);
   buildShaders();
   buildTextures();
-  rebuildEnvironmentTexture();
   _pathTraceTilesPerCommandBudget = kPathTraceMaxTilesPerCommand;
 
   recalculateViewport();
@@ -1884,6 +1882,8 @@ ResidencyStrategy Renderer::residencyStrategy() const {
 }
 
 const std::string &Renderer::scenePath() const { return _scenePath; }
+
+bool Renderer::hasSceneLoaded() const { return _hasSceneLoaded; }
 
 void Renderer::initializeBenchmarking() {
   const char *primaryEnv = std::getenv("METALPT_BENCH");
@@ -2906,17 +2906,22 @@ Renderer::buildSceneAccelerationStructures(size_t primitiveCount,
 }
 
 bool Renderer::loadScene(const std::string &path) {
-  _scenePath = path.empty() ? "scene.xml" : path;
+  _hasSceneLoaded = false;
+  if (path.empty()) {
+    _scenePath.clear();
+    std::printf("No scene selected. Choose a scene file to begin rendering.\n");
+    return false;
+  }
+
+  _scenePath = path;
   resetProbabilisticResidencyState();
   bool loaded = SceneLoader::LoadSceneFromXML(_scenePath, _pScene);
   if (!loaded) {
-    std::filesystem::path alt =
-        std::filesystem::path(__FILE__).parent_path() / "../scene_bistro_test_v2.xml";
-    loaded = SceneLoader::LoadSceneFromXML(alt.string(), _pScene);
-    if (loaded)
-      _scenePath = alt.string();
+    std::printf("Failed to load scene: %s\n", _scenePath.c_str());
+    return false;
   }
 
+  _hasSceneLoaded = true;
   Camera::screenSize = _pScene->screenSize;
   _animationFrame = 0;
   _observerActive = false;
@@ -3251,7 +3256,10 @@ bool Renderer::loadScene(const std::string &path) {
   return loaded;
 }
 
-void Renderer::updateVisibleScene() { loadScene("scene.xml"); }
+void Renderer::updateVisibleScene() {
+  if (!_scenePath.empty())
+    loadScene(_scenePath);
+}
 
 void Renderer::prewarmAlwaysResidentResources() {
   if (!_pScene ||
@@ -7406,6 +7414,31 @@ void Renderer::updateUniforms(bool cameraChanged) {
 
 void Renderer::draw(MTK::View *pView) {
   processRayHitCounters();
+
+  if (!_hasSceneLoaded || !_pScene) {
+    NS::AutoreleasePool *pPool = NS::AutoreleasePool::alloc()->init();
+    MTL::CommandBuffer *cmd = _pCommandQueue ? _pCommandQueue->commandBuffer() : nullptr;
+    if (cmd) {
+      MTL::RenderPassDescriptor *pass = pView ? pView->currentRenderPassDescriptor() : nullptr;
+      MTL::Drawable *drawable = pView ? pView->currentDrawable() : nullptr;
+      if (pass && drawable) {
+        auto *colorAttachment = pass->colorAttachments()->object(0);
+        if (colorAttachment) {
+          colorAttachment->setLoadAction(MTL::LoadActionClear);
+          colorAttachment->setStoreAction(MTL::StoreActionStore);
+          colorAttachment->setClearColor(MTL::ClearColor(0.08, 0.08, 0.1, 1.0));
+        }
+        MTL::RenderCommandEncoder *enc = cmd->renderCommandEncoder(pass);
+        if (enc)
+          enc->endEncoding();
+        cmd->presentDrawable(drawable);
+      }
+      trackFrameCommandBuffer(cmd);
+      cmd->commit();
+    }
+    pPool->release();
+    return;
+  }
   bool cameraChanged = updateCameraStates();
   Camera::State viewCamera =
       _observerActive ? _observerCameraState : _primaryCameraState;

--- a/Nomad Path Tracer/Renderer/Renderer.h
+++ b/Nomad Path Tracer/Renderer/Renderer.h
@@ -136,6 +136,7 @@ public:
   void setResidencyStrategy(ResidencyStrategy strategy);
   ResidencyStrategy residencyStrategy() const;
   const std::string &scenePath() const;
+  bool hasSceneLoaded() const;
 
   bool hasKeyframes() const;
   bool setPrimitiveActive(size_t index, bool active);
@@ -780,7 +781,8 @@ private:
 
   uint32_t _minSamplesPerPixel = 1;
   uint32_t _maxSamplesPerPixel = 4;
-  std::string _scenePath = "scene.xml";
+  std::string _scenePath;
+  bool _hasSceneLoaded = false;
   MTL::Buffer *_pTextureClearBuffer = nullptr;
   size_t _textureClearBufferCapacity = 0;
 

--- a/Nomad Path Tracer/Window/ApplicationDelegate.cpp
+++ b/Nomad Path Tracer/Window/ApplicationDelegate.cpp
@@ -1,6 +1,4 @@
 #include "ApplicationDelegate.h"
-#include "SceneLoader.h"
-#include <filesystem>
 
 using namespace NomadPathTracer;
 
@@ -26,15 +24,9 @@ void ApplicationDelegate::applicationDidFinishLaunching(
     return;
   _initialized = true;
 
-  Scene tmpScene;
-  bool loaded = SceneLoader::LoadSceneFromXML("scene.xml", &tmpScene);
-  if (!loaded) {
-    std::filesystem::path alt =
-        std::filesystem::path(__FILE__).parent_path() / "../scene.xml";
-    SceneLoader::LoadSceneFromXML(alt.string(), &tmpScene);
-  }
-
-  CGRect frame = {{100.0, 100.0}, {tmpScene.screenSize.x, tmpScene.screenSize.y}};
+  constexpr float kDefaultWidth = 1280.0f;
+  constexpr float kDefaultHeight = 720.0f;
+  CGRect frame = {{100.0, 100.0}, {kDefaultWidth, kDefaultHeight}};
 
   _pWindow = NS::Window::alloc()->init(frame,
                                        NS::WindowStyleMaskClosable |

--- a/Nomad Path Tracer/Window/ControllerView.mm
+++ b/Nomad Path Tracer/Window/ControllerView.mm
@@ -21,6 +21,8 @@
  + (void)residencyStrategyChanged:(NSPopUpButton *)sender;
  + (void)openScenePressed:(id)sender;
  + (void)reloadScenePressed:(id)sender;
+ + (void)promptForSceneIfNeeded;
+ + (void)updateSceneStatus;
 @end
 
 static NomadPathTracer::ViewDelegate *renderDelegate = nullptr;
@@ -35,6 +37,7 @@ static NSSlider *maxSamplesSlider;
 static NSTextField *maxSamplesLabel;
 static NSPopUpButton *strategyPopup;
 static NSTextField *scenePathLabel;
+static bool didPromptForScene = false;
 
 static NSArray<NSString *> *residencyStrategyNames() {
     return @[@"Distance LOD", @"Energy", @"Ray-hit", @"Screen-space", @"Probabilistic", @"Always Resident", @"Environment", @"Predictive Env", @"Unified"];
@@ -128,29 +131,29 @@ void NomadPathTracer::ControllerView::setViewDelegate(ViewDelegate *delegate) {
     [memoryLabel setStringValue:@"GPU: 0.0 MB"];
     [adapter addSubview:memoryLabel];
 
-    NSView *controlPanel = [[NSView alloc] initWithFrame:NSMakeRect(10, 10, 300, 300)];
+    NSView *controlPanel = [[NSView alloc] initWithFrame:NSMakeRect(10, 10, 300, 320)];
     [controlPanel setWantsLayer:YES];
     controlPanel.layer.backgroundColor = [[NSColor colorWithCalibratedWhite:0 alpha:0.5] CGColor];
     controlPanel.layer.cornerRadius = 6.0;
 
-    NSButton *openButton = [[NSButton alloc] initWithFrame:NSMakeRect(10, 264, 120, 26)];
+    NSButton *openButton = [[NSButton alloc] initWithFrame:NSMakeRect(10, 284, 120, 26)];
     [openButton setTitle:@"Open Scene…"];
     [openButton setTarget:self];
     [openButton setAction:@selector(openScenePressed:)];
     [controlPanel addSubview:openButton];
 
-    NSButton *reloadButton = [[NSButton alloc] initWithFrame:NSMakeRect(170, 264, 120, 26)];
+    NSButton *reloadButton = [[NSButton alloc] initWithFrame:NSMakeRect(170, 284, 120, 26)];
     [reloadButton setTitle:@"Run / Reload"];
     [reloadButton setTarget:self];
     [reloadButton setAction:@selector(reloadScenePressed:)];
     [controlPanel addSubview:reloadButton];
 
-    scenePathLabel = createLabel(NSMakeRect(10, 242, 280, 18), @"Scene: scene.xml");
+    scenePathLabel = createLabel(NSMakeRect(10, 260, 280, 18), @"No scene loaded");
     [controlPanel addSubview:scenePathLabel];
 
-    refreshRateLabel = createLabel(NSMakeRect(10, 216, 220, 18), @"Refresh: 60 FPS");
+    refreshRateLabel = createLabel(NSMakeRect(10, 234, 220, 18), @"Refresh: 60 FPS");
     [controlPanel addSubview:refreshRateLabel];
-    refreshRateSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(10, 196, 280, 20)];
+    refreshRateSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(10, 214, 280, 20)];
     [refreshRateSlider setMinValue:24];
     [refreshRateSlider setMaxValue:240];
     [refreshRateSlider setIntegerValue:60];
@@ -158,9 +161,9 @@ void NomadPathTracer::ControllerView::setViewDelegate(ViewDelegate *delegate) {
     [refreshRateSlider setAction:@selector(refreshRateChanged:)];
     [controlPanel addSubview:refreshRateSlider];
 
-    maxRayDepthLabel = createLabel(NSMakeRect(10, 170, 220, 18), @"Max Ray Depth: 8");
+    maxRayDepthLabel = createLabel(NSMakeRect(10, 188, 220, 18), @"Max Ray Depth: 8");
     [controlPanel addSubview:maxRayDepthLabel];
-    maxRayDepthSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(10, 150, 280, 20)];
+    maxRayDepthSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(10, 168, 280, 20)];
     [maxRayDepthSlider setMinValue:1];
     [maxRayDepthSlider setMaxValue:64];
     [maxRayDepthSlider setIntegerValue:8];
@@ -168,9 +171,9 @@ void NomadPathTracer::ControllerView::setViewDelegate(ViewDelegate *delegate) {
     [maxRayDepthSlider setAction:@selector(maxRayDepthChanged:)];
     [controlPanel addSubview:maxRayDepthSlider];
 
-    minSamplesLabel = createLabel(NSMakeRect(10, 124, 220, 18), @"Min Samples: 1");
+    minSamplesLabel = createLabel(NSMakeRect(10, 142, 220, 18), @"Min Samples: 1");
     [controlPanel addSubview:minSamplesLabel];
-    minSamplesSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(10, 104, 280, 20)];
+    minSamplesSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(10, 122, 280, 20)];
     [minSamplesSlider setMinValue:1];
     [minSamplesSlider setMaxValue:16];
     [minSamplesSlider setIntegerValue:1];
@@ -178,9 +181,9 @@ void NomadPathTracer::ControllerView::setViewDelegate(ViewDelegate *delegate) {
     [minSamplesSlider setAction:@selector(minSamplesChanged:)];
     [controlPanel addSubview:minSamplesSlider];
 
-    maxSamplesLabel = createLabel(NSMakeRect(10, 78, 220, 18), @"Max Samples: 4");
+    maxSamplesLabel = createLabel(NSMakeRect(10, 96, 220, 18), @"Max Samples: 4");
     [controlPanel addSubview:maxSamplesLabel];
-    maxSamplesSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(10, 58, 280, 20)];
+    maxSamplesSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(10, 76, 280, 20)];
     [maxSamplesSlider setMinValue:1];
     [maxSamplesSlider setMaxValue:32];
     [maxSamplesSlider setIntegerValue:4];
@@ -188,7 +191,7 @@ void NomadPathTracer::ControllerView::setViewDelegate(ViewDelegate *delegate) {
     [maxSamplesSlider setAction:@selector(maxSamplesChanged:)];
     [controlPanel addSubview:maxSamplesSlider];
 
-    strategyPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(10, 24, 280, 28) pullsDown:NO];
+    strategyPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(10, 34, 280, 28) pullsDown:NO];
     [strategyPopup addItemsWithTitles:residencyStrategyNames()];
     [strategyPopup setTarget:self];
     [strategyPopup setAction:@selector(residencyStrategyChanged:)];
@@ -214,6 +217,7 @@ void NomadPathTracer::ControllerView::setViewDelegate(ViewDelegate *delegate) {
 + (void)setDelegate:(NomadPathTracer::ViewDelegate *)delegate {
     renderDelegate = delegate;
     [self updateControlValues];
+    [self promptForSceneIfNeeded];
 }
 
 + (void)updateControlValues {
@@ -237,8 +241,7 @@ void NomadPathTracer::ControllerView::setViewDelegate(ViewDelegate *delegate) {
         auto strategy = renderDelegate->residencyStrategy();
         [strategyPopup selectItemAtIndex:static_cast<NSInteger>(strategy)];
 
-        std::string scenePath = renderDelegate->scenePath();
-        [scenePathLabel setStringValue:[NSString stringWithFormat:@"Scene: %s", scenePath.c_str()]];
+        [self updateSceneStatus];
     }
 }
 
@@ -302,7 +305,13 @@ void NomadPathTracer::ControllerView::setViewDelegate(ViewDelegate *delegate) {
     if ([panel runModal] == NSModalResponseOK) {
         NSURL *url = panel.URL;
         if (url.path) {
-            renderDelegate->loadScene(std::string(url.path.UTF8String));
+            bool loaded = renderDelegate->loadScene(std::string(url.path.UTF8String));
+            if (!loaded) {
+                NSAlert *alert = [[NSAlert alloc] init];
+                [alert setMessageText:@"Failed to load scene"];
+                [alert setInformativeText:@"The selected scene could not be loaded."];
+                [alert runModal];
+            }
             [self updateControlValues];
         }
     }
@@ -311,8 +320,44 @@ void NomadPathTracer::ControllerView::setViewDelegate(ViewDelegate *delegate) {
 + (void)reloadScenePressed:(id)sender {
     if (!renderDelegate)
         return;
-    renderDelegate->reloadScene();
+    if (!renderDelegate->hasSceneLoaded() || renderDelegate->scenePath().empty()) {
+        NSAlert *alert = [[NSAlert alloc] init];
+        [alert setMessageText:@"No scene loaded"];
+        [alert setInformativeText:@"Choose a scene with Open Scene… before running reload."];
+        [alert runModal];
+        return;
+    }
+
+    bool loaded = renderDelegate->reloadScene();
+    if (!loaded) {
+        NSAlert *alert = [[NSAlert alloc] init];
+        [alert setMessageText:@"Reload failed"];
+        [alert setInformativeText:@"The current scene could not be reloaded."];
+        [alert runModal];
+    }
     [self updateControlValues];
+}
+
+
++ (void)updateSceneStatus {
+    if (!scenePathLabel)
+        return;
+    if (!renderDelegate || !renderDelegate->hasSceneLoaded() || renderDelegate->scenePath().empty()) {
+        [scenePathLabel setStringValue:@"No scene loaded"];
+        return;
+    }
+
+    std::string scenePath = renderDelegate->scenePath();
+    [scenePathLabel setStringValue:[NSString stringWithFormat:@"Scene: %s", scenePath.c_str()]];
+}
+
++ (void)promptForSceneIfNeeded {
+    if (didPromptForScene || !renderDelegate)
+        return;
+    if (renderDelegate->hasSceneLoaded() || !renderDelegate->scenePath().empty())
+        return;
+    didPromptForScene = true;
+    [self openScenePressed:nil];
 }
 
 - (id)init {

--- a/Nomad Path Tracer/Window/ViewDelegate.cpp
+++ b/Nomad Path Tracer/Window/ViewDelegate.cpp
@@ -123,9 +123,15 @@ bool ViewDelegate::loadScene(const std::string &path) {
   return _pRenderer->loadScene(path);
 }
 
-bool ViewDelegate::reloadScene() { return _pRenderer->loadScene(_pRenderer->scenePath()); }
+bool ViewDelegate::reloadScene() {
+  if (_pRenderer->scenePath().empty())
+    return false;
+  return _pRenderer->loadScene(_pRenderer->scenePath());
+}
 
 const std::string &ViewDelegate::scenePath() const { return _pRenderer->scenePath(); }
+
+bool ViewDelegate::hasSceneLoaded() const { return _pRenderer->hasSceneLoaded(); }
 
 void ViewDelegate::setMaxRayDepth(uint32_t depth) {
   _pRenderer->setMaxRayDepth(depth);

--- a/Nomad Path Tracer/Window/ViewDelegate.h
+++ b/Nomad Path Tracer/Window/ViewDelegate.h
@@ -21,6 +21,7 @@ public:
   bool loadScene(const std::string &path);
   bool reloadScene();
   const std::string &scenePath() const;
+  bool hasSceneLoaded() const;
   void setMaxRayDepth(uint32_t depth);
   uint32_t maxRayDepth() const;
   void setSamplesPerPixel(uint32_t minSamples, uint32_t maxSamples);


### PR DESCRIPTION
### Motivation
- Prevent the app from assuming a bundled `scene.xml` at startup and crashing or allocating scene-dependent resources before a scene is chosen. 
- Decouple renderer initialization from scene loading so GPU/renderer resources that don't require geometry are available immediately. 
- Provide clearer UX by prompting the user to pick a scene and showing an explicit status label so users know when rendering can start.

### Description
- Start with an empty `_scenePath` and add `_hasSceneLoaded` / `hasSceneLoaded()` to track load state and avoid implicit defaults. 
- Remove the automatic `loadScene(_scenePath)` call from `Renderer::Renderer` and initialize only scene-independent resources. 
- Make `Renderer::loadScene(path)` fail fast for empty or invalid paths and set `_hasSceneLoaded = true` only after a successful load, and change `updateVisibleScene()` to reload only when a path exists. 
- Guard `Renderer::draw()` to early-return after issuing a neutral clear when no scene is loaded so the renderer no-ops safely until a scene is chosen. 
- Use a fixed 1280x720 startup window in `ApplicationDelegate` so app launch no longer depends on `scene.xml`. 
- Update `ControllerView.mm` to auto-prompt `NSOpenPanel` once on first delegate attach when no scene is loaded, display `No scene loaded` / `Scene: <path>` in the control panel, and block `Run / Reload` until a scene is present while preserving the existing `Open Scene…` flow. 
- Expose `hasSceneLoaded()` in `ViewDelegate` and guard `reloadScene()` when there is no selected scene path.

### Testing
- Ran repository checks and searches (`git diff --check`, `rg`/`sed` based validations) to confirm edits and references were updated, and those checks completed successfully. 
- Committed the change (`git commit`) and inspected the commit (`git show --stat`) successfully to verify the patch was recorded. 
- Attempted a Playwright screenshot of a web UI (not applicable to this native macOS change) which failed with `ERR_EMPTY_RESPONSE`, but this does not affect the native view/controller changes. 
- No compile or unit tests were run in this environment; integration/CI build is recommended to validate platform-specific behavior (macOS Metal/MTK view) before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699487252c9c832da19e0ae09e40de62)